### PR TITLE
-q オプション指定時に余計なログを出力しないように修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/CUILauncher.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/CUILauncher.java
@@ -21,23 +21,13 @@ import jp.kusumotolab.kgenprog.project.PatchGenerator;
 
 public class CUILauncher {
 
-  // region Fields
-  private static final Logger log = LoggerFactory.getLogger(CUILauncher.class);
-  // endregion
-
   public static void main(final String[] args) {
-    log.info("start kGenProg");
-
     final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
     final CUILauncher launcher = new CUILauncher();
     launcher.launch(config);
-
-    log.info("end kGenProg");
   }
 
   public void launch(final Configuration config) {
-    log.debug("enter launch()");
-
     setLogLevel(config.getLogLevel());
 
     final FaultLocalization faultLocalization = new Ochiai();
@@ -56,8 +46,6 @@ public class CUILauncher {
         crossover, sourceCodeGeneration, sourceCodeValidation, variantSelection, patchGenerator);
 
     kGenProgMain.run();
-
-    log.debug("exit launch()");
   }
 
   // region Private Method

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -403,14 +403,14 @@ public class Configuration {
     @Option(name = "-v", aliases = "--verbose", usage = "Verbose mode. Print DEBUG level logs.")
     private void setLogLevelDebugFromCmdLineParser(final boolean isVerbose) {
       log.debug("enter setLogLevelDebugFromCmdLineParser(boolean)");
-      log.info("log level has been set DEBUG");
+      log.debug("log level has been set DEBUG");
       logLevel = Level.DEBUG;
     }
 
     @Option(name = "-q", aliases = "--quiet", usage = "Quiet mode. Print ERROR level logs.")
     private void setLogLevelErrorFromCmdLineParser(final boolean isQuiet) {
       log.debug("enter setLogLevelErrorFromCmdLineParser(boolean)");
-      log.info("log level has been set ERROR");
+      log.debug("log level has been set ERROR");
       logLevel = Level.ERROR;
     }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -159,7 +159,10 @@ public class Configuration {
       this.targetProject = targetProject;
     }
 
-    private Builder() {}
+    private Builder() {
+      // do nothing
+      // do not call me except from buildFromCmdLineArgs
+    }
 
     // endregion
 

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -186,24 +186,6 @@ public class Configuration {
       return builder.build();
     }
 
-    private static void validateArgument(final Builder builder) throws IllegalArgumentException {
-      final Path currentDir = Paths.get(".");
-      final Path projectRootDir = builder.rootDir;
-
-      try {
-        if (!Files.isSameFile(currentDir, projectRootDir)) {
-          log.warn(
-              "The directory where kGenProg is running is different from the root directory of the given target project.");
-          log.warn(
-              "If the target project include test cases with file I/O, such test cases won't run correctly.");
-          log.warn(
-              "We recommend that you run kGenProg with the root directory of the target project as the current directory.");
-        }
-      } catch (final IOException e) {
-        throw new IllegalArgumentException("directory " + projectRootDir + " is not accessible");
-      }
-    }
-
     public Configuration build() {
       log.debug("enter build()");
 
@@ -310,6 +292,28 @@ public class Configuration {
 
       this.executionTests.add(executionTest);
       return this;
+    }
+
+    // endregion
+
+    // region Private methods
+
+    private static void validateArgument(final Builder builder) throws IllegalArgumentException {
+      final Path currentDir = Paths.get(".");
+      final Path projectRootDir = builder.rootDir;
+
+      try {
+        if (!Files.isSameFile(currentDir, projectRootDir)) {
+          log.warn(
+              "The directory where kGenProg is running is different from the root directory of the given target project.");
+          log.warn(
+              "If the target project include test cases with file I/O, such test cases won't run correctly.");
+          log.warn(
+              "We recommend that you run kGenProg with the root directory of the target project as the current directory.");
+        }
+      } catch (final IOException e) {
+        throw new IllegalArgumentException("directory " + projectRootDir + " is not accessible");
+      }
     }
 
     // endregion

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -303,7 +303,7 @@ public class Configuration {
       final Path projectRootDir = builder.rootDir;
 
       try {
-        if (!Files.isSameFile(currentDir, projectRootDir)) {
+        if (!isQuiet(builder) && !Files.isSameFile(currentDir, projectRootDir)) {
           log.warn(
               "The directory where kGenProg is running is different from the root directory of the given target project.");
           log.warn(
@@ -314,6 +314,10 @@ public class Configuration {
       } catch (final IOException e) {
         throw new IllegalArgumentException("directory " + projectRootDir + " is not accessible");
       }
+    }
+
+    private static boolean isQuiet(final Builder builder) {
+      return builder.logLevel.equals(Level.ERROR);
     }
 
     // endregion


### PR DESCRIPTION
resolve #293 

### やったこと
- `CUILauncher` のロギング処理削除
- `Configuration.Builder` 内で `-q` オプション指定時に warning メッセージを出力しないように修正
- `Configuration.Builder` の雑多な変更
  - メソッド並べ替え
  - ログレベル変更処理時のログメッセージのログレベルを INFO -> DEBUG に変更
  - コメント追加