### PR TITLE
gradleにデフォルトエンコーディングの指定を追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ repositories {
     jcenter()
 }
 
+// Set default encoding to UTF-8
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+
 // In this section you declare the dependencies for your production and test code
 dependencies {
     // The production code uses the SLF4J logging API at compile time


### PR DESCRIPTION
win環境のjavaはデフォルトエンコーディングがsjisなので，gradleビルドに失敗する．
コンパイル時エンコーディングを明示的にUTF-8に指定．
gradle文化しらんので確認頼む．