### PR TITLE
KGenProgMainTestのexample04-06を修正

### DIFF
--- a/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
@@ -1,11 +1,14 @@
 package jp.kusumotolab.kgenprog;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import jp.kusumotolab.kgenprog.fl.FaultLocalization;
@@ -23,6 +26,7 @@ import jp.kusumotolab.kgenprog.ga.SinglePointCrossover;
 import jp.kusumotolab.kgenprog.ga.SourceCodeGeneration;
 import jp.kusumotolab.kgenprog.ga.SourceCodeValidation;
 import jp.kusumotolab.kgenprog.ga.StatementSelection;
+import jp.kusumotolab.kgenprog.ga.Variant;
 import jp.kusumotolab.kgenprog.ga.VariantSelection;
 import jp.kusumotolab.kgenprog.project.DiffOutput;
 import jp.kusumotolab.kgenprog.project.ResultOutput;
@@ -33,11 +37,19 @@ import jp.kusumotolab.kgenprog.project.factory.JUnitLibraryResolver.JUnitVersion
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
 
-@Ignore
 public class KGenProgMainTest {
 
-  final static String bc = "jp.kusumotolab.BuggyCalculator";
-  final static String bct = "jp.kusumotolab.BuggyCalculatorTest";
+  final static String bc = "src/jp/kusumotolab/BuggyCalculator.java";
+  final static String bct = "src/jp/kusumotolab/BuggyCalculatorTest.java";
+
+  final Path workPath = Paths.get("tmp/work");
+  final Path outPath = Paths.get("tmp/out");
+
+  @Before
+  public void before() throws IOException {
+    FileUtils.deleteDirectory(workPath.toFile());
+    FileUtils.deleteDirectory(outPath.toFile());
+  }
 
   @Test
   public void testExample04() {
@@ -52,22 +64,26 @@ public class KGenProgMainTest {
         testSourcePaths, Collections.emptyList(), JUnitVersion.JUNIT4);
     final FaultLocalization faultLocalization = new Ochiai();
     final RandomNumberGeneration randomNumberGeneration = new RandomNumberGeneration();
-    final StatementSelection statementSelection = new RouletteStatementSelection(
-        randomNumberGeneration);
+    final StatementSelection statementSelection =
+        new RouletteStatementSelection(randomNumberGeneration);
     final Mutation mutation = new RandomMutation(10, randomNumberGeneration, statementSelection);
     final Crossover crossover = new SinglePointCrossover(randomNumberGeneration);
     final SourceCodeGeneration sourceCodeGeneration = new DefaultSourceCodeGeneration();
     final SourceCodeValidation sourceCodeValidation = new DefaultCodeValidation();
     final VariantSelection variantSelection = new GenerationalVariantSelection();
-    final Path outPath = Paths.get(System.getProperty("java.io.tmpdir"), "kgenprog-work");
     final ResultOutput resultGenerator = new DiffOutput(outPath);
 
     final KGenProgMain kGenProgMain =
         new KGenProgMain(project, faultLocalization, mutation, crossover, sourceCodeGeneration,
-            sourceCodeValidation, variantSelection, resultGenerator, outPath);
-    kGenProgMain.run();
+            sourceCodeValidation, variantSelection, resultGenerator, workPath);
+
+    final List<Variant> variants = kGenProgMain.run();
+    assertThat(variants).hasSize(1)
+        .allMatch(variant -> variant.getFitness()
+            .getValue() == 1.0);
   }
 
+  @Ignore // Be ignored but should not be ignored
   @Test
   public void testExample05() {
 
@@ -81,21 +97,25 @@ public class KGenProgMainTest {
         testSourcePaths, Collections.emptyList(), JUnitVersion.JUNIT4);
     final FaultLocalization faultLocalization = new Ochiai();
     final RandomNumberGeneration randomNumberGeneration = new RandomNumberGeneration();
-    final StatementSelection statementSelection = new RouletteStatementSelection(
-        randomNumberGeneration);
+    final StatementSelection statementSelection =
+        new RouletteStatementSelection(randomNumberGeneration);
     final Mutation mutation = new RandomMutation(10, randomNumberGeneration, statementSelection);
     final Crossover crossover = new SinglePointCrossover(randomNumberGeneration);
     final SourceCodeGeneration sourceCodeGeneration = new DefaultSourceCodeGeneration();
     final SourceCodeValidation sourceCodeValidation = new DefaultCodeValidation();
     final VariantSelection variantSelection = new DefaultVariantSelection();
-    final Path outPath = Paths.get(System.getProperty("java.io.tmpdir"), "kgenprog-work");
     final ResultOutput resultGenerator = new DiffOutput(outPath);
     final KGenProgMain kGenProgMain =
         new KGenProgMain(project, faultLocalization, mutation, crossover, sourceCodeGeneration,
-            sourceCodeValidation, variantSelection, resultGenerator, outPath);
-    kGenProgMain.run();
+            sourceCodeValidation, variantSelection, resultGenerator, workPath);
+
+    final List<Variant> variants = kGenProgMain.run();
+    assertThat(variants).hasSize(1)
+        .allMatch(variant -> variant.getFitness()
+            .getValue() == 1.0);
   }
 
+  @Ignore // Be ignored but should not be ignored
   @Test
   public void testExample06() {
 
@@ -109,81 +129,84 @@ public class KGenProgMainTest {
         testSourcePaths, Collections.emptyList(), JUnitVersion.JUNIT4);
     final FaultLocalization faultLocalization = new Ochiai();
     final RandomNumberGeneration randomNumberGeneration = new RandomNumberGeneration();
-    final StatementSelection statementSelection = new RouletteStatementSelection(
-        randomNumberGeneration);
+    final StatementSelection statementSelection =
+        new RouletteStatementSelection(randomNumberGeneration);
     final Mutation mutation = new RandomMutation(10, randomNumberGeneration, statementSelection);
     final Crossover crossover = new SinglePointCrossover(randomNumberGeneration);
     final SourceCodeGeneration sourceCodeGeneration = new DefaultSourceCodeGeneration();
     final SourceCodeValidation sourceCodeValidation = new DefaultCodeValidation();
     final VariantSelection variantSelection = new GenerationalVariantSelection();
-    final Path outPath = Paths.get(System.getProperty("java.io.tmpdir"), "kgenprog-work");
     final ResultOutput resultGenerator = new DiffOutput(outPath);
 
     final KGenProgMain kGenProgMain =
         new KGenProgMain(project, faultLocalization, mutation, crossover, sourceCodeGeneration,
-            sourceCodeValidation, variantSelection, resultGenerator, outPath);
-    kGenProgMain.run();
+            sourceCodeValidation, variantSelection, resultGenerator, workPath);
+
+    final List<Variant> variants = kGenProgMain.run();
+    assertThat(variants).hasSize(1)
+        .allMatch(variant -> variant.getFitness()
+            .getValue() == 1.0);
   }
 
+  @Ignore
   @Test
   public void testExample07() {
 
     final Path rootPath = Paths.get("example/example07");
-    final List<SourcePath> targetSourceFiles = new ArrayList<>();
-    targetSourceFiles.add(
-        new TargetSourcePath(rootPath.resolve("src/jp/kusumotolab/GreatestCommonDivider.java")));
-    final List<SourcePath> testSourceFiles = new ArrayList<>();
-    testSourceFiles.add(
-        new TestSourcePath(rootPath.resolve("src/jp/kusumotolab/GreatestCommonDividerTest.java")));
+    final String gcd = "src/jp/kusumotolab/GreatestCommonDivider.java";
+    final String gcdt = "src/jp/kusumotolab/GreatestCommonDividerTest.java";
+    final SourcePath gcdPath = new TargetSourcePath(rootPath.resolve(gcd));
+    final SourcePath gcdtPath = new TestSourcePath(rootPath.resolve(gcdt));
+    final List<SourcePath> targetSourceFiles = Arrays.asList(gcdPath);
+    final List<SourcePath> testSourceFiles = Arrays.asList(gcdtPath);
 
     final TargetProject project = TargetProjectFactory.create(rootPath, targetSourceFiles,
         testSourceFiles, Collections.emptyList(), JUnitVersion.JUNIT4);
     final FaultLocalization faultLocalization = new Ochiai();
     final RandomNumberGeneration randomNumberGeneration = new RandomNumberGeneration();
-    final StatementSelection statementSelection = new RouletteStatementSelection(
-        randomNumberGeneration);
+    final StatementSelection statementSelection =
+        new RouletteStatementSelection(randomNumberGeneration);
     final Mutation mutation = new RandomMutation(10, randomNumberGeneration, statementSelection);
     final Crossover crossover = new SinglePointCrossover(randomNumberGeneration);
     final SourceCodeGeneration sourceCodeGeneration = new DefaultSourceCodeGeneration();
     final SourceCodeValidation sourceCodeValidation = new DefaultCodeValidation();
     final VariantSelection variantSelection = new GenerationalVariantSelection();
-    final Path workingPath = Paths.get(System.getProperty("java.io.tmpdir"), "kgenprog-work");
-    final ResultOutput resultGenerator = new DiffOutput(workingPath);
+    final ResultOutput resultGenerator = new DiffOutput(outPath);
 
     final KGenProgMain kGenProgMain =
         new KGenProgMain(project, faultLocalization, mutation, crossover, sourceCodeGeneration,
-            sourceCodeValidation, variantSelection, resultGenerator, workingPath, 60, 10, 1);
+            sourceCodeValidation, variantSelection, resultGenerator, workPath, 60, 10, 1);
     kGenProgMain.run();
   }
 
-  //@Test
+  @Ignore
+  @Test
   public void testExample08() {
 
     final Path rootPath = Paths.get("example/example08");
-    final List<SourcePath> targetSourceFiles = new ArrayList<>();
-    targetSourceFiles.add(
-        new TargetSourcePath(rootPath.resolve("src/jp/kusumotolab/QuickSort.java")));
-    final List<SourcePath> testSourceFiles = new ArrayList<>();
-    testSourceFiles.add(
-        new TestSourcePath(rootPath.resolve("src/jp/kusumotolab/QuickSortTest.java")));
+    final String qs = "src/jp/kusumotolab/QuickSort.java";
+    final String qst = "src/jp/kusumotolab/QuickSortTest.java";
+    final SourcePath qsPath = new TargetSourcePath(rootPath.resolve(qs));
+    final SourcePath qsttPath = new TestSourcePath(rootPath.resolve(qst));
+    final List<SourcePath> targetSourceFiles = Arrays.asList(qsPath);
+    final List<SourcePath> testSourceFiles = Arrays.asList(qsttPath);
 
     final TargetProject project = TargetProjectFactory.create(rootPath, targetSourceFiles,
         testSourceFiles, Collections.emptyList(), JUnitVersion.JUNIT4);
     final FaultLocalization faultLocalization = new Ochiai();
     final RandomNumberGeneration randomNumberGeneration = new RandomNumberGeneration();
-    final RouletteStatementSelection statementSelection = new RouletteStatementSelection(
-        randomNumberGeneration);
+    final RouletteStatementSelection statementSelection =
+        new RouletteStatementSelection(randomNumberGeneration);
     final Mutation mutation = new RandomMutation(10, randomNumberGeneration, statementSelection);
     final Crossover crossover = new SinglePointCrossover(randomNumberGeneration);
     final SourceCodeGeneration sourceCodeGeneration = new DefaultSourceCodeGeneration();
     final SourceCodeValidation sourceCodeValidation = new DefaultCodeValidation();
     final VariantSelection variantSelection = new GenerationalVariantSelection();
-    final Path workingPath = Paths.get(System.getProperty("java.io.tmpdir"), "kgenprog-work");
-    final ResultOutput resultGenerator = new DiffOutput(workingPath);
+    final ResultOutput resultGenerator = new DiffOutput(outPath);
 
     final KGenProgMain kGenProgMain =
         new KGenProgMain(project, faultLocalization, mutation, crossover, sourceCodeGeneration,
-            sourceCodeValidation, variantSelection, resultGenerator, workingPath, 60, 10, 1);
+            sourceCodeValidation, variantSelection, resultGenerator, workPath, 60, 10, 1);
     kGenProgMain.run();
   }
 }


### PR DESCRIPTION
resolve #179
resolve #210  

MainTest周りISSUE2点の修正 + 細かい修正2点．

### テストに対するAssertを追加 #179
example04-06それぞれに対して，
少なくとも一つの成功遺伝子（全テストパス）を生成できることを確認するassert．

### example04-06がfailしていた問題を修正 #210

### テスト全体の`@Ignore`を削除
CIでもMainのテストを行う方針に．
https://github.com/kusumotolab/kGenProg/wiki/20180725-meeting の議論より．

### ついでにtest07/08のコードの一貫性と作業ディレクトリの指定方法を修正．

ただし現在，別バグ #212 によりtest05/06がfailしているのでマージ不可能．
よって，一時的にtest05/06に`@Ignore`を追加中．
#212 の修正PR #211 をクローズ後に戻す必要あり．
