### PR TITLE
SourceCodeValidation#exec の引数変更

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/Strategies.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Strategies.java
@@ -52,9 +52,9 @@ public class Strategies {
     return testExecutor.exec(generatedSourceCode);
   }
 
-  public Fitness execSourceCodeValidation(final VariantStore variantStore,
+  public Fitness execSourceCodeValidation(final GeneratedSourceCode sourceCode,
       final TestResults testResults) {
-    return sourceCodeValidation.exec(variantStore, testResults);
+    return sourceCodeValidation.exec(sourceCode, testResults);
   }
 
   public GeneratedSourceCode execASTConstruction(final TargetProject targetProject) {

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/DefaultCodeValidation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/DefaultCodeValidation.java
@@ -2,6 +2,7 @@ package jp.kusumotolab.kgenprog.ga;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 public class DefaultCodeValidation implements SourceCodeValidation {
@@ -9,7 +10,7 @@ public class DefaultCodeValidation implements SourceCodeValidation {
   private static Logger log = LoggerFactory.getLogger(DefaultCodeValidation.class);
 
   @Override
-  public Fitness exec(final VariantStore variantStore, final TestResults testResults) {
+  public Fitness exec(final GeneratedSourceCode sourceCode, final TestResults testResults) {
     log.debug("enter exec(Variant, TargetProject, TestProcessBuilder)");
     return new SimpleFitness(testResults.getSuccessRate());
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/SourceCodeValidation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/SourceCodeValidation.java
@@ -1,8 +1,9 @@
 package jp.kusumotolab.kgenprog.ga;
 
+import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 public interface SourceCodeValidation {
 
-  public Fitness exec(VariantStore variantStore, TestResults testResults);
+  Fitness exec(GeneratedSourceCode sourceCode, TestResults testResults);
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/VariantStore.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/VariantStore.java
@@ -90,9 +90,8 @@ public class VariantStore {
   /**
    * 引数の要素すべてを次世代のVariantとして追加する
    *
-   * @see addNextGenerationVariant(Variant)
-   *
    * @param variants 追加対象
+   * @see addNextGenerationVariant(Variant)
    */
   public void addGeneratedVariants(final Variant... variants) {
     addGeneratedVariants(Arrays.asList(variants));
@@ -101,9 +100,8 @@ public class VariantStore {
   /**
    * リストの要素すべてを次世代のVariantとして追加する
    *
-   * @see addNextGenerationVariant(Variant)
-   *
    * @param variants 追加対象
+   * @see addNextGenerationVariant(Variant)
    */
   public void addGeneratedVariants(final Collection<? extends Variant> variants) {
     variants.forEach(this::addGeneratedVariant);
@@ -154,7 +152,7 @@ public class VariantStore {
   private Variant createVariant(final Gene gene, final GeneratedSourceCode sourceCode,
       final HistoricalElement element) {
     final TestResults testResults = strategies.execTestExecutor(sourceCode);
-    final Fitness fitness = strategies.execSourceCodeValidation(this, testResults);
+    final Fitness fitness = strategies.execSourceCodeValidation(sourceCode, testResults);
     final List<Suspiciousness> suspiciousnesses =
         strategies.execFaultLocalization(sourceCode, testResults);
     return new Variant(generation.get(), gene, sourceCode, testResults, fitness, suspiciousnesses,


### PR DESCRIPTION
resolve #361 

`SourceCodeValidation#exec` の第1引数を `VariantStore` -> `GeneratedSourceCode` に変更