### PR TITLE
FitnessがNanのVariantが上位に来るバグを修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/DefaultVariantSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/DefaultVariantSelection.java
@@ -25,12 +25,19 @@ public class DefaultVariantSelection implements VariantSelection {
     log.debug("enter exec(List<>)");
 
     final List<Variant> list = variants.stream()
-        .filter(e -> !Double.isNaN(e.getFitness().getValue()))
-        .sorted(Comparator.<Variant>comparingDouble(e -> e.getFitness()
-            .getValue())
-            .reversed())
+        .sorted((o1, o2) -> compareFitness(o1.getFitness(), o2.getFitness()))
         .limit(maxVariantsPerGeneration)
         .collect(Collectors.toList());
     return list;
+  }
+
+  private int compareFitness(final Fitness fitness1, final Fitness fitness2) {
+    if (Double.isNaN(fitness1.getValue())) {
+      return 1;
+    }
+    if (Double.isNaN(fitness2.getValue())) {
+      return -1;
+    }
+    return -Double.compare(fitness1.getValue(), fitness2.getValue());
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/DefaultVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/DefaultVariantSelectionTest.java
@@ -59,12 +59,12 @@ public class DefaultVariantSelectionTest {
 
     final List<Variant> result1 = variantSelection.exec(variants);
 
-    assertThat(result1).hasSize(0);
+    assertThat(result1).hasSize(10);
 
     final Variant normalVariant = new Variant(null, new SimpleFitness(0.5d), null);
     variants.add(normalVariant);
     final List<Variant> result2 = variantSelection.exec(variants);
-    assertThat(result2).hasSize(1);
+    assertThat(result2).hasSize(10);
     assertThat(result2.get(0)).isEqualTo(normalVariant);
   }
 }


### PR DESCRIPTION
## 問題点
`DefaultVariantSelection`で次の世代に残す`Variant`を選択する際、`Fitness`の値が`Nan`のものが上位にきてしまい、世代を重ねる毎に`Nan`の数が増えてしまう。
最終的には次の世代に残す`Variant`の`Fitness`が全て`Nan`になってしまう。

## 原因
`Fitness`の値に応じてソートする時に`Nan`を取り除いてからソートしていない。

## 修正内容
- `Nan`を取り除いてからソートするよう修正
- `Fitness`が`Nanの時のテストを追加
