### PR TITLE
VariantStore内部でgeneratedVariantsを扱うように変更

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/Strategies.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Strategies.java
@@ -7,6 +7,8 @@ import jp.kusumotolab.kgenprog.ga.Fitness;
 import jp.kusumotolab.kgenprog.ga.Gene;
 import jp.kusumotolab.kgenprog.ga.SourceCodeGeneration;
 import jp.kusumotolab.kgenprog.ga.SourceCodeValidation;
+import jp.kusumotolab.kgenprog.ga.Variant;
+import jp.kusumotolab.kgenprog.ga.VariantSelection;
 import jp.kusumotolab.kgenprog.ga.VariantStore;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
@@ -21,16 +23,19 @@ public class Strategies {
   private final JDTASTConstruction astConstruction;
   private final SourceCodeValidation sourceCodeValidation;
   private final TestExecutor testExecutor;
+  private final VariantSelection variantSelection;
 
   public Strategies(final FaultLocalization faultLocalization,
       final JDTASTConstruction astConstruction, final SourceCodeGeneration sourceCodeGeneration,
-      final SourceCodeValidation sourceCodeValidation, final TestExecutor testExecutor) {
+      final SourceCodeValidation sourceCodeValidation, final TestExecutor testExecutor,
+      final VariantSelection variantSelection) {
 
     this.faultLocalization = faultLocalization;
     this.astConstruction = astConstruction;
     this.sourceCodeGeneration = sourceCodeGeneration;
     this.sourceCodeValidation = sourceCodeValidation;
     this.testExecutor = testExecutor;
+    this.variantSelection = variantSelection;
   }
 
   public List<Suspiciousness> execFaultLocalization(final GeneratedSourceCode generatedSourceCode,
@@ -54,5 +59,10 @@ public class Strategies {
 
   public GeneratedSourceCode execASTConstruction(final TargetProject targetProject) {
     return new GeneratedSourceCode(astConstruction.constructAST(targetProject));
+  }
+
+  public List<Variant> execVariantSelection(final List<Variant> current,
+      final List<Variant> generated) {
+    return variantSelection.exec(current, generated);
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/VariantStore.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/VariantStore.java
@@ -1,8 +1,12 @@
 package jp.kusumotolab.kgenprog.ga;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import jp.kusumotolab.kgenprog.OrdinalNumber;
 import jp.kusumotolab.kgenprog.Strategies;
 import jp.kusumotolab.kgenprog.fl.Suspiciousness;
@@ -12,10 +16,13 @@ import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 public class VariantStore {
 
+  private static Logger log = LoggerFactory.getLogger(VariantStore.class);
+
   private final TargetProject targetProject;
   private final Strategies strategies;
   private final Variant initialVariant;
   private List<Variant> currentVariants;
+  private List<Variant> generatedVariants;
   private final List<Variant> foundSolutions;
   private final OrdinalNumber generation;
 
@@ -25,10 +32,11 @@ public class VariantStore {
 
     initialVariant = createInitialVariant();
     currentVariants = Collections.singletonList(initialVariant);
+    generatedVariants = new ArrayList<>();
     foundSolutions = new ArrayList<>();
     generation = new OrdinalNumber(1);
   }
-  
+
   /**
    * テスト用
    */
@@ -37,8 +45,9 @@ public class VariantStore {
     this.targetProject = null;
     this.strategies = null;
     this.initialVariant = initialVariant;
-    
+
     currentVariants = Collections.singletonList(initialVariant);
+    generatedVariants = new ArrayList<>();
     foundSolutions = new ArrayList<>();
     generation = new OrdinalNumber(1);
   }
@@ -64,17 +73,70 @@ public class VariantStore {
     return currentVariants;
   }
 
-  public void addFoundSolution(final Variant variant) {
-    foundSolutions.add(variant);
+  public List<Variant> getGeneratedVariants() {
+    return generatedVariants;
   }
 
   public List<Variant> getFoundSolutions() {
     return foundSolutions;
   }
 
-  public void setNextGenerationVariants(final List<Variant> variants) {
+  /**
+   * 引数の要素すべてを次世代のVariantとして追加する
+   * 
+   * @see addNextGenerationVariant(Variant)
+   * 
+   * @param variants 追加対象
+   */
+  public void addGeneratedVariants(Variant... variants) {
+    addGeneratedVariants(Arrays.asList(variants));
+  }
+
+  /**
+   * リストの要素すべてを次世代のVariantとして追加する
+   * 
+   * @see addNextGenerationVariant(Variant)
+   * 
+   * @param variants 追加対象
+   */
+  public void addGeneratedVariants(Collection<? extends Variant> variants) {
+    variants.forEach(this::addGeneratedVariant);
+  }
+
+  /**
+   * 引数を次世代のVariantとして追加する {@code variant.isCompleted() == true}
+   * の場合，foundSolutionとして追加され次世代のVariantには追加されない
+   * 
+   * @param variant
+   */
+  public void addGeneratedVariant(Variant variant) {
+    log.debug("enter addNextGenerationVariant(Variant)");
+
+    if (variant.isCompleted()) {
+      foundSolutions.add(variant);
+      log.info("{} solution has been found", getFoundSolutionsNumber());
+    } else {
+      generatedVariants.add(variant);
+    }
+  }
+
+  /**
+   * VariantSelectionを実行し世代交代を行う
+   * 
+   * currentVariantsおよびgeneratedVariantsから次世代のVariantsを選択し，それらを次のcurrentVariantsとする
+   * また，generatedVariantsをclearする
+   */
+  public void changeGeneration() {
+    log.debug("enter changeGeneration()");
+
+    final List<Variant> nextVariants =
+        strategies.execVariantSelection(currentVariants, generatedVariants);
     generation.incrementAndGet();
-    currentVariants = variants;
+    log.info("exec selection. {} variants: ({}, {}) => {}", generation, currentVariants.size(),
+        generatedVariants.size(), nextVariants.size());
+
+    currentVariants = nextVariants;
+    generatedVariants = new ArrayList<>();
   }
 
   private Variant createInitialVariant() {
@@ -89,4 +151,5 @@ public class VariantStore {
         strategies.execFaultLocalization(sourceCode, testResults);
     return new Variant(gene, sourceCode, testResults, fitness, suspiciousnesses);
   }
+
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/VariantStoreTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/VariantStoreTest.java
@@ -1,9 +1,13 @@
 package jp.kusumotolab.kgenprog.ga;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
@@ -12,85 +16,101 @@ import jp.kusumotolab.kgenprog.fl.Suspiciousness;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
-import jp.kusumotolab.kgenprog.project.test.MockTestResults;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 
 public class VariantStoreTest {
 
-  
-  private static class MockStrategies extends Strategies{
-    private final List<Suspiciousness> faultLocalizationResult = new ArrayList<>();
-    private final GeneratedSourceCode sourceCodeGenerationResult = new GeneratedSourceCode(Collections.emptyList());
-    private final TestResults testExecutorResult = new MockTestResults();
-    private final Fitness sourceCodeValidationResult = new SimpleFitness(Double.NaN);
-    private final GeneratedSourceCode astConstructionResult = new GeneratedSourceCode(Collections.emptyList());
-    
-    
-    public MockStrategies() {
-      super(null, null, null, null, null);
-    }
-
-    @Override
-    public List<Suspiciousness> execFaultLocalization(GeneratedSourceCode generatedSourceCode,
-        TestResults testResults) {
-      return faultLocalizationResult;
-    }
-
-    @Override
-    public GeneratedSourceCode execSourceCodeGeneration(VariantStore variantStore, Gene gene) {
-      return sourceCodeGenerationResult;
-    }
-
-    @Override
-    public TestResults execTestExecutor(GeneratedSourceCode generatedSourceCode) {
-      return testExecutorResult;
-    }
-
-    @Override
-    public Fitness execSourceCodeValidation(VariantStore variantStore, TestResults testResults) {
-      return sourceCodeValidationResult;
-    }
-
-    @Override
-    public GeneratedSourceCode execASTConstruction(TargetProject targetProject) {
-      return astConstructionResult;
-    }
-    
-  }
-  
   @Test
   public void testCreateVariant() {
     final Path basePath = Paths.get("example/BuildSuccess01");
     final TargetProject project = TargetProjectFactory.create(basePath);
-    final MockStrategies strategies = new MockStrategies();
+
+    final List<Suspiciousness> faultLocalizationResult = new ArrayList<>();
+    final GeneratedSourceCode sourceCodeGenerationResult =
+        new GeneratedSourceCode(Collections.emptyList());
+    final TestResults testExecutorResult = mock(TestResults.class);
+    final Fitness sourceCodeValidationResult = new SimpleFitness(Double.NaN);
+    final GeneratedSourceCode astConstructionResult =
+        new GeneratedSourceCode(Collections.emptyList());
+    final Strategies strategies = mock(Strategies.class);
+    when(strategies.execFaultLocalization(any(), any())).thenReturn(faultLocalizationResult);
+    when(strategies.execSourceCodeGeneration(any(), any())).thenReturn(sourceCodeGenerationResult);
+    when(strategies.execTestExecutor(any())).thenReturn(testExecutorResult);
+    when(strategies.execSourceCodeValidation(any(), any())).thenReturn(sourceCodeValidationResult);
+    when(strategies.execASTConstruction(any())).thenReturn(astConstructionResult);
+
     final VariantStore variantStore = new VariantStore(project, strategies);
     final Gene gene = new SimpleGene(Collections.emptyList());
-    
+
     final Variant variant = variantStore.createVariant(gene);
     assertThat(variant.getGene()).isSameAs(gene);
-    assertThat(variant.getGeneratedSourceCode()).isSameAs(strategies.sourceCodeGenerationResult);
-    assertThat(variant.getTestResults()).isSameAs(strategies.testExecutorResult);
-    assertThat(variant.getFitness()).isSameAs(strategies.sourceCodeValidationResult);
+    assertThat(variant.getGeneratedSourceCode()).isSameAs(sourceCodeGenerationResult);
+    assertThat(variant.getTestResults()).isSameAs(testExecutorResult);
+    assertThat(variant.getFitness()).isSameAs(sourceCodeValidationResult);
   }
 
   @Test
   public void testGetGenerationNumber() {
     final Path basePath = Paths.get("example/BuildSuccess01");
     final TargetProject project = TargetProjectFactory.create(basePath);
-    final MockStrategies strategies = new MockStrategies();
+    final Strategies strategies = mock(Strategies.class);
+    when(strategies.execVariantSelection(any(), any())).thenReturn(Collections.emptyList());
+
     final VariantStore variantStore = new VariantStore(project, strategies);
-    
-    //初期世代番号は1
-    assertThat(variantStore.getGenerationNumber().get()).isEqualTo(1);
-    
-    //setNextGenerationVariantsするたびに1増える
-    variantStore.setNextGenerationVariants(Collections.emptyList());
-    assertThat(variantStore.getGenerationNumber().get()).isEqualTo(2);
-    
-    variantStore.setNextGenerationVariants(Collections.emptyList());
+
+    // 初期世代番号は1
+    assertThat(variantStore.getGenerationNumber()
+        .get()).isEqualTo(1);
+
+    // setNextGenerationVariantsするたびに1増える
+    variantStore.changeGeneration();
+    assertThat(variantStore.getGenerationNumber()
+        .get()).isEqualTo(2);
+
+    variantStore.changeGeneration();
     assertThat(variantStore.getGenerationNumber()
         .get()).isEqualTo(3);
 
+  }
+
+  @Test
+  public void testGetGeneratedVariants() {
+    final Path basePath = Paths.get("example/BuildSuccess01");
+    final TargetProject project = TargetProjectFactory.create(basePath);
+    final Strategies strategies = mock(Strategies.class);
+    when(strategies.execVariantSelection(any(), any())).then(v -> v.getArgument(1));
+
+    final VariantStore variantStore = new VariantStore(project, strategies);
+
+    final Variant success1 = createMockVariant(true);
+    final Variant success2 = createMockVariant(true);
+    final Variant success3 = createMockVariant(true);
+    final Variant fail1 = createMockVariant(false);
+    final Variant fail2 = createMockVariant(false);
+    final Variant fail3 = createMockVariant(false);
+
+    variantStore.addGeneratedVariant(success1);
+    variantStore.addGeneratedVariant(fail1);
+    variantStore.addGeneratedVariants(Arrays.asList(success2, fail2));
+    variantStore.addGeneratedVariants(fail3, success3);
+
+    // テスト成功Variantのみが含まれているか確認
+    assertThat(variantStore.getFoundSolutionsNumber()).hasValue(3);
+    assertThat(variantStore.getFoundSolutions()).containsExactly(success1, success2, success3);
+
+    // テスト成功Variantが含まれていないか確認
+    assertThat(variantStore.getGeneratedVariants()).containsExactly(fail1, fail2, fail3);
+
+    variantStore.changeGeneration();
+
+    // 世代交代が行われたか確認
+    assertThat(variantStore.getCurrentVariants()).containsExactly(fail1, fail2, fail3);
+  }
+
+  private Variant createMockVariant(boolean isCompleted) {
+    final Variant variant = mock(Variant.class);
+    when(variant.isCompleted()).thenReturn(isCompleted);
+    return variant;
   }
 }


### PR DESCRIPTION
resolve #345 

次世代のVariantsをVariantStore内部で持つように変更し、Variantが追加されるときにCompletedVariantかを判定する。
VariantSelectionもVariantStore内から呼び出すように変更