### PR TITLE
各種IDEのコードフォーマッタファイルを追加

### DIFF
--- a/src/main/settings/eclipse-coding-style.xml
+++ b/src/main/settings/eclipse-coding-style.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <profiles version="13">
-<profile kind="CodeFormatterProfile" name="GoogleStyle" version="13">
+<profile kind="CodeFormatterProfile" name="KGenProg" version="13">
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
@@ -145,7 +145,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>

--- a/src/main/settings/intellij-coding-style.xml
+++ b/src/main/settings/intellij-coding-style.xml
@@ -1,4 +1,4 @@
-<code_scheme name="GoogleStyle" version="173">
+<code_scheme name="KGenProg" version="173">
   <option name="OTHER_INDENT_OPTIONS">
     <value>
       <option name="INDENT_SIZE" value="2" />
@@ -27,9 +27,14 @@
     </option>
     <option name="IMPORT_LAYOUT_TABLE">
       <value>
-        <package name="" withSubpackages="true" static="true" />
         <emptyLine />
+        <package name="" withSubpackages="true" static="true" />
+        <package name="java" withSubpackages="true" static="false" />
+        <package name="javax" withSubpackages="true" static="false" />
+        <package name="org" withSubpackages="true" static="false" />
+        <package name="com" withSubpackages="true" static="false" />
         <package name="" withSubpackages="true" static="false" />
+        <emptyLine />
       </value>
     </option>
     <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
@@ -37,51 +42,6 @@
     <option name="JD_P_AT_EMPTY_LINES" value="false" />
     <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
   </JavaCodeStyleSettings>
-  <Objective-C>
-    <option name="INDENT_NAMESPACE_MEMBERS" value="0" />
-    <option name="INDENT_C_STRUCT_MEMBERS" value="2" />
-    <option name="INDENT_CLASS_MEMBERS" value="2" />
-    <option name="INDENT_VISIBILITY_KEYWORDS" value="1" />
-    <option name="INDENT_INSIDE_CODE_BLOCK" value="2" />
-    <option name="KEEP_STRUCTURES_IN_ONE_LINE" value="true" />
-    <option name="FUNCTION_PARAMETERS_WRAP" value="5" />
-    <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5" />
-    <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="5" />
-    <option name="TEMPLATE_CALL_ARGUMENTS_ALIGN_MULTILINE" value="true" />
-    <option name="ALIGN_INIT_LIST_IN_COLUMNS" value="false" />
-    <option name="SPACE_BEFORE_SUPERCLASS_COLON" value="false" />
-  </Objective-C>
-  <Objective-C-extensions>
-    <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK" />
-    <option name="RELEASE_STYLE" value="IVAR" />
-    <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE" />
-    <file>
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
-    </file>
-    <class>
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
-    </class>
-    <extensions>
-      <pair source="cc" header="h" />
-      <pair source="c" header="h" />
-    </extensions>
-  </Objective-C-extensions>
-  <Python>
-    <option name="USE_CONTINUATION_INDENT_FOR_ARGUMENTS" value="true" />
-  </Python>
   <TypeScriptCodeStyleSettings>
     <option name="INDENT_CHAINED_CALLS" value="false" />
   </TypeScriptCodeStyleSettings>
@@ -128,6 +88,7 @@
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
     <option name="ALIGN_MULTILINE_FOR" value="false" />
+    <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="METHOD_PARAMETERS_WRAP" value="1" />
     <option name="EXTENDS_LIST_WRAP" value="1" />


### PR DESCRIPTION
resolve #108 
related to #15 

eclipseとintellijのフォーマッタファイルを追加した．
ベースは[GoogleStyle](https://github.com/HPI-Information-Systems/Metanome/wiki/Installing-the-google-styleguide-settings-in-intellij-and-eclipse)であり，Stream等のメソッドチェーンを改行するように修正した．

eclipse - intellij間での互換性の担保が一番重要だが，雑な確認しかしていない．
レビューで確認してもらえると助かる．
一部，javadocの行末スペースで互換性がないことを確認済み．どう修正すべきかは不明．

```diff
   /**
    * a_nf
-   * 
+   *
    * @param sourceFile
    * @param location
    * @return

上記削除行の行末スペースが，intellijでは削除，eclipseでは挿入される．
```