### PR TITLE
実行するテストを指定可能に

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -33,7 +33,6 @@ public class Configuration {
   public static final Path DEFAULT_WORKING_DIR;
   public static final Path DEFAULT_OUT_DIR = Paths.get("kgenprog-out");
   public static final long DEFAULT_RANDOM_SEED = 0;
-  public static final String DEFAULT_EXECUTED_TESTS = "";
 
   static {
     try {
@@ -45,6 +44,7 @@ public class Configuration {
   }
 
   private final TargetProject targetProject;
+  private final List<String> executionTests;
   private final Path workingDir;
   private final Path outDir;
   private final int siblingsCount;
@@ -54,13 +54,13 @@ public class Configuration {
   private final int requiredSolutionsCount;
   private final Level logLevel;
   private final long randomSeed;
-  private final String executedTests;
   // endregion
 
   // region Constructor
 
   private Configuration(final Builder builder) {
     targetProject = builder.targetProject;
+    executionTests = builder.executionTests;
     workingDir = builder.workingDir;
     outDir = builder.outDir;
     siblingsCount = builder.siblingsCount;
@@ -70,13 +70,16 @@ public class Configuration {
     requiredSolutionsCount = builder.requiredSolutionsCount;
     logLevel = builder.logLevel;
     randomSeed = builder.randomSeed;
-    executedTests = builder.executedTests;
   }
 
   // endregion
 
   public TargetProject getTargetProject() {
     return targetProject;
+  }
+
+  public List<String> getExecutedTests() {
+    return executionTests;
   }
 
   public Path getWorkingDir() {
@@ -119,10 +122,6 @@ public class Configuration {
     return randomSeed;
   }
 
-  public String getExecutedTests() {
-    return executedTests;
-  }
-
   public static class Builder {
 
     // region Fields
@@ -131,6 +130,7 @@ public class Configuration {
     private List<Path> productPaths = new ArrayList<>();
     private List<Path> testPaths = new ArrayList<>();
     private List<Path> classPaths = new ArrayList<>();
+    private List<String> executionTests = new ArrayList<>();
     private TargetProject targetProject;
     private Path workingDir = DEFAULT_WORKING_DIR;
     private Path outDir = DEFAULT_OUT_DIR;
@@ -141,7 +141,6 @@ public class Configuration {
     private int requiredSolutionsCount = DEFAULT_REQUIRED_SOLUTIONS_COUNT;
     private Level logLevel = DEFAULT_LOG_LEVEL;
     private long randomSeed = DEFAULT_RANDOM_SEED;
-    private String executedTests = DEFAULT_EXECUTED_TESTS;
     // endregion
 
     // region Constructors
@@ -303,10 +302,10 @@ public class Configuration {
       return this;
     }
 
-    public Builder setExecutedTest(final String executedTests) {
-      log.debug("enter setExecutedTest(String)");
+    public Builder addExecutionTest(final String executionTest) {
+      log.debug("enter addExecutionTest(String)");
 
-      this.executedTests = executedTests;
+      this.executionTests.add(executionTest);
       return this;
     }
 
@@ -344,6 +343,12 @@ public class Configuration {
       this.classPaths.add(Paths.get(classPath));
     }
 
+    @Option(name = "-x", aliases = "--exec-test", usage = "Execution test cases.")
+    private void addExecutionTestFromCmdLineParser(final String executionTest) {
+      log.debug("enter addExecutionTestFromCmdLineParser(String)");
+      this.executionTests.add(executionTest);
+    }
+    
     @Option(name = "-w", aliases = "--working-dir", metaVar = "<path>",
         usage = "Path of a working directory")
     private void setWorkingDirFromCmdLineParser(final String workingDir) {
@@ -412,11 +417,6 @@ public class Configuration {
       this.randomSeed = randomSeed;
     }
 
-    @Option(name = "-x", aliases = "--exec-test", usage = "Executed test cases.")
-    private void setExecutedTestCases(final String executedTests) {
-      log.debug("enter setExecutedTestCases(String)");
-      this.executedTests = executedTests;
-    }
     // endregion
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -33,6 +33,7 @@ public class Configuration {
   public static final Path DEFAULT_WORKING_DIR;
   public static final Path DEFAULT_OUT_DIR = Paths.get("kgenprog-out");
   public static final long DEFAULT_RANDOM_SEED = 0;
+  public static final String DEFAULT_EXECUTED_TESTS = "";
 
   static {
     try {
@@ -53,6 +54,7 @@ public class Configuration {
   private final int requiredSolutionsCount;
   private final Level logLevel;
   private final long randomSeed;
+  private final String executedTests;
   // endregion
 
   // region Constructor
@@ -68,6 +70,7 @@ public class Configuration {
     requiredSolutionsCount = builder.requiredSolutionsCount;
     logLevel = builder.logLevel;
     randomSeed = builder.randomSeed;
+    executedTests = builder.executedTests;
   }
 
   // endregion
@@ -116,6 +119,10 @@ public class Configuration {
     return randomSeed;
   }
 
+  public String getExecutedTests() {
+    return executedTests;
+  }
+
   public static class Builder {
 
     // region Fields
@@ -134,6 +141,7 @@ public class Configuration {
     private int requiredSolutionsCount = DEFAULT_REQUIRED_SOLUTIONS_COUNT;
     private Level logLevel = DEFAULT_LOG_LEVEL;
     private long randomSeed = DEFAULT_RANDOM_SEED;
+    private String executedTests = DEFAULT_EXECUTED_TESTS;
     // endregion
 
     // region Constructors
@@ -295,6 +303,13 @@ public class Configuration {
       return this;
     }
 
+    public Builder setExecutedTest(final String executedTests) {
+      log.debug("enter setExecutedTest(String)");
+
+      this.executedTests = executedTests;
+      return this;
+    }
+
     // endregion
 
     // region Methods for CmdLineParser
@@ -395,6 +410,12 @@ public class Configuration {
     private void setRandomSeedFromCmdLineParser(final long randomSeed) {
       log.debug("enter setRandomSeedFromCmdLineParser(long)");
       this.randomSeed = randomSeed;
+    }
+
+    @Option(name = "-x", aliases = "--exec-test", usage = "Executed test cases.")
+    private void setExecutedTestCases(final String executedTests) {
+      log.debug("enter setExecutedTestCases(String)");
+      this.executedTests = executedTests;
     }
     // endregion
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestExecutor.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestExecutor.java
@@ -17,13 +17,13 @@ public class TestExecutor {
     this.config = config;
   }
 
-  // これを活かす
   public TestResults exec(final GeneratedSourceCode generatedSourceCode) {
-    if(!generatedSourceCode.isGenerationSuccess()) {
+    if (!generatedSourceCode.isGenerationSuccess()) {
       return EmptyTestResults.instance;
     }
 
-    final TestThread testThread = new TestThread(generatedSourceCode, config.getTargetProject());
+    final TestThread testThread =
+        new TestThread(generatedSourceCode, config.getTargetProject(), config.getExecutedTests());
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     final Future<?> future = executor.submit(testThread);
     executor.shutdown();
@@ -43,29 +43,5 @@ public class TestExecutor {
     return testThread.getTestResults();
   }
 
-  // これは死ぬ
-  // public TestResults ______exec(final GeneratedSourceCode generatedSourceCode,
-  // final List<ClassPath> classPath, final List<FullyQualifiedName> sourceFQNs,
-  // final List<FullyQualifiedName> testFQNs) throws ExecutionException {
-  //
-  // final TestThread testThread =
-  // new TestThread(generatedSourceCode, targetProject, classPath, sourceFQNs, testFQNs);
-  //
-  // final ExecutorService executor = Executors.newSingleThreadExecutor();
-  // final Future<?> future = executor.submit(testThread);
-  // executor.shutdown();
-  // try {
-  // future.get(timeoutSeconds, TimeUnit.SECONDS);
-  // } catch (final ExecutionException e) {
-  // // Executor側での例外をそのまま通す．
-  // throw e;
-  // } catch (final InterruptedException e) {
-  // // TODO Should handle safely
-  // e.printStackTrace();
-  // } catch (final TimeoutException e) {
-  // return EmptyTestResults.instance;
-  // }
-  //
-  // return testThread.getTestResults();
-  // }
+
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -34,8 +33,6 @@ import jp.kusumotolab.kgenprog.project.factory.TargetProject;
  */
 class TestThread extends Thread {
 
-  private final static String FQN_SEPARATOR = ";";
-
   private MemoryClassLoader memoryClassLoader;
   private final IRuntime jacocoRuntime;
   private final Instrumenter jacocoInstrumenter;
@@ -45,17 +42,17 @@ class TestThread extends Thread {
 
   private final GeneratedSourceCode generatedSourceCode;
   private final TargetProject targetProject;
-  private final String executedFqnStrings;
+  private final List<String> executionTestNames;
 
   public TestThread(final GeneratedSourceCode generatedSourceCode,
-      final TargetProject targetProject, final String executedFqnStrings) {
+      final TargetProject targetProject, final List<String> executionTestNames) {
     this.jacocoRuntime = new LoggerRuntime();
     this.jacocoInstrumenter = new Instrumenter(jacocoRuntime);
     this.jacocoRuntimeData = new RuntimeData();
 
     this.generatedSourceCode = generatedSourceCode;
     this.targetProject = targetProject;
-    this.executedFqnStrings = executedFqnStrings;
+    this.executionTestNames = executionTestNames;
   }
 
   // Result extraction point for multi thread
@@ -111,9 +108,8 @@ class TestThread extends Thread {
     return projectBuilder.build(generatedSourceCode);
   }
 
-  private List<FullyQualifiedName> convertStringToFqn() {
-    return Arrays.stream(executedFqnStrings.split(FQN_SEPARATOR))
-        .filter(fqn -> !fqn.isEmpty())
+  private List<FullyQualifiedName> convertExecutionTestNameToFqn() {
+    return executionTestNames.stream()
         .map(TestFullyQualifiedName::new)
         .collect(Collectors.toList());
   }
@@ -123,7 +119,7 @@ class TestThread extends Thread {
   }
 
   private List<FullyQualifiedName> getTestFQNs() {
-    final List<FullyQualifiedName> fqns = convertStringToFqn();
+    final List<FullyQualifiedName> fqns = convertExecutionTestNameToFqn();
     if (!fqns.isEmpty()) {
       return fqns;
     }

--- a/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
@@ -643,14 +643,26 @@ public class ConfigurationBuilderTest {
   }
 
   @Test
-  public void testBuildFromCmdLineArgsWithExecTests() {
-    final String executedTests = "example.FooTest";
+  public void testBuildFromCmdLineArgsWithExecTest() {
+    final String executionTest = "example.FooTest";
     final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
-        testPath.toString(), "-x", executedTests};
+        testPath.toString(), "-x", executionTest};
     final Configuration config = Builder.buildFromCmdLineArgs(args);
 
     assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
-    assertThat(config.getExecutedTests()).isEqualTo(executedTests);
+    assertThat(config.getExecutedTests()).contains(executionTest);
+  }
+
+  @Test
+  public void testBuildFromCmdLineArgsWithExecTests() {
+    final String executionTest1 = "example.FooTest";
+    final String executionTest2 = "example.BarTest";
+    final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
+        testPath.toString(), "-x", executionTest1, "-x", executionTest2};
+    final Configuration config = Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getExecutedTests()).containsExactlyInAnyOrder(executionTest1, executionTest2);
   }
 
   @Test

--- a/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
@@ -650,7 +650,7 @@ public class ConfigurationBuilderTest {
     final Configuration config = Builder.buildFromCmdLineArgs(args);
 
     assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
-    assertThat(config.getExecutedTests()).contains(executionTest);
+    assertThat(config.getExecutedTests()).containsExactlyInAnyOrder(executionTest);
   }
 
   @Test

--- a/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
@@ -642,6 +642,16 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTargetProject()).isEqualTo(expectedProject);
   }
 
+  @Test
+  public void testBuildFromCmdLineArgsWithExecTests() {
+    final String executedTests = "example.FooTest";
+    final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
+        testPath.toString(), "-x", executedTests};
+    final Configuration config = Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getExecutedTests()).isEqualTo(executedTests);
+  }
 
   @Test
   public void testBuildFromCmdLineArgsWithDifferentRootDir() {

--- a/src/test/java/jp/kusumotolab/kgenprog/project/test/TestExecutorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/test/TestExecutorTest.java
@@ -42,13 +42,14 @@ public class TestExecutorTest {
   public void testTestExecutorForBuildSuccess01() throws Exception {
     final Path rootPath = Paths.get("example/BuildSuccess01");
     final TargetProject targetProject = TargetProjectFactory.create(rootPath);
-    final GeneratedSourceCode generatedSourceCode = TestUtil.createGeneratedSourceCode(targetProject);
+    final GeneratedSourceCode generatedSourceCode =
+        TestUtil.createGeneratedSourceCode(targetProject);
     final ProjectBuilder projectBuilder = new ProjectBuilder(targetProject);
     projectBuilder.build(generatedSourceCode);
 
-    final Configuration config = new Configuration.Builder(targetProject)
-        .setTimeLimitSeconds(timeoutSeconds)
-        .build();
+    final Configuration config =
+        new Configuration.Builder(targetProject).setTimeLimitSeconds(timeoutSeconds)
+            .build();
     final TestExecutor executor = new TestExecutor(config);
     final TestResults result = executor.exec(generatedSourceCode);
 
@@ -81,13 +82,14 @@ public class TestExecutorTest {
   public void testTestExecutorForBuildSuccess02() throws Exception {
     final Path rootPath = Paths.get("example/BuildSuccess02");
     final TargetProject targetProject = TargetProjectFactory.create(rootPath);
-    final GeneratedSourceCode generatedSourceCode = TestUtil.createGeneratedSourceCode(targetProject);
+    final GeneratedSourceCode generatedSourceCode =
+        TestUtil.createGeneratedSourceCode(targetProject);
     final ProjectBuilder projectBuilder = new ProjectBuilder(targetProject);
     projectBuilder.build(generatedSourceCode);
 
-    final Configuration config = new Configuration.Builder(targetProject)
-        .setTimeLimitSeconds(timeoutSeconds)
-        .build();
+    final Configuration config =
+        new Configuration.Builder(targetProject).setTimeLimitSeconds(timeoutSeconds)
+            .build();
     final TestExecutor executor = new TestExecutor(config);
     final TestResults result = executor.exec(generatedSourceCode);
 
@@ -132,13 +134,14 @@ public class TestExecutorTest {
 
     final Path rootPath = Paths.get("example/BuildSuccess03");
     final TargetProject targetProject = TargetProjectFactory.create(rootPath);
-    final GeneratedSourceCode generatedSourceCode = TestUtil.createGeneratedSourceCode(targetProject);
+    final GeneratedSourceCode generatedSourceCode =
+        TestUtil.createGeneratedSourceCode(targetProject);
     final ProjectBuilder projectBuilder = new ProjectBuilder(targetProject);
     projectBuilder.build(generatedSourceCode);
 
-    final Configuration config = new Configuration.Builder(targetProject)
-        .setTimeLimitSeconds(timeoutSeconds)
-        .build();
+    final Configuration config =
+        new Configuration.Builder(targetProject).setTimeLimitSeconds(timeoutSeconds)
+            .build();
     final TestExecutor executor = new TestExecutor(config);
     final TestResults result = executor.exec(generatedSourceCode);
 
@@ -153,19 +156,64 @@ public class TestExecutorTest {
     // 無限ループする題材
     final Path rootPath = Paths.get("example/BuildSuccess04");
     final TargetProject targetProject = TargetProjectFactory.create(rootPath);
-    final GeneratedSourceCode generatedSourceCode = TestUtil.createGeneratedSourceCode(targetProject);
+    final GeneratedSourceCode generatedSourceCode =
+        TestUtil.createGeneratedSourceCode(targetProject);
     final ProjectBuilder projectBuilder = new ProjectBuilder(targetProject);
     projectBuilder.build(generatedSourceCode);
 
     // タイムアウト時間を短めに設定（CI高速化のため）
     final long timeout = 1;
-    final Configuration config = new Configuration.Builder(targetProject)
-        .setTimeLimitSeconds(timeout)
-        .build();
+    final Configuration config =
+        new Configuration.Builder(targetProject).setTimeLimitSeconds(timeout)
+            .build();
     final TestExecutor executor = new TestExecutor(config);
     final TestResults result = executor.exec(generatedSourceCode);
 
     // 無限ループが発生し，タイムアウトで打ち切られてEmptyになるはず
     assertThat(result).isInstanceOf(EmptyTestResults.class);
   }
+
+  @Test
+  public void testTestExecutorForBuildSuccess02WithSpecifyingExecutedTest() throws Exception {
+    final Path rootPath = Paths.get("example/BuildSuccess02");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final GeneratedSourceCode generatedSourceCode =
+        TestUtil.createGeneratedSourceCode(targetProject);
+    final ProjectBuilder projectBuilder = new ProjectBuilder(targetProject);
+    projectBuilder.build(generatedSourceCode);
+
+    // 実行するべきテストをFooTestのみに変更 （BarTestを実行しない）
+    final Configuration config =
+        new Configuration.Builder(targetProject).setExecutedTest("example.FooTest")
+            .build();
+    final TestExecutor executor = new TestExecutor(config);
+    final TestResults result = executor.exec(generatedSourceCode);
+
+    // 実行されたテストは10個から4個に減ったはず
+    assertThat(result.getExecutedTestFQNs()).containsExactlyInAnyOrder( //
+        FooTest01, FooTest02, FooTest03, FooTest04);
+    // BarTest01, BarTest02, BarTest03, BarTest04, BarTest05);
+
+    // 全テストの成否はこうなるはず
+    assertThat(result.getTestResult(FooTest01).failed).isFalse();
+    assertThat(result.getTestResult(FooTest02).failed).isFalse();
+    assertThat(result.getTestResult(FooTest03).failed).isTrue();
+    assertThat(result.getTestResult(FooTest04).failed).isFalse();
+    // assertThat(result.getTestResult(BarTest01).failed).isFalse();
+    // assertThat(result.getTestResult(BarTest02).failed).isFalse();
+    // assertThat(result.getTestResult(BarTest03).failed).isFalse();
+    // assertThat(result.getTestResult(BarTest04).failed).isFalse();
+    // assertThat(result.getTestResult(BarTest05).failed).isFalse();
+
+    final TestResult fooTest01result = result.getTestResult(FooTest01);
+
+    // FooTest.test01()ではFooとBarが実行されたはず
+    assertThat(fooTest01result.getExecutedTargetFQNs()).containsExactlyInAnyOrder(Foo, Bar);
+
+    // FooTest.test01()で実行されたFooのカバレッジはこうなるはず
+    assertThat(fooTest01result.getCoverages(Foo).statuses).containsExactlyInAnyOrder(EMPTY, COVERED,
+        EMPTY, COVERED, COVERED, EMPTY, EMPTY, NOT_COVERED, EMPTY, COVERED);
+
+  }
+
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/project/test/TestExecutorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/test/TestExecutorTest.java
@@ -184,7 +184,7 @@ public class TestExecutorTest {
 
     // 実行するべきテストをFooTestのみに変更 （BarTestを実行しない）
     final Configuration config =
-        new Configuration.Builder(targetProject).setExecutedTest("example.FooTest")
+        new Configuration.Builder(targetProject).addExecutionTest("example.FooTest")
             .build();
     final TestExecutor executor = new TestExecutor(config);
     final TestResults result = executor.exec(generatedSourceCode);


### PR DESCRIPTION
resolve #287

CUIから `-x` で実行すべきテストを指定可能に．
テストはひとまずFQNで指定（将来的にファイルしても可能に）．

```bash
# テストを指定しない＝全テストを実行する（asis）
$ kgp ./ -s src/ -t test/

# 単一テストを指定
$ kgp ./ -s src/ -t test/ -x example.FooTest

# 複数テストを指定（クラスパスと同様コロン区切りに）
$ kgp ./ -s src/ -t test/ -x example.FooTest:example.BarTest
```

動作確認用のテストを追加してます．
`TestExecutorTest#testTestExecutorForBuildSuccess02WithSpecifyingExecutedTest`