### PR TITLE
CLI のオプション指定の一貫性を確保

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -329,7 +329,7 @@ public class Configuration {
     }
 
     @Option(name = "-t", aliases = "--test", required = true,
-        handler = StringArrayOptionHandler.class, metaVar = "<path> ...",
+        handler = StringArrayOptionHandler.class, metaVar = "<fqn> ...",
         usage = "Paths of the root directories holding test codes")
     private void addTestPathFromCmdLineParser(final String testPath) {
       log.debug("enter addTestPathFromCmdLineParser(String)");

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -343,12 +343,13 @@ public class Configuration {
       this.classPaths.add(Paths.get(classPath));
     }
 
-    @Option(name = "-x", aliases = "--exec-test", usage = "Execution test cases.")
+    @Option(name = "-x", aliases = "--exec-test", handler = StringArrayOptionHandler.class,
+        metaVar = "<path> ...", usage = "Execution test cases.")
     private void addExecutionTestFromCmdLineParser(final String executionTest) {
       log.debug("enter addExecutionTestFromCmdLineParser(String)");
       this.executionTests.add(executionTest);
     }
-    
+
     @Option(name = "-w", aliases = "--working-dir", metaVar = "<path>",
         usage = "Path of a working directory")
     private void setWorkingDirFromCmdLineParser(final String workingDir) {

--- a/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
@@ -658,7 +658,7 @@ public class ConfigurationBuilderTest {
     final String executionTest1 = "example.FooTest";
     final String executionTest2 = "example.BarTest";
     final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
-        testPath.toString(), "-x", executionTest1, "-x", executionTest2};
+        testPath.toString(), "-x", executionTest1, executionTest2};
     final Configuration config = Builder.buildFromCmdLineArgs(args);
 
     assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);


### PR DESCRIPTION
resolve #318

メモ：
`handler = StringArrayOptionHandler.class` を指定しなくても（前の状態でも），
`-x A -x B` と `-x A B` 両方動くっぽい．

さらに，`handler = StringArrayOptionHandler.class` を指定しても
`-x A -x B` と `-x A B` 両方動くっぽい．

実装方法が一貫していないのは事実なので修正．