### PR TITLE
Statement内に含まれるStatementの数でルーレット選択するよう修正 

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/RouletteStatementSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/RouletteStatementSelection.java
@@ -19,15 +19,20 @@ public class RouletteStatementSelection implements CandidateSelection {
     final StatementVisitor visitor = new StatementVisitor(candidates);
 
     final Function<Statement, Double> weightFunction = statement -> {
-      final String statementString = statement.toString();
-      final int statementLength = statementString.length();
+      final int statementWeight = getStatementWeight(statement);
 
-      final double inverse = 1 / ((double) statementLength);
+      final double inverse = 1 / ((double) statementWeight);
       return Math.pow(inverse, 2);
     };
 
     final List<Statement> statements = visitor.getStatements();
     roulette = new Roulette<>(statements, weightFunction, randomNumberGeneration);
+  }
+
+  protected int getStatementWeight(Statement statement) {
+    final StatementVisitor statementVisitor = new StatementVisitor(statement);
+    final List<Statement> statements = statementVisitor.getStatements();
+    return statements.size();
   }
 
   @Override

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/StatementVisitor.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/StatementVisitor.java
@@ -27,6 +27,10 @@ public class StatementVisitor extends ASTVisitor {
 
   private List<Statement> statements = new ArrayList<>();
 
+  public StatementVisitor(final Statement statement) {
+    statement.accept(this);
+  }
+
   public StatementVisitor(final List<GeneratedAST> generatedASTS) {
     for (GeneratedAST generatedAST : generatedASTS) {
       final CompilationUnit unit = ((GeneratedJDTAST) generatedAST).getRoot();

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/RandomMutationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/RandomMutationTest.java
@@ -114,6 +114,6 @@ public class RandomMutationTest {
         .getDeclaredField("astNode");
     field.setAccessible(true);
     final ASTNode node = (ASTNode) field.get(insertOperation);
-    assertThat(node).isSameSourceCodeAs("n++;");
+    assertThat(node).isSameSourceCodeAs("return n;");
   }
 }


### PR DESCRIPTION
resolve #177 
Statementに対して`toStringn()`した単純な長さでルーレット選択をしていたが，それをStatement内のStatementの数でルーレサット選択するよう修正