### PR TITLE
createMainのパスまわりのバグを修正

### DIFF
--- a/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
@@ -55,8 +55,8 @@ public class KGenProgMainTest {
   private KGenProgMain createMain(final Path rootPath, final Path productPath,
       final Path testPath) {
 
-    final ProductSourcePath productSourcePath = new ProductSourcePath(rootPath.resolve(bc));
-    final TestSourcePath testSourcePath = new TestSourcePath(rootPath.resolve(bct));
+    final ProductSourcePath productSourcePath = new ProductSourcePath(productPath);
+    final TestSourcePath testSourcePath = new TestSourcePath(testPath);
     final List<ProductSourcePath> productSourcePaths = Arrays.asList(productSourcePath);
     final List<TestSourcePath> testSourcePaths = Arrays.asList(testSourcePath);
 


### PR DESCRIPTION
### 問題点
example07やexample08のテストをすると、初期`Variant`の生成に失敗する

### 原因
`KgenProgMainTest`の`createMain`で`KGenProg`に渡している`Path`がおかしい

### 修正内容
引数で与えられる`Path`を`KGenProgMain`に渡すようにしました