### PR TITLE
ルーレットの配列あふれバグの修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/PerformanceTest.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/PerformanceTest.java
@@ -53,7 +53,7 @@ public class PerformanceTest {
             .setWorkingDir(WORK_PATH)
             .build();
     final FaultLocalization faultLocalization = new Ochiai();
-    final Random random = new Random();
+    final Random random = new Random(config.getRandomSeed());
     final CandidateSelection statementSelection = new RouletteStatementSelection(random);
     final Mutation mutation = new RandomMutation(10, random, statementSelection);
     final Crossover crossover = new SinglePointCrossover(random);

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/RandomMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/RandomMutation.java
@@ -32,16 +32,17 @@ public class RandomMutation extends Mutation {
       final List<Suspiciousness> suspiciousnesses = variant.getSuspiciousnesses();
       final Function<Suspiciousness, Double> weightFunction = susp -> Math.pow(susp.getValue(), 2);
 
-      final Roulette<Suspiciousness> roulette =
-          new Roulette<>(suspiciousnesses, weightFunction, random);
+      try {
+        final Roulette<Suspiciousness> roulette =
+            new Roulette<>(suspiciousnesses, weightFunction, random);
 
-      for (int i = 0; i < numberOfBase; i++) {
-        final Suspiciousness suspiciousness = roulette.exec();
-        final Base base = makeBase(suspiciousness);
-        final Gene gene = makeGene(variant.getGene(), base);
-        generatedVariants.add(variantStore.createVariant(gene));
-      }
-
+        for (int i = 0; i < numberOfBase; i++) {
+          final Suspiciousness suspiciousness = roulette.exec();
+          final Base base = makeBase(suspiciousness);
+          final Gene gene = makeGene(variant.getGene(), base);
+          generatedVariants.add(variantStore.createVariant(gene));
+        }
+      } catch (final IllegalArgumentException ignored) { }
     }
 
     log.debug("exit exec(VariantStore)");

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/RandomMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/RandomMutation.java
@@ -32,17 +32,24 @@ public class RandomMutation extends Mutation {
       final List<Suspiciousness> suspiciousnesses = variant.getSuspiciousnesses();
       final Function<Suspiciousness, Double> weightFunction = susp -> Math.pow(susp.getValue(), 2);
 
-      try {
-        final Roulette<Suspiciousness> roulette =
-            new Roulette<>(suspiciousnesses, weightFunction, random);
+      if (suspiciousnesses.isEmpty()) {
+        log.debug("suspiciousnesses is empty.");
+        continue;
+      }
+      final Roulette<Suspiciousness> roulette;
 
-        for (int i = 0; i < numberOfBase; i++) {
-          final Suspiciousness suspiciousness = roulette.exec();
-          final Base base = makeBase(suspiciousness);
-          final Gene gene = makeGene(variant.getGene(), base);
-          generatedVariants.add(variantStore.createVariant(gene));
-        }
-      } catch (final IllegalArgumentException ignored) { }
+      try {
+        roulette = new Roulette<>(suspiciousnesses, weightFunction, random);
+      } catch (final IllegalArgumentException ignored) {
+        continue;
+      }
+
+      for (int i = 0; i < numberOfBase; i++) {
+        final Suspiciousness suspiciousness = roulette.exec();
+        final Base base = makeBase(suspiciousness);
+        final Gene gene = makeGene(variant.getGene(), base);
+        generatedVariants.add(variantStore.createVariant(gene));
+      }
     }
 
     log.debug("exit exec(VariantStore)");

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/RandomMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/RandomMutation.java
@@ -36,13 +36,8 @@ public class RandomMutation extends Mutation {
         log.debug("suspiciousnesses is empty.");
         continue;
       }
-      final Roulette<Suspiciousness> roulette;
-
-      try {
-        roulette = new Roulette<>(suspiciousnesses, weightFunction, random);
-      } catch (final IllegalArgumentException ignored) {
-        continue;
-      }
+      final Roulette<Suspiciousness> roulette = new Roulette<>(suspiciousnesses, weightFunction,
+          random);
 
       for (int i = 0; i < numberOfBase; i++) {
         final Suspiciousness suspiciousness = roulette.exec();

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/Roulette.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/Roulette.java
@@ -17,6 +17,9 @@ public class Roulette<T> {
 
   public Roulette(final List<T> valueList, final Function<T, Double> weightFunction,
       final Random random) {
+    if (valueList.isEmpty()) {
+      throw new IllegalArgumentException("valueList must have at least one element.");
+    }
     final List<Double> weightList = valueList.stream()
         .map(weightFunction)
         .collect(Collectors.toList());

--- a/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
@@ -58,7 +58,7 @@ public class KGenProgMainTest {
             .setRequiredSolutionsCount(1)
             .build();
     final FaultLocalization faultLocalization = new Ochiai();
-    final Random random = new Random();
+    final Random random = new Random(config.getRandomSeed());
     final CandidateSelection statementSelection = new RouletteStatementSelection(random);
     final Mutation mutation = new RandomMutation(10, random, statementSelection);
     final Crossover crossover = new SinglePointCrossover(random);

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/RouletteTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/RouletteTest.java
@@ -1,6 +1,7 @@
 package jp.kusumotolab.kgenprog.ga;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -16,7 +17,7 @@ import jp.kusumotolab.kgenprog.Configuration;
 public class RouletteTest {
 
   @Test
-  public void exec() {
+  public void testExec() {
     final Random random = new Random(Configuration.DEFAULT_RANDOM_SEED);
     random.setSeed(0);
     final List<Integer> indexList = IntStream.range(0, 10)
@@ -41,5 +42,12 @@ public class RouletteTest {
         .sorted(Comparator.comparingInt(Entry::getKey))
         .collect(Collectors.toList());
     assertThat(sortedEntrySet).isSortedAccordingTo(Comparator.comparingInt(Entry::getValue));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testException() {
+    final Random random = new Random(Configuration.DEFAULT_RANDOM_SEED);
+    new Roulette<>(new ArrayList<>(),
+        Integer::doubleValue, random);
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/RouletteTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/RouletteTest.java
@@ -19,13 +19,11 @@ public class RouletteTest {
   @Test
   public void testExec() {
     final Random random = new Random(Configuration.DEFAULT_RANDOM_SEED);
-    random.setSeed(0);
     final List<Integer> indexList = IntStream.range(0, 10)
         .boxed()
         .collect(Collectors.toList());
     final Function<Integer, Double> weightFunction = Integer::doubleValue;
-    final Roulette<Integer> roulette = new Roulette<>(indexList, weightFunction,
-        random);
+    final Roulette<Integer> roulette = new Roulette<>(indexList, weightFunction, random);
 
     final Map<Integer, Integer> map = new HashMap<>();
     for (int i = 0; i < 1000; i++) {
@@ -47,7 +45,6 @@ public class RouletteTest {
   @Test(expected = IllegalArgumentException.class)
   public void testException() {
     final Random random = new Random(Configuration.DEFAULT_RANDOM_SEED);
-    new Roulette<>(new ArrayList<>(),
-        Integer::doubleValue, random);
+    new Roulette<>(new ArrayList<>(), Integer::doubleValue, random);
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/RouletteTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/RouletteTest.java
@@ -11,12 +11,13 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.Test;
+import jp.kusumotolab.kgenprog.Configuration;
 
 public class RouletteTest {
 
   @Test
   public void exec() {
-    final Random random = new Random();
+    final Random random = new Random(Configuration.DEFAULT_RANDOM_SEED);
     random.setSeed(0);
     final List<Integer> indexList = IntStream.range(0, 10)
         .boxed()


### PR DESCRIPTION
resolve #315 
## 問題
- `Random` の引数の指定がバラバラ
- ルーレットの候補のリストが空の場合に `java.lang.IndexOutOfBoundsException: Index: 0, Size: 0` で落ちる

## 修正内容
- `Random` の引数を `config` の値 ( もしくはそのデフォルト値 ) に修正
- ルーレットの候補のリストが空の場合に `java.lang.IllegalArgumentException` を投げるよう修正

## 懸念点
ルーレットの候補の空の場合の処理ってこれでいいですかね？
良いプラクティスがあれば教えてください。
