### PR TITLE
タイムアウト混在バグの修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -290,7 +290,7 @@ public class Configuration {
     public Builder setTestTimeLimitSeconds(final long testTimeLimitSeconds) {
       log.debug("enter setTestTimeLimitSeconds(long)");
 
-      this.timeLimit = Duration.ofSeconds(testTimeLimitSeconds);
+      this.testTimeLimit = Duration.ofSeconds(testTimeLimitSeconds);
       return this;
     }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -287,6 +287,20 @@ public class Configuration {
       return this;
     }
 
+    public Builder setTestTimeLimitSeconds(final long testTimeLimitSeconds) {
+      log.debug("enter setTestTimeLimitSeconds(long)");
+
+      this.timeLimit = Duration.ofSeconds(testTimeLimitSeconds);
+      return this;
+    }
+
+    public Builder setTestTimeLimit(final Duration testTimeLimit) {
+      log.debug("enter setTestTimeLimit(Duration)");
+
+      this.testTimeLimit = testTimeLimit;
+      return this;
+    }
+
     public Builder setRequiredSolutionsCount(final int requiredSolutionsCount) {
       log.debug("enter setRequiredSolutionsCount(int)");
 

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -29,6 +29,7 @@ public class Configuration {
   public static final int DEFAULT_HEADCOUNT = 100;
   public static final int DEFAULT_REQUIRED_SOLUTIONS_COUNT = 1;
   public static final Duration DEFAULT_TIME_LIMIT = Duration.ofSeconds(60);
+  public static final Duration DEFAULT_TEST_TIME_LIMIT = Duration.ofSeconds(10);
   public static final Level DEFAULT_LOG_LEVEL = Level.INFO;
   public static final Path DEFAULT_WORKING_DIR;
   public static final Path DEFAULT_OUT_DIR = Paths.get("kgenprog-out");
@@ -51,6 +52,7 @@ public class Configuration {
   private final int headcount;
   private final int maxGeneration;
   private final Duration timeLimit;
+  private final Duration testTimeLimit;
   private final int requiredSolutionsCount;
   private final Level logLevel;
   private final long randomSeed;
@@ -67,6 +69,7 @@ public class Configuration {
     headcount = builder.headcount;
     maxGeneration = builder.maxGeneration;
     timeLimit = builder.timeLimit;
+    testTimeLimit = builder.testTimeLimit;
     requiredSolutionsCount = builder.requiredSolutionsCount;
     logLevel = builder.logLevel;
     randomSeed = builder.randomSeed;
@@ -110,6 +113,14 @@ public class Configuration {
     return timeLimit;
   }
 
+  public long getTestTimeLimitSeconds() {
+    return getTestTimeLimit().getSeconds();
+  }
+
+  public Duration getTestTimeLimit() {
+    return testTimeLimit;
+  }
+
   public int getRequiredSolutionsCount() {
     return requiredSolutionsCount;
   }
@@ -138,6 +149,7 @@ public class Configuration {
     private int headcount = DEFAULT_HEADCOUNT;
     private int maxGeneration = DEFAULT_MAX_GENERATION;
     private Duration timeLimit = DEFAULT_TIME_LIMIT;
+    private Duration testTimeLimit = DEFAULT_TEST_TIME_LIMIT;
     private int requiredSolutionsCount = DEFAULT_REQUIRED_SOLUTIONS_COUNT;
     private Level logLevel = DEFAULT_LOG_LEVEL;
     private long randomSeed = DEFAULT_RANDOM_SEED;
@@ -388,6 +400,13 @@ public class Configuration {
     private void setTimeLimitFromCmdLineParser(final long timeLimit) {
       log.debug("enter setTimeLimitFromCmdLineParser(long)");
       this.timeLimit = Duration.ofSeconds(timeLimit);
+    }
+
+    @Option(name = "--test-time-limit",
+        usage = "Time limit to build and test for each variant in second")
+    private void setTestTimeLimitFromCmdLineParser(final long testTimeLimit) {
+      log.debug("enter setTestTimeLimitFromCmdLineParser(long)");
+      this.testTimeLimit = Duration.ofSeconds(testTimeLimit);
     }
 
     @Option(name = "-e", aliases = "--required-solutions",

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestExecutor.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestExecutor.java
@@ -28,7 +28,7 @@ public class TestExecutor {
     final Future<?> future = executor.submit(testThread);
     executor.shutdown();
     try {
-      future.get(config.getTimeLimitSeconds(), TimeUnit.SECONDS);
+      future.get(config.getTestTimeLimitSeconds(), TimeUnit.SECONDS);
     } catch (final ExecutionException e) {
       // TODO Should handle safely
       // Executor側での例外をそのまま通す．

--- a/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
@@ -37,6 +37,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -61,6 +64,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -85,6 +91,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -110,6 +119,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -134,6 +146,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -159,6 +174,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -182,6 +200,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
     assertThat(config.getTimeLimit()).isEqualTo(timeLimit);
     assertThat(config.getTimeLimitSeconds()).isEqualTo(timeLimit.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -206,6 +227,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
     assertThat(config.getTimeLimit()).isEqualTo(Duration.ofSeconds(timeLimitSeconds));
     assertThat(config.getTimeLimitSeconds()).isEqualTo(timeLimitSeconds);
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -231,6 +255,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount()).isEqualTo(requiredSolutionsCount);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
@@ -254,6 +281,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(logLevel);
@@ -277,6 +307,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Level.DEBUG);
@@ -301,6 +334,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -325,6 +361,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -349,6 +388,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -375,6 +417,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -401,6 +446,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -427,6 +475,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -453,6 +504,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -479,6 +533,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -504,8 +561,12 @@ public class ConfigurationBuilderTest {
     assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
     assertThat(config.getTimeLimit()).isEqualTo(timeLimit);
     assertThat(config.getTimeLimitSeconds()).isEqualTo(timeLimit.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
 
@@ -530,6 +591,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount()).isEqualTo(requiredSolutionsCount);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
@@ -554,6 +618,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Level.DEBUG);
@@ -579,6 +646,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Level.ERROR);
@@ -605,6 +675,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -631,6 +704,9 @@ public class ConfigurationBuilderTest {
     assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
     assertThat(config.getTimeLimitSeconds())
         .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
     assertThat(config.getRequiredSolutionsCount())
         .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
@@ -663,6 +739,18 @@ public class ConfigurationBuilderTest {
 
     assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
     assertThat(config.getExecutedTests()).containsExactlyInAnyOrder(executionTest1, executionTest2);
+  }
+
+  @Test
+  public void testBuildFromCmdLineArgsWithTestTimeLimit() {
+    final Duration testTimeLimit = Duration.ofSeconds(99);
+    final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
+        testPath.toString(), "--test-time-limit", String.valueOf(testTimeLimit.getSeconds())};
+    final Configuration config = Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getTestTimeLimit()).isEqualTo(testTimeLimit);
+    assertThat(config.getTestTimeLimitSeconds()).isEqualTo(testTimeLimit.getSeconds());
   }
 
   @Test


### PR DESCRIPTION
resolve #327

### やったこと
- Configurationオブジェクト内で2つのタイムアウトを切り分け
- 上記テストの追加
- TestExecutorでテスト用のタイムアウトを読み込むように修正