### PR TITLE
テスト実行中のsysoutを削除

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/GeneratedSourceCode.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/GeneratedSourceCode.java
@@ -1,13 +1,12 @@
 package jp.kusumotolab.kgenprog.project;
 
-import java.util.ArrayList;
 import java.util.List;
-import jp.kusumotolab.kgenprog.project.jdt.GeneratedJDTAST;
 
 /**
  * APR によって生成されたソースコード 複数ソースファイルの AST の集合を持つ
  */
 public class GeneratedSourceCode {
+  // TODO listは順序が保証されず重複を許容してしまう．Mapで名前から引ける方が外から使いやすい．
   private List<GeneratedAST> files;
 
   public GeneratedSourceCode(List<GeneratedAST> files) {

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/DefaultSourceCodeGenerationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/DefaultSourceCodeGenerationTest.java
@@ -33,6 +33,7 @@ public class DefaultSourceCodeGenerationTest {
 
     // NoneOperationにより全てのソースコードが初期ソースコードと等価であるはず
     for (int i = 0; i < targetProject.getSourceFiles().size(); i++) {
+      // TODO list内部要素の順序が変更されたらバグる
       final String expected = initialSourceCode.getFiles().get(i).getSourceCode();
       final String actual = generatedSourceCode.getFiles().get(i).getSourceCode();
       assertThat(actual, is(expected));


### PR DESCRIPTION
DefaultSourceCodeGenerationTest#execTest()でsysoutが汚れるのでひとまずコメントアウト．

本質的には適切なテストを追加するべき．以下イメージ．
```java
assertThat(generatedSourceCode.getFiles().size(), is(1));
assertThat(...); // 中身の比較すべき．変更されていないことを確認．
```