### PR TITLE
DefaultVariantSelectionのバグを修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/DefaultVariantSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/DefaultVariantSelection.java
@@ -1,6 +1,5 @@
 package jp.kusumotolab.kgenprog.ga;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -32,6 +31,9 @@ public class DefaultVariantSelection implements VariantSelection {
   }
 
   private int compareFitness(final Fitness fitness1, final Fitness fitness2) {
+    if (Double.isNaN(fitness1.getValue()) && Double.isNaN(fitness2.getValue())) {
+      return 0;
+    }
     if (Double.isNaN(fitness1.getValue())) {
       return 1;
     }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/DefaultVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/DefaultVariantSelectionTest.java
@@ -1,6 +1,7 @@
 package jp.kusumotolab.kgenprog.ga;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -66,5 +67,27 @@ public class DefaultVariantSelectionTest {
     final List<Variant> result2 = variantSelection.exec(variants);
     assertThat(result2).hasSize(10);
     assertThat(result2.get(0)).isEqualTo(normalVariant);
+  }
+
+  @Test
+  public void testExecForNanCompare() {
+    final DefaultVariantSelection variantSelection = new DefaultVariantSelection(10);
+
+    final List<Variant> nanVariants = IntStream.range(0, 100)
+        .mapToObj(e -> {
+          if (e == 50) {
+            return new SimpleFitness(1.0d);
+          }
+          return new SimpleFitness(Double.NaN);
+        })
+        .map(e -> new Variant(null, e, null))
+        .collect(Collectors.toList());
+
+    try {
+      final List<Variant> result = variantSelection.exec(nanVariants);
+      assertThat(result).hasSize(10);
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
resolves #212 

### 問題点
Double.Nanの比較にバグが存在していて，落ちる

### 原因
Nan同士の比較の際の挙動が定義されていなかった

### 修正内容
- Nan同士の比較を追加
- Nan同士の比較が必要なテストを追加