### PR TITLE
KGenProgMainでのworkingdirを指定

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -1,5 +1,7 @@
 package jp.kusumotolab.kgenprog;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import jp.kusumotolab.kgenprog.fl.FaultLocalization;
@@ -14,7 +16,6 @@ import jp.kusumotolab.kgenprog.ga.SourceCodeValidation;
 import jp.kusumotolab.kgenprog.ga.Variant;
 import jp.kusumotolab.kgenprog.ga.VariantSelection;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
-import jp.kusumotolab.kgenprog.project.ProjectBuilder;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.test.TestProcessBuilder;
 
@@ -27,8 +28,12 @@ public class KGenProgMain {
   private SourceCodeGeneration sourceCodeGeneration;
   private SourceCodeValidation sourceCodeValidation;
   private VariantSelection variantSelection;
-  private ProjectBuilder projectBuilder;
   private TestProcessBuilder testProcessBuilder;
+
+  // TODO #146
+  // workingdirのパスを一時的にMainに記述
+  // 別クラスが管理すべき情報？
+  private final Path WORKING_DIR = Paths.get(System.getProperty("java.io.tmpdir"), "kgenprog-work");
 
   public KGenProgMain(TargetProject targetProject, FaultLocalization faultLocalization,
       Mutation mutation, Crossover crossover, SourceCodeGeneration sourceCodeGeneration,
@@ -40,8 +45,7 @@ public class KGenProgMain {
     this.sourceCodeGeneration = sourceCodeGeneration;
     this.sourceCodeValidation = sourceCodeValidation;
     this.variantSelection = variantSelection;
-    this.projectBuilder = new ProjectBuilder(targetProject);
-    this.testProcessBuilder = new TestProcessBuilder(targetProject);
+    this.testProcessBuilder = new TestProcessBuilder(targetProject, WORKING_DIR);
   }
 
   public void run() {

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestProcessBuilder.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestProcessBuilder.java
@@ -42,11 +42,6 @@ public class TestProcessBuilder {
     this(targetProject, Paths.get("")); // TODO
   }
 
-  @Deprecated
-  public TestResults exec(final GeneratedSourceCode generatedSourceCode) {
-    return null;
-  }
-
   public TestProcessBuilder(final TargetProject targetProject, final Path workingDir) {
     this.targetProject = targetProject;
     this.workingDir = workingDir;


### PR DESCRIPTION
resolve #118

- KGenProgMainでのworkingdirを指定
- 上記で利用していたTestProcessBuilderでのdeprecatedメソッドを削除
- Main中の不要フィールドをついでに掃除