### PR TITLE
設定ファイル読み込み機能を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ kGenProg は単一の jar ファイルにまとめてあります．[ここ](htt
 
 
 ## 使用方法
-```sh
+```
 $ java -jar path/to/kGenProg.jar 
 $ java -jar path/to/kGenProg.jar --config <path>
 $ java -jar path/to/kGenProg.jar -r <path> -s <path>... -t <path>... [-x <fqn>...] [-c <path>...]
@@ -37,6 +37,7 @@ $ java -jar path/to/kGenProg.jar -r ./ -s src/example/CloseToZero.java -t src/ex
 ```
 
 `.toml` ファイルにパラメータをまとめておいて，実行時に指定することもできます．
+[example/CloseToZero01/kgenprog.toml](example/CloseToZero01/kgenprog.toml) に設定ファイルのサンプルがあります．
 ```sh
 $ java -jar path/to/kGenProg.jar --config kGenProg/example/CloseToZero01/kgenprog.toml
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ kGenProg は単一の jar ファイルにまとめてあります．[ここ](htt
 
 
 ## 使用方法
+```sh
+$ java -jar path/to/kGenProg.jar 
+$ java -jar path/to/kGenProg.jar --config <path>
+$ java -jar path/to/kGenProg.jar -r <path> -s <path>... -t <path>... [-x <fqn>...] [-c <path>...]
+    [-w <path>] [-o <path>] [-v | -q] [--siblings-count <num>] [--headcount <num>]
+    [--max-generation <num>] [--time-limit <sec>] [--required-solutions <num>] [--random-seed <num>]
+    
+```
 
 ### 使用例
 [kGenProg/example](example) には kGenProg のテストに用いているバグが置いてあります．
@@ -28,13 +36,24 @@ $ cd kGenProg/example/CloseToZero01
 $ java -jar path/to/kGenProg.jar -r ./ -s src/example/CloseToZero.java -t src/example/CloseToZeroTest.java
 ```
 
+`.toml` ファイルにパラメータをまとめておいて，実行時に指定することもできます．
+```sh
+$ java -jar path/to/kGenProg.jar --config kGenProg/example/CloseToZero01/kgenprog.toml
+```
+
+実行時にオプションを省略した場合は，カレントディレクトリの `kgenprog.toml` を読み込みます．
+```sh
+$ cd kGenProg/example/CloseToZero01
+$ java -jar path/to/kGenProg.jar
+```
+
 
 ### オプション
 | オプション | 説明 | デフォルト値/デフォルト動作 |
 |---|---|---|
-| `-r`, `--root-dir` | 修正対象プロジェクトのルートディレクトリへのパス．テスト実行の都合上，対象プロジェクトのルートに移動した上でカレントディレクトリを指定することを推奨します．（必須オプション） | なし |
-| `-s`, `--src` | プロダクトコード（単体テスト用のコードを除く実装系のソースコード）へのパス，もしくはプロダクトコードを含むディレクトリへのパス．スペース区切りで複数指定可能．（必須オプション） | なし |
-| `-t`, `--test` | テストコード（単体テスト用のソースコード）へのパス，もしくはテストコードを含むディレクトリへのパス．スペース区切りで複数指定可能．（必須オプション） | なし |
+| `-r`, `--root-dir` | 修正対象プロジェクトのルートディレクトリへのパス．テスト実行の都合上，対象プロジェクトのルートに移動した上でカレントディレクトリを指定することを推奨します． | なし |
+| `-s`, `--src` | プロダクトコード（単体テスト用のコードを除く実装系のソースコード）へのパス，もしくはプロダクトコードを含むディレクトリへのパス．スペース区切りで複数指定可能． | なし |
+| `-t`, `--test` | テストコード（単体テスト用のソースコード）へのパス，もしくはテストコードを含むディレクトリへのパス．スペース区切りで複数指定可能． | なし |
 | `-x`, `--exec-test` | 遺伝的アルゴリズム中に実行されるテストクラスの完全限定名．バグを発現させるテストクラスを指定してください．スペース区切りで複数指定可能． | すべてのテストクラス |
 | `-c`, `--cp` | 修正対象プロジェクトのビルドに必要なクラスパス．スペース区切りで複数指定可能． | なし |
 | `-w`, `--working-dir` | kGenProg が作業を行うディレクトリへのパス | システムの一時ファイルディレクトリ（Windows: `%tmp%`; *nix: `$TMPDIR`）以下に `kgenprog-work` で始まるディレクトリが実行ごとに新規に作成される |
@@ -47,3 +66,4 @@ $ java -jar path/to/kGenProg.jar -r ./ -s src/example/CloseToZero.java -t src/ex
 | `--time-limit` | 遺伝的アルゴリズムを打ち切る時間（秒） | 60 |
 | `--required-solutions` | 出力する解（修正パッチ）の数 | 1 |
 | `--random-seed` | kGenProg 全体で用いる乱数のシード値 | 0 |
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ $ java -jar path/to/kGenProg.jar
 $ java -jar path/to/kGenProg.jar --config <path>
 $ java -jar path/to/kGenProg.jar -r <path> -s <path>... -t <path>... [-x <fqn>...] [-c <path>...]
     [-w <path>] [-o <path>] [-v | -q] [--siblings-count <num>] [--headcount <num>]
-    [--max-generation <num>] [--time-limit <sec>] [--required-solutions <num>] [--random-seed <num>]
+    [--max-generation <num>] [--time-limit <sec>] [--test-time-limit <sec>]
+    [--required-solutions <num>] [--random-seed <num>]
     
 ```
 
@@ -65,6 +66,7 @@ $ java -jar path/to/kGenProg.jar
 | `--headcount` | 遺伝的アルゴリズムの選択操作によって1世代に残される個体の最大数 | 100 |
 | `--max-generation` | 遺伝的アルゴリズムを打ち切る世代数 | 10 |
 | `--time-limit` | 遺伝的アルゴリズムを打ち切る時間（秒） | 60 |
+| `--test-time-limit` | 各個体のビルドおよびテストを打ち切る時間（秒） | 10 |
 | `--required-solutions` | 出力する解（修正パッチ）の数 | 1 |
 | `--random-seed` | kGenProg 全体で用いる乱数のシード値 | 0 |
 

--- a/build.gradle
+++ b/build.gradle
@@ -80,4 +80,6 @@ dependencies {
 
     // https://mvnrepository.com/artifact/com.google.guava/guava
     compile group: 'com.google.guava', name: 'guava', version: '26.0-jre'
+
+    compile 'com.electronwill.night-config:toml:3.4.0'
 }

--- a/example/BuildSuccess08/kgenprog.toml
+++ b/example/BuildSuccess08/kgenprog.toml
@@ -1,0 +1,4 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+

--- a/example/BuildSuccess08/withClassPath.toml
+++ b/example/BuildSuccess08/withClassPath.toml
@@ -1,0 +1,5 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+cp = ["lib/"]
+

--- a/example/BuildSuccess08/withExecTests.toml
+++ b/example/BuildSuccess08/withExecTests.toml
@@ -1,0 +1,5 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+exec-test = ["example.FooTest", "example.BarTest"]
+

--- a/example/BuildSuccess08/withHeadCount.toml
+++ b/example/BuildSuccess08/withHeadCount.toml
@@ -1,0 +1,5 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+headcount = 50
+

--- a/example/BuildSuccess08/withLogLevel.toml
+++ b/example/BuildSuccess08/withLogLevel.toml
@@ -1,0 +1,5 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+log-level = "DEBUG"
+

--- a/example/BuildSuccess08/withMaxGeneration.toml
+++ b/example/BuildSuccess08/withMaxGeneration.toml
@@ -1,0 +1,5 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+max-generation = 50
+

--- a/example/BuildSuccess08/withOutDir.toml
+++ b/example/BuildSuccess08/withOutDir.toml
@@ -1,0 +1,5 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+out-dir = "./out/"
+

--- a/example/BuildSuccess08/withRandomSeed.toml
+++ b/example/BuildSuccess08/withRandomSeed.toml
@@ -1,0 +1,4 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+random-seed = 50

--- a/example/BuildSuccess08/withRequiredSolutionsCount.toml
+++ b/example/BuildSuccess08/withRequiredSolutionsCount.toml
@@ -1,0 +1,5 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+required-solutions = 50
+

--- a/example/BuildSuccess08/withSiblingsCount.toml
+++ b/example/BuildSuccess08/withSiblingsCount.toml
@@ -1,0 +1,5 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+siblings-count = 50
+

--- a/example/BuildSuccess08/withTestTimeLimit.toml
+++ b/example/BuildSuccess08/withTestTimeLimit.toml
@@ -1,0 +1,5 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+test-time-limit = 50
+

--- a/example/BuildSuccess08/withTimeLimit.toml
+++ b/example/BuildSuccess08/withTimeLimit.toml
@@ -1,0 +1,5 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+time-limit = 50
+

--- a/example/BuildSuccess08/withWorkingDir.toml
+++ b/example/BuildSuccess08/withWorkingDir.toml
@@ -1,0 +1,5 @@
+root-dir = "./"
+src = ["src/"]
+test = ["test/"]
+working-dir = "./work/"
+

--- a/example/CloseToZero01/kgenprog.toml
+++ b/example/CloseToZero01/kgenprog.toml
@@ -1,0 +1,4 @@
+root-dir = "./"
+src = ["src/example/CloseToZero.java"]
+test = ["src/example/CloseToZeroTest.java"]
+

--- a/example/CloseToZero01/kgenprog.toml
+++ b/example/CloseToZero01/kgenprog.toml
@@ -31,7 +31,7 @@ test = ["src/example/CloseToZeroTest.java"]
 # Specifies how many variants are generated from a parent in a generation.
 #siblings-count = <num>
 
-# Specifies how many variants are survive in a generation.
+# Specifies how many variants survive in a generation.
 #headcount = <num>
 
 # Terminates searching solutions when the specified number of generations reached.
@@ -46,6 +46,6 @@ test = ["src/example/CloseToZeroTest.java"]
 # Terminates searching solutions when the specified number of solutions are found.
 #required-solutions = <num>
 
-# Specifies random seed used random number generator.
+# Specifies random seed used by random number generator.
 #random-seed = <num>
 

--- a/example/CloseToZero01/kgenprog.toml
+++ b/example/CloseToZero01/kgenprog.toml
@@ -1,4 +1,48 @@
+# Specifies the path to the root directory of the target project.
 root-dir = "./"
+
+# Specifies paths to "product" source code (i.e. main, non-test code),
+# or to directories containing them.
 src = ["src/example/CloseToZero.java"]
+
+# Specifies paths to test source code, or to directories containing them.
 test = ["src/example/CloseToZeroTest.java"]
+
+# Specifies class paths needed to build the target project.
+#cp = [<class-path>, ...]
+
+# Specifies fully qualified names of test classes executed during evaluation
+# of variants (i.e. fix-candidates).
+# By default, all tests are executed. It might take a terribly long time,
+# so we recommend you specify test classes detecting a bug.
+#exec-test = [<fqn>, ...]
+
+# Specifies the path to working directory. By default, a working directory is
+# created under system temporary directory (i.e. $TMPDIR on *nix, %TMP% on Windows)
+# every kGenProg execution.
+#working-dir = <path>
+
+# Writes patches kGenProg generated to the specified directory.
+#out-dir = <path>
+
+# Selects the log level to be shown at least.
+#log-level = ("OFF" | "ERROR" | "WARN" | "INFO" | "DEBUG" | "TRACE" | "ALL")
+
+# Specifies how many variants are generated from a parent in a generation.
+#siblings-count = <num>
+
+# Specifies how many variants are survive in a generation.
+#headcount = <num>
+
+# Terminates searching solutions when the specified number of generations reached.
+#max-generation = <num>
+
+# Terminates searching solutions when the specified time has passed.
+#time-limit = <sec>
+
+# Terminates searching solutions when the specified number of solutions are found.
+#required-solutions = <num>
+
+# Specifies random seed used random number generator.
+#random-seed = <num>
 

--- a/example/CloseToZero01/kgenprog.toml
+++ b/example/CloseToZero01/kgenprog.toml
@@ -40,6 +40,9 @@ test = ["src/example/CloseToZeroTest.java"]
 # Terminates searching solutions when the specified time has passed.
 #time-limit = <sec>
 
+# Specifies time limit to build and test for each variant in second
+#test-time-limit = <sec>
+
 # Terminates searching solutions when the specified number of solutions are found.
 #required-solutions = <num>
 

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -174,7 +174,7 @@ public class Configuration {
 
     @com.electronwill.nightconfig.core.conversion.Path("exec-test")
     @PreserveNotNull
-    private List<String> executionTests = new ArrayList<>();
+    private final List<String> executionTests = new ArrayList<>();
 
     private transient TargetProject targetProject;
 
@@ -425,7 +425,7 @@ public class Configuration {
       return builder.logLevel.equals(Level.ERROR);
     }
 
-    private static boolean needsParseConfigFile(String[] args) {
+    private static boolean needsParseConfigFile(final String[] args) {
       return args.length == 0 || Arrays.asList(args)
           .contains("--config");
     }
@@ -441,7 +441,7 @@ public class Configuration {
 
         log.debug("config = {}", config);
 
-        ObjectConverter converter = new ObjectConverter();
+        final ObjectConverter converter = new ObjectConverter();
         converter.toObject(config, this);
         resolvePaths();
       }
@@ -624,7 +624,7 @@ public class Configuration {
     private static class PathToString implements Converter<Path, String> {
 
       @Override
-      public Path convertToField(String value) {
+      public Path convertToField(final String value) {
         if (value == null) {
           return null;
         }
@@ -633,7 +633,7 @@ public class Configuration {
       }
 
       @Override
-      public String convertFromField(Path value) {
+      public String convertFromField(final Path value) {
         if (value == null) {
           return null;
         }
@@ -645,7 +645,7 @@ public class Configuration {
     private static class PathsToStrings implements Converter<List<Path>, List<String>> {
 
       @Override
-      public List<Path> convertToField(List<String> value) {
+      public List<Path> convertToField(final List<String> value) {
         if (value == null) {
           return null;
         }
@@ -656,7 +656,7 @@ public class Configuration {
       }
 
       @Override
-      public List<String> convertFromField(List<Path> value) {
+      public List<String> convertFromField(final List<Path> value) {
         if (value == null) {
           return null;
         }
@@ -670,7 +670,7 @@ public class Configuration {
     private static class LevelToString implements Converter<Level, String> {
 
       @Override
-      public Level convertToField(String value) {
+      public Level convertToField(final String value) {
         if (value == null) {
           return null;
         }
@@ -679,7 +679,7 @@ public class Configuration {
       }
 
       @Override
-      public String convertFromField(Level value) {
+      public String convertFromField(final Level value) {
         if (value == null) {
           return null;
         }
@@ -692,7 +692,7 @@ public class Configuration {
 
       // todo: make it possible to take minutes and hours etc.
       @Override
-      public Duration convertToField(Integer value) {
+      public Duration convertToField(final Integer value) {
         if (value == null) {
           return null;
         }
@@ -701,7 +701,7 @@ public class Configuration {
       }
 
       @Override
-      public Integer convertFromField(Duration value) {
+      public Integer convertFromField(final Duration value) {
         if (value == null) {
           return null;
         }

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -543,7 +543,7 @@ public class Configuration {
       this.outDir = Paths.get(outDir);
     }
 
-    @Option(name = "-i", aliases = "--siblings-count",
+    @Option(name = "--siblings-count", metaVar = "<num>",
         usage = "The number of how many child variants are generated from a parent",
         depends = {"-r", "-s", "-t"})
     private void setSiblingsCountFromCmdLineParser(final int siblingsCount) {
@@ -551,7 +551,7 @@ public class Configuration {
       this.siblingsCount = siblingsCount;
     }
 
-    @Option(name = "-h", aliases = "--headcount",
+    @Option(name = "--headcount", metaVar = "<num>",
         usage = "The number of how many variants are generated maximally in a generation",
         depends = {"-r", "-s", "-t"})
     private void setHeadcountFromCmdLineParser(final int headcount) {
@@ -559,21 +559,21 @@ public class Configuration {
       this.headcount = headcount;
     }
 
-    @Option(name = "-g", aliases = "--max-generation", usage = "Maximum generation",
+    @Option(name = "--max-generation", metaVar = "<num>", usage = "Maximum generation",
         depends = {"-r", "-s", "-t"})
     private void setMaxGenerationFromCmdLineParser(final int maxGeneration) {
       log.debug("enter setMaxGenerationFromCmdLineParser(int)");
       this.maxGeneration = maxGeneration;
     }
 
-    @Option(name = "-l", aliases = "--time-limit", usage = "Time limit for repairing in second",
+    @Option(name = "--time-limit", metaVar = "<sec>", usage = "Time limit for repairing in second",
         depends = {"-r", "-s", "-t"})
     private void setTimeLimitFromCmdLineParser(final long timeLimit) {
       log.debug("enter setTimeLimitFromCmdLineParser(long)");
       this.timeLimit = Duration.ofSeconds(timeLimit);
     }
 
-    @Option(name = "--test-time-limit",
+    @Option(name = "--test-time-limit", metaVar = "<sec>",
         usage = "Time limit to build and test for each variant in second",
         depends = {"-r", "-s", "-t"})
     private void setTestTimeLimitFromCmdLineParser(final long testTimeLimit) {
@@ -581,7 +581,7 @@ public class Configuration {
       this.testTimeLimit = Duration.ofSeconds(testTimeLimit);
     }
 
-    @Option(name = "-e", aliases = "--required-solutions",
+    @Option(name = "--required-solutions", metaVar = "<num>",
         usage = "The number of solutions needed to be searched", depends = {"-r", "-s", "-t"})
     private void setRequiredSolutionsCountFromCmdLineParser(final int requiredSolutionsCount) {
       log.debug("enter setTimeLimitFromCmdLineParser(int)");
@@ -604,7 +604,7 @@ public class Configuration {
       logLevel = Level.ERROR;
     }
 
-    @Option(name = "-a", aliases = "--random-seed",
+    @Option(name = "--random-seed", metaVar = "<num>",
         usage = "The seed of a random seed generator used across this program",
         depends = {"-r", "-s", "-t"})
     private void setRandomSeedFromCmdLineParser(final long randomSeed) {

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -448,7 +448,7 @@ public class Configuration {
     }
 
     private void resolvePaths() {
-      final Path configDir = configPath.getParent();
+      final Path configDir = getParent(configPath, Paths.get("."));
 
       rootDir = configDir.resolve(rootDir)
           .normalize();
@@ -471,6 +471,10 @@ public class Configuration {
         outDir = configDir.resolve(outDir)
             .normalize();
       }
+    }
+
+    private Path getParent(final Path path, final Path defaultPath) {
+      return path.getParent() != null ? path.getParent() : defaultPath;
     }
 
     // endregion

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -150,60 +150,74 @@ public class Configuration {
 
     private Path configPath = Paths.get("kgenprog.toml");
 
+    @com.electronwill.nightconfig.core.conversion.Path("root-dir")
     @SpecNotNull
     @Conversion(PathToString.class)
     private Path rootDir;
 
+    @com.electronwill.nightconfig.core.conversion.Path("src")
     @SpecNotNull
     @Conversion(PathsToStrings.class)
     private List<Path> productPaths;
 
+    @com.electronwill.nightconfig.core.conversion.Path("test")
     @SpecNotNull
     @Conversion(PathsToStrings.class)
     private List<Path> testPaths;
 
+    @com.electronwill.nightconfig.core.conversion.Path("cp")
     @PreserveNotNull
     @Conversion(PathsToStrings.class)
     private List<Path> classPaths = new ArrayList<>();
 
+    @com.electronwill.nightconfig.core.conversion.Path("exec-test")
     @PreserveNotNull
     @Conversion(PathsToStrings.class)
     private List<String> executionTests = new ArrayList<>();
 
     private transient TargetProject targetProject;
 
+    @com.electronwill.nightconfig.core.conversion.Path("working-dir")
     @PreserveNotNull
     @Conversion(PathToString.class)
     private Path workingDir = DEFAULT_WORKING_DIR;
 
+    @com.electronwill.nightconfig.core.conversion.Path("out-dir")
     @PreserveNotNull
     @Conversion(PathToString.class)
     private Path outDir = DEFAULT_OUT_DIR;
 
+    @com.electronwill.nightconfig.core.conversion.Path("siblings-count")
     @PreserveNotNull
     private int siblingsCount = DEFAULT_SIBLINGS_COUNT;
 
     @PreserveNotNull
     private int headcount = DEFAULT_HEADCOUNT;
 
+    @com.electronwill.nightconfig.core.conversion.Path("max-generation")
     @PreserveNotNull
     private int maxGeneration = DEFAULT_MAX_GENERATION;
 
+    @com.electronwill.nightconfig.core.conversion.Path("time-limit")
     @PreserveNotNull
     @Conversion(DurationToInteger.class)
     private Duration timeLimit = DEFAULT_TIME_LIMIT;
 
+    @com.electronwill.nightconfig.core.conversion.Path("test-time-limit")
     @PreserveNotNull
     @Conversion(DurationToInteger.class)
     private Duration testTimeLimit = DEFAULT_TEST_TIME_LIMIT;
 
+    @com.electronwill.nightconfig.core.conversion.Path("required-solutions")
     @PreserveNotNull
     private int requiredSolutionsCount = DEFAULT_REQUIRED_SOLUTIONS_COUNT;
 
+    @com.electronwill.nightconfig.core.conversion.Path("log-level")
     @PreserveNotNull
     @Conversion(LevelToString.class)
     private Level logLevel = DEFAULT_LOG_LEVEL;
 
+    @com.electronwill.nightconfig.core.conversion.Path("random-seed")
     @PreserveNotNull
     private long randomSeed = DEFAULT_RANDOM_SEED;
 

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -149,6 +149,7 @@ public class Configuration {
 
     private static transient final Logger log = LoggerFactory.getLogger(Builder.class);
 
+    @PreserveNotNull
     private Path configPath = Paths.get("kgenprog.toml");
 
     @com.electronwill.nightconfig.core.conversion.Path("root-dir")
@@ -442,6 +443,33 @@ public class Configuration {
 
         ObjectConverter converter = new ObjectConverter();
         converter.toObject(config, this);
+        resolvePaths();
+      }
+    }
+
+    private void resolvePaths() {
+      final Path configDir = configPath.getParent();
+
+      rootDir = configDir.resolve(rootDir)
+          .normalize();
+      productPaths = productPaths.stream()
+          .map(p -> configDir.resolve(p)
+              .normalize())
+          .collect(Collectors.toList());
+      testPaths = testPaths.stream()
+          .map(p -> configDir.resolve(p)
+              .normalize())
+          .collect(Collectors.toList());
+      classPaths = classPaths.stream()
+          .map(p -> configDir.resolve(p)
+              .normalize())
+          .collect(Collectors.toList());
+      workingDir = configDir.resolve(workingDir)
+          .normalize();
+
+      if (!outDir.equals(DEFAULT_OUT_DIR)) {
+        outDir = configDir.resolve(outDir)
+            .normalize();
       }
     }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -172,7 +172,6 @@ public class Configuration {
 
     @com.electronwill.nightconfig.core.conversion.Path("exec-test")
     @PreserveNotNull
-    @Conversion(PathsToStrings.class)
     private List<String> executionTests = new ArrayList<>();
 
     private transient TargetProject targetProject;

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -2,6 +2,7 @@ package jp.kusumotolab.kgenprog;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -265,7 +266,7 @@ public class Configuration {
 
         validateArgument(builder);
       } catch (final CmdLineException | IllegalArgumentException | InvalidValueException
-          | IOException e) {
+          | NoSuchFileException e) {
         // todo: make error message of InvalidValueException more user-friendly
         log.error(e.getMessage());
         parser.printUsage(System.err);
@@ -428,9 +429,10 @@ public class Configuration {
           .contains("--config");
     }
 
-    private void parseConfigFile() throws InvalidValueException, IOException {
+    private void parseConfigFile() throws InvalidValueException, NoSuchFileException {
       if (Files.notExists(configPath)) {
-        throw new IOException("config file \"" + configPath.toString() + "\" is not found");
+        throw new NoSuchFileException("config file \"" + configPath.toAbsolutePath()
+            .toString() + "\" is not found.");
       }
 
       try (final FileConfig config = FileConfig.of(configPath)) {

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -481,7 +481,7 @@ public class Configuration {
 
     // region Methods for CmdLineParser
 
-    @Option(name = "--config", metaVar = "<path>", usage = "Path of a configuration file",
+    @Option(name = "--config", metaVar = "<path>", usage = "Specifies the path to the config file.",
         forbids = {"-r", "-s", "-t"})
     private void setConfigPathFromCmdLineParser(final String configPath) {
       log.debug("enter setConfigPathFromCmdLineParser(String)");
@@ -489,47 +489,49 @@ public class Configuration {
     }
 
     @Option(name = "-r", aliases = "--root-dir", metaVar = "<path>",
-        usage = "Path of a root directory of a target project",
+        usage = "Specifies the path to the root directory of the target project.",
         depends = {"-s", "-t"}, forbids = {"--config"})
     private void setRootDirFromCmdLineParser(final String rootDir) {
       log.debug("enter setRootDirFromCmdLineParser(String)");
       this.rootDir = Paths.get(rootDir);
     }
 
-    @Option(name = "-s", aliases = "--src", handler = StringArrayOptionHandler.class,
-        metaVar = "<path> ...", usage = "Paths of the root directories holding src codes",
-        depends = {"-r", "-t"}, forbids = {"--config"})
+    @Option(name = "-s", aliases = "--src", metaVar = "<path> ...",
+        usage = " Specifies paths to \"product\" source code (i.e. main, non-test code),"
+            + " or to directories containing them.",
+        depends = {"-r", "-t"}, forbids = {"--config"}, handler = StringArrayOptionHandler.class)
     private void addProductPathFromCmdLineParser(final String sourcePath) {
       log.debug("enter addProductPathFromCmdLineParser(String)");
       this.productPaths.add(Paths.get(sourcePath));
     }
 
-    @Option(name = "-t", aliases = "--test", handler = StringArrayOptionHandler.class,
-        metaVar = "<path> ...", usage = "Paths of the root directories holding test codes",
-        depends = {"-r", "-s"}, forbids = {"--config"})
+    @Option(name = "-t", aliases = "--test", metaVar = "<path> ...",
+        usage = "Specifies paths to test source code, or to directories containing them.",
+        depends = {"-r", "-s"}, forbids = {"--config"}, handler = StringArrayOptionHandler.class)
     private void addTestPathFromCmdLineParser(final String testPath) {
       log.debug("enter addTestPathFromCmdLineParser(String)");
       this.testPaths.add(Paths.get(testPath));
     }
 
-    @Option(name = "-c", aliases = "--cp", handler = StringArrayOptionHandler.class,
-        metaVar = "<class path> ...", usage = "Class paths required to build the target project",
-        depends = {"-r", "-s", "-t"})
+    @Option(name = "-c", aliases = "--cp", metaVar = "<class path> ...",
+        usage = "Specifies class paths needed to build the target project.",
+        depends = {"-r", "-s", "-t"}, handler = StringArrayOptionHandler.class)
     private void addClassPathFromCmdLineParser(final String classPath) {
       log.debug("enter addClassPathFromCmdLineParser(String)");
       this.classPaths.add(Paths.get(classPath));
     }
 
-    @Option(name = "-x", aliases = "--exec-test", handler = StringArrayOptionHandler.class,
-        metaVar = "<fqn> ...", usage = "Execution test cases.",
-        depends = {"-r", "-s", "-t"})
+    @Option(name = "-x", aliases = "--exec-test", metaVar = "<fqn> ...",
+        usage = "Specifies fully qualified names of test classes executed"
+            + " during evaluation of variants (i.e. fix-candidates).",
+        depends = {"-r", "-s", "-t"}, handler = StringArrayOptionHandler.class)
     private void addExecutionTestFromCmdLineParser(final String executionTest) {
       log.debug("enter addExecutionTestFromCmdLineParser(String)");
       this.executionTests.add(executionTest);
     }
 
     @Option(name = "-w", aliases = "--working-dir", metaVar = "<path>",
-        usage = "Path of a working directory",
+        usage = "Specifies the path to working directory.",
         depends = {"-r", "-s", "-t"})
     private void setWorkingDirFromCmdLineParser(final String workingDir) {
       log.debug("enter setWorkingDirFromCmdLineParser(String)");
@@ -537,14 +539,15 @@ public class Configuration {
     }
 
     @Option(name = "-o", aliases = "--out-dir", metaVar = "<path>",
-        usage = "Path of a output directory", depends = {"-r", "-s", "-t"})
+        usage = "Writes patches kGenProg generated to the specified directory.",
+        depends = {"-r", "-s", "-t"})
     private void setOutDirFromCmdLineParser(final String outDir) {
       log.debug("enter setOutDirFromCmdLineParser(String)");
       this.outDir = Paths.get(outDir);
     }
 
     @Option(name = "--siblings-count", metaVar = "<num>",
-        usage = "The number of how many child variants are generated from a parent",
+        usage = "Specifies how many variants are generated from a parent in a generation.",
         depends = {"-r", "-s", "-t"})
     private void setSiblingsCountFromCmdLineParser(final int siblingsCount) {
       log.debug("enter setSiblingsCountFromCmdLineParser(int)");
@@ -552,29 +555,32 @@ public class Configuration {
     }
 
     @Option(name = "--headcount", metaVar = "<num>",
-        usage = "The number of how many variants are generated maximally in a generation",
+        usage = "Specifies how many variants survive in a generation.",
         depends = {"-r", "-s", "-t"})
     private void setHeadcountFromCmdLineParser(final int headcount) {
       log.debug("enter setHeadcountFromCmdLineParser(int)");
       this.headcount = headcount;
     }
 
-    @Option(name = "--max-generation", metaVar = "<num>", usage = "Maximum generation",
+    @Option(name = "--max-generation", metaVar = "<num>",
+        usage = "Terminates searching solutions when the specified number of generations reached.",
         depends = {"-r", "-s", "-t"})
     private void setMaxGenerationFromCmdLineParser(final int maxGeneration) {
       log.debug("enter setMaxGenerationFromCmdLineParser(int)");
       this.maxGeneration = maxGeneration;
     }
 
-    @Option(name = "--time-limit", metaVar = "<sec>", usage = "Time limit for repairing in second",
+    @Option(name = "--time-limit", metaVar = "<sec>",
+        usage = "Terminates searching solutions when the specified time has passed.",
         depends = {"-r", "-s", "-t"})
     private void setTimeLimitFromCmdLineParser(final long timeLimit) {
       log.debug("enter setTimeLimitFromCmdLineParser(long)");
       this.timeLimit = Duration.ofSeconds(timeLimit);
     }
 
+    // todo update usage
     @Option(name = "--test-time-limit", metaVar = "<sec>",
-        usage = "Time limit to build and test for each variant in second",
+        usage = "Specifies time limit to build and test for each variant in second",
         depends = {"-r", "-s", "-t"})
     private void setTestTimeLimitFromCmdLineParser(final long testTimeLimit) {
       log.debug("enter setTestTimeLimitFromCmdLineParser(long)");
@@ -582,21 +588,22 @@ public class Configuration {
     }
 
     @Option(name = "--required-solutions", metaVar = "<num>",
-        usage = "The number of solutions needed to be searched", depends = {"-r", "-s", "-t"})
+        usage = "Terminates searching solutions when the specified number of solutions are found.",
+        depends = {"-r", "-s", "-t"})
     private void setRequiredSolutionsCountFromCmdLineParser(final int requiredSolutionsCount) {
       log.debug("enter setTimeLimitFromCmdLineParser(int)");
       this.requiredSolutionsCount = requiredSolutionsCount;
     }
 
-    @Option(name = "-v", aliases = "--verbose", usage = "Verbose mode. Print DEBUG level logs.",
-        depends = {"-r", "-s", "-t"})
+    @Option(name = "-v", aliases = "--verbose",
+        usage = "Be more verbose, printing DEBUG level logs.", depends = {"-r", "-s", "-t"})
     private void setLogLevelDebugFromCmdLineParser(final boolean isVerbose) {
       log.debug("enter setLogLevelDebugFromCmdLineParser(boolean)");
       log.debug("log level has been set DEBUG");
       logLevel = Level.DEBUG;
     }
 
-    @Option(name = "-q", aliases = "--quiet", usage = "Quiet mode. Print ERROR level logs.",
+    @Option(name = "-q", aliases = "--quiet", usage = "Be more quiet, suppressing non-ERROR logs.",
         depends = {"-r", "-s", "-t"})
     private void setLogLevelErrorFromCmdLineParser(final boolean isQuiet) {
       log.debug("enter setLogLevelErrorFromCmdLineParser(boolean)");
@@ -605,7 +612,7 @@ public class Configuration {
     }
 
     @Option(name = "--random-seed", metaVar = "<num>",
-        usage = "The seed of a random seed generator used across this program",
+        usage = "Specifies random seed used by random number generator.",
         depends = {"-r", "-s", "-t"})
     private void setRandomSeedFromCmdLineParser(final long randomSeed) {
       log.debug("enter setRandomSeedFromCmdLineParser(long)");

--- a/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
@@ -464,7 +464,7 @@ public class ConfigurationBuilderTest {
   public void testBuildFromCmdLineArgsWithSiblingsCount() {
     final int siblingsCount = 50;
     final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
-        testPath.toString(), "-i", Integer.toString(siblingsCount)};
+        testPath.toString(), "--siblings-count", Integer.toString(siblingsCount)};
     final Configuration config = Builder.buildFromCmdLineArgs(args);
 
     assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
@@ -493,7 +493,7 @@ public class ConfigurationBuilderTest {
   public void testBuildFromCmdLineArgsWithHeadcount() {
     final int headcount = 50;
     final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
-        testPath.toString(), "-h", Integer.toString(headcount)};
+        testPath.toString(), "--headcount", Integer.toString(headcount)};
     final Configuration config = Builder.buildFromCmdLineArgs(args);
 
     assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
@@ -522,7 +522,7 @@ public class ConfigurationBuilderTest {
   public void testBuildFromCmdLineArgsWithMaxGeneration() {
     final int maxGeneration = 50;
     final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
-        testPath.toString(), "-g", Integer.toString(maxGeneration)};
+        testPath.toString(), "--max-generation", Integer.toString(maxGeneration)};
     final Configuration config = Builder.buildFromCmdLineArgs(args);
 
     assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
@@ -551,7 +551,7 @@ public class ConfigurationBuilderTest {
   public void testBuildFromCmdLineArgsWithTimeLimit() {
     final Duration timeLimit = Duration.ofSeconds(1800);
     final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
-        testPath.toString(), "-l", Long.toString(timeLimit.getSeconds())};
+        testPath.toString(), "--time-limit", Long.toString(timeLimit.getSeconds())};
     final Configuration config = Builder.buildFromCmdLineArgs(args);
 
     assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
@@ -580,7 +580,7 @@ public class ConfigurationBuilderTest {
   public void testBuildFromCmdLineArgsWithRequiredSolutionsCount() {
     final int requiredSolutionsCount = 10;
     final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
-        testPath.toString(), "-e", Integer.toString(requiredSolutionsCount)};
+        testPath.toString(), "--required-solutions", Integer.toString(requiredSolutionsCount)};
     final Configuration config = Builder.buildFromCmdLineArgs(args);
 
     assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
@@ -693,7 +693,7 @@ public class ConfigurationBuilderTest {
   public void testBuildFromCmdLineArgsWithRandomSeed() {
     final long randomSeed = 10;
     final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
-        testPath.toString(), "-a", Long.toString(randomSeed)};
+        testPath.toString(), "--random-seed", Long.toString(randomSeed)};
     final Configuration config = Builder.buildFromCmdLineArgs(args);
 
     assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);

--- a/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
@@ -787,4 +787,399 @@ public class ConfigurationBuilderTest {
 
     System.setOut(printStream);
   }
+
+  @Test
+  public void testBuildFromConfigFile() {
+    final Path configPath = rootDir.resolve("kgenprog.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithWorkingDir() {
+    final Path configPath = rootDir.resolve("withWorkingDir.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    final Path workingDir = rootDir.resolve("work");
+    assertThat(config.getWorkingDir()).isEqualTo(workingDir);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithOutDir() {
+    final Path configPath = rootDir.resolve("withOutDir.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+
+    final Path outDir = rootDir.resolve("out");
+    assertThat(config.getOutDir()).isEqualTo(outDir);
+
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithSiblingsCount() {
+    final Path configPath = rootDir.resolve("withSiblingsCount.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+
+    final int siblingsCount = 50;
+    assertThat(config.getSiblingsCount()).isEqualTo(siblingsCount);
+
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithHeadCount() {
+    final Path configPath = rootDir.resolve("withHeadCount.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+
+    final int headCount = 50;
+    assertThat(config.getHeadcount()).isEqualTo(headCount);
+
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithMaxGeneration() {
+    final Path configPath = rootDir.resolve("withMaxGeneration.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+
+    final int maxGeneration = 50;
+    assertThat(config.getMaxGeneration()).isEqualTo(maxGeneration);
+
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithTimeLimit() {
+    final Path configPath = rootDir.resolve("withTimeLimit.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+
+    final long timeLimit = 50;
+    assertThat(config.getTimeLimit()).isEqualTo(Duration.ofSeconds(timeLimit));
+    assertThat(config.getTimeLimitSeconds()).isEqualTo(timeLimit);
+
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithTestTimeLimit() {
+    final Path configPath = rootDir.resolve("withTestTimeLimit.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+
+    final long testTimeLimit = 50;
+    assertThat(config.getTestTimeLimit()).isEqualTo(Duration.ofSeconds(testTimeLimit));
+    assertThat(config.getTestTimeLimitSeconds()).isEqualTo(testTimeLimit);
+
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithRequiredSolutionsCount() {
+    final Path configPath = rootDir.resolve("withRequiredSolutionsCount.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+
+    final int requiredSolutionsCount = 50;
+    assertThat(config.getRequiredSolutionsCount()).isEqualTo(requiredSolutionsCount);
+
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithLogLevel() {
+    final Path configPath = rootDir.resolve("withLogLevel.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+
+    final Level logLevel = Level.DEBUG;
+    assertThat(config.getLogLevel()).isEqualTo(logLevel);
+
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithClassPath() {
+    final Path configPath = rootDir.resolve("withClassPath.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final Path classPath = rootDir.resolve("lib");
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, ImmutableList.of(classPath),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithRandomSeed() {
+    final Path configPath = rootDir.resolve("withRandomSeed.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+
+    final int randomSeed = 50;
+    assertThat(config.getRandomSeed()).isEqualTo(randomSeed);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  @Test
+  public void testBuildFromConfigFileWithExecTests() {
+    final Path configPath = rootDir.resolve("withExecTests.toml");
+    final String[] args = {"--config", configPath.toString()};
+    final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
+
+    assertThat(config.getWorkingDir()).isEqualTo(Configuration.DEFAULT_WORKING_DIR);
+    assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
+    assertThat(config.getSiblingsCount()).isEqualTo(Configuration.DEFAULT_SIBLINGS_COUNT);
+    assertThat(config.getHeadcount()).isEqualTo(Configuration.DEFAULT_HEADCOUNT);
+    assertThat(config.getMaxGeneration()).isEqualTo(Configuration.DEFAULT_MAX_GENERATION);
+    assertThat(config.getTimeLimit()).isEqualTo(Configuration.DEFAULT_TIME_LIMIT);
+    assertThat(config.getTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TIME_LIMIT.getSeconds());
+    assertThat(config.getTestTimeLimit()).isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT);
+    assertThat(config.getTestTimeLimitSeconds())
+        .isEqualTo(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    assertThat(config.getRequiredSolutionsCount())
+        .isEqualTo(Configuration.DEFAULT_REQUIRED_SOLUTIONS_COUNT);
+    assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
+    assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
+
+    final String executionTest1 = "example.FooTest";
+    final String executionTest2 = "example.BarTest";
+    assertThat(config.getExecutedTests()).containsExactlyInAnyOrder(executionTest1, executionTest2);
+
+    final TargetProject expectedProject =
+        TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
+            JUnitVersion.JUNIT4);
+    assertThat(config.getTargetProject()).isEqualTo(expectedProject);
+  }
+
+  // todo: 引数がなかった場合の挙動を確かめるために，カレントディレクトリを変更した上でテスト実行
 }


### PR DESCRIPTION
resolve #26 

### やったこと
- 設定ファイル読み込み処理の実装
- これにともない，`-r`, `-s`, `-t` をオプショナルにした
- オプションが何も指定されなければ，カレントディレクトリの `kgenprog.toml` を読み込むようにした
  - この場合のテストは書けていません
  - テスト実行時にカレントディレクトリを変更する方法が分からなかったため
- 雑多な修正
  - 覚えづらい短縮オプションの削除（`-i`, `-a` 等）
  - `metaVar` （usage で表示されるオプションの引数を表す `<path>` 等の文字列）がいくつかのオプションに設定されていなかったので，それらを追加
  - usage メッセージを変更