### PR TITLE
jacocoの操作をするライブラリを変更

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ dependencies {
     // https://mvnrepository.com/artifact/org.eclipse.jdt/org.eclipse.jdt.core
     compile group: 'org.eclipse.jdt', name: 'org.eclipse.jdt.core', version: '3.13.102'
 
-    // https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin
-    compile group: 'org.jacoco', name: 'jacoco-maven-plugin', version: '0.8.1'
+    // https://mvnrepository.com/artifact/org.jacoco/org.jacoco.core
+    compile group: 'org.jacoco', name: 'org.jacoco.core', version: '0.8.1'
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
     compile group: 'commons-io', name: 'commons-io', version: '2.6'

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/Coverage.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/Coverage.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.ICounter;
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class TestResult implements Serializable {
 


### PR DESCRIPTION
resolve #270
## 修正内容
- 使用するライブラリを`jacoco-maven-plugin`から`jacoco-core`に変更
- 付随していたライブラリのバージョンが変わったことによる import の修正