### PR TITLE
CrossOver する際にどちらの遺伝子も最低一つを含めるよう修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/SinglePointCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/SinglePointCrossover.java
@@ -55,6 +55,9 @@ public class SinglePointCrossover implements Crossover {
     final Gene geneB = variantB.getGene();
     final List<Base> basesA = geneA.getBases();
     final List<Base> basesB = geneB.getBases();
+    if (!canMakeVariant(basesA, basesB)) {
+      return Collections.emptyList();
+    }
     final int index = getPointAtRandom(basesA.size(), basesB.size());
     final Gene newGeneA = makeGene(basesA.subList(0, index), basesB.subList(index, basesB.size()));
     final Gene newGeneB = makeGene(basesB.subList(0, index), basesA.subList(index, basesA.size()));
@@ -64,14 +67,16 @@ public class SinglePointCrossover implements Crossover {
         store.createVariant(newGeneB, elementB));
   }
 
-  private int getPointAtRandom(int a, int b) {
-    final int min = Math.min(a, b);
-    if (min <= 2) {
-      return random.nextInt(min);
-    }
+  private boolean canMakeVariant(final List<Base> basesA, final List<Base> basesB) {
+    final int sizeA = basesA.size();
+    final int sizeB = basesB.size();
+    return Math.min(sizeA, sizeB) > 2;
+  }
 
+  private int getPointAtRandom(final int a, final int b) {
     // random.nextInt(a) は 0 ~ a の間の値をランダムで出力するので、
     // 0 を避けるために 1 足している
+    final int min = Math.min(a, b);
     return random.nextInt(min - 2) + 1;
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/SinglePointCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/SinglePointCrossover.java
@@ -55,13 +55,24 @@ public class SinglePointCrossover implements Crossover {
     final Gene geneB = variantB.getGene();
     final List<Base> basesA = geneA.getBases();
     final List<Base> basesB = geneB.getBases();
-    final int index = random.nextInt(Math.min(basesA.size(), basesB.size()));
+    final int index = getPointAtRandom(basesA.size(), basesB.size());
     final Gene newGeneA = makeGene(basesA.subList(0, index), basesB.subList(index, basesB.size()));
     final Gene newGeneB = makeGene(basesB.subList(0, index), basesA.subList(index, basesA.size()));
     final HistoricalElement elementA = new CrossoverHistoricalElement(variantA, variantB, index);
     final HistoricalElement elementB = new CrossoverHistoricalElement(variantB, variantA, index);
     return Arrays.asList(store.createVariant(newGeneA, elementA),
         store.createVariant(newGeneB, elementB));
+  }
+
+  private int getPointAtRandom(int a, int b) {
+    final int min = Math.min(a, b);
+    if (min <= 2) {
+      return random.nextInt(min);
+    }
+
+    // random.nextInt(a) は 0 ~ a の間の値をランダムで出力するので、
+    // 0 を避けるために 1 足している
+    return random.nextInt(min - 2) + 1;
   }
 
   private Gene makeGene(final List<Base> basesA, final List<Base> basesB) {

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/SinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/SinglePointCrossoverTest.java
@@ -56,7 +56,7 @@ public class SinglePointCrossoverTest {
     assertThat(element).isInstanceOf(CrossoverHistoricalElement.class);
     final CrossoverHistoricalElement cElement = (CrossoverHistoricalElement) element;
     assertThat(cElement.getParents()).containsExactly(insertOperationVariant, noneOperationVariant);
-    assertThat(cElement.getCrossoverPoint()).isEqualTo(3);
+    assertThat(cElement.getCrossoverPoint()).isEqualTo(1);
 
     final List<Gene> genes = variants.stream()
         .map(Variant::getGene)


### PR DESCRIPTION
close #350 

## 問題点
CrossOver する際に親と同じ遺伝子を持つ Variant が出力されてしまう。

## 修正内容
二つの base 列のサイズの小さい方の値が min の時、
1 ~ min-2 の間で CrossOver するよう修正した。
(ただし、min が 2 以下 なら、0 ~ min の間で CrossOver する)