### PR TITLE
static importが生成されないバグを修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTConstruction.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTConstruction.java
@@ -11,6 +11,7 @@ import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.FileASTRequestor;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import jp.kusumotolab.kgenprog.project.GeneratedAST;
 import jp.kusumotolab.kgenprog.project.SourceFile;
 import jp.kusumotolab.kgenprog.project.TargetProject;
@@ -24,11 +25,7 @@ public class JDTASTConstruction {
     String[] filePaths =
         sourceFiles.stream().map(file -> file.path.toString()).toArray(String[]::new);
 
-    ASTParser parser = ASTParser.newParser(AST.JLS10);
-    // TODO: Bindingが必要か検討
-    parser.setResolveBindings(false);
-    parser.setBindingsRecovery(false);
-    parser.setEnvironment(null, null, null, true);
+    ASTParser parser = createNewParser();
 
     Map<Path, SourceFile> pathToSourceFile =
         sourceFiles.stream().collect(Collectors.toMap(file -> file.path, file -> file));
@@ -51,14 +48,26 @@ public class JDTASTConstruction {
   }
 
   public GeneratedAST constructAST(SourceFile file, char[] data) {
-    ASTParser parser = ASTParser.newParser(AST.JLS10);
-
-    Map<String, String> options = JavaCore.getOptions();
-    options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_10);
-
-    parser.setCompilerOptions(options);
+    ASTParser parser = createNewParser();
     parser.setSource(data);
 
     return new GeneratedJDTAST(file, (CompilationUnit) parser.createAST(null));
+  }
+
+  private ASTParser createNewParser() {
+    ASTParser parser = ASTParser.newParser(AST.JLS10);
+
+    final Map<String, String> options = DefaultCodeFormatterConstants.getEclipseDefaultSettings();
+    options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
+    options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
+    options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
+    parser.setCompilerOptions(options);
+
+    // TODO: Bindingが必要か検討
+    parser.setResolveBindings(false);
+    parser.setBindingsRecovery(false);
+    parser.setEnvironment(null, null, null, true);
+
+    return parser;
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/GeneratedJDTASTTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/GeneratedJDTASTTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import java.nio.file.Paths;
 import java.util.List;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.junit.Before;
 import org.junit.Test;
 import jp.kusumotolab.kgenprog.project.Location;
@@ -134,4 +135,17 @@ public class GeneratedJDTASTTest {
     assertThat(ast.getPrimaryClassName(), is("a.b.c.package-info"));
   }
 
+  @Test
+  public void testStaticImport() {
+    String testSource = "import static java.lang.Math.max; class StaticImport{ }";
+    SourceFile testSourceFile = new TargetSourceFile(Paths.get("StaticImport.java"));
+
+    JDTASTConstruction constructor = new JDTASTConstruction();
+    GeneratedJDTAST ast =
+        (GeneratedJDTAST) constructor.constructAST(testSourceFile, testSource.toCharArray());
+
+    List<ImportDeclaration> imports = ast.getRoot().imports();
+    assertThat(imports.size(), is(1));
+    assertThat(imports.get(0).isStatic(), is(true));
+  }
 }


### PR DESCRIPTION
Resolves #91 .

ASTParserを生成する際のオプションが不足していたことが原因。
以下の3つを指定

```
options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
```