### PR TITLE
テストクラスへのTimeout フィールド追加処理を実装

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/VariantStore.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/VariantStore.java
@@ -9,7 +9,9 @@ import jp.kusumotolab.kgenprog.OrdinalNumber;
 import jp.kusumotolab.kgenprog.Strategies;
 import jp.kusumotolab.kgenprog.fl.Suspiciousness;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.project.Operation;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
+import jp.kusumotolab.kgenprog.project.jdt.InsertTimeoutRuleFieldOperation;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 public class VariantStore {
@@ -136,7 +138,9 @@ public class VariantStore {
 
   private Variant createInitialVariant() {
     final GeneratedSourceCode sourceCode = strategies.execASTConstruction(targetProject);
-    return createVariant(new Gene(Collections.emptyList()), sourceCode,
+    final Operation operation = new InsertTimeoutRuleFieldOperation(10);
+    final GeneratedSourceCode appliedSourceCode = operation.apply(sourceCode, null);
+    return createVariant(new Gene(Collections.emptyList()), appliedSourceCode,
         new OriginalHistoricalElement());
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/ASTStream.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/ASTStream.java
@@ -1,0 +1,559 @@
+package jp.kusumotolab.kgenprog.project.jdt;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.eclipse.jdt.core.dom.*;
+
+public class ASTStream extends ASTVisitor implements Iterator<ASTNode> {
+
+  public static Iterator<ASTNode> iterator(final ASTNode node) {
+    return new ASTStream(node);
+  }
+
+  public static Stream<ASTNode> stream(final ASTNode node) {
+    final Spliterator<ASTNode> spliterator =
+        Spliterators.spliteratorUnknownSize(iterator(node), Spliterator.NONNULL);
+    return StreamSupport.stream(spliterator, false);
+  }
+
+  private final Deque<ASTNode> globalStack;
+  private final Deque<ASTNode> stepStack;
+  private boolean alreadyConsumed;
+
+  public ASTStream(final ASTNode node) {
+    globalStack = new ArrayDeque<>();
+    stepStack = new ArrayDeque<>();
+
+    globalStack.push(node);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return !globalStack.isEmpty();
+  }
+
+  @Override
+  public ASTNode next() {
+    final ASTNode node = globalStack.pop();
+
+    alreadyConsumed = false;
+    node.accept(this);
+
+    while (!stepStack.isEmpty()) {
+      globalStack.push(stepStack.pop());
+    }
+
+    return node;
+  }
+
+  private boolean consume(final ASTNode node) {
+    if (alreadyConsumed) {
+      stepStack.push(node);
+      return false;
+    }
+    alreadyConsumed = true;
+    return true;
+  }
+
+  @Override
+  public boolean visit(final AnnotationTypeDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final AnnotationTypeMemberDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final AnonymousClassDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ArrayAccess node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ArrayCreation node) {
+
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ArrayInitializer node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ArrayType node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final AssertStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final Assignment node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final Block node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final BlockComment node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final BooleanLiteral node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final BreakStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final CastExpression node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final CatchClause node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final CharacterLiteral node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ClassInstanceCreation node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final CompilationUnit node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ConditionalExpression node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ConstructorInvocation node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ContinueStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final CreationReference node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final Dimension node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final DoStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final EmptyStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final EnhancedForStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final EnumConstantDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final EnumDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ExportsDirective node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ExpressionMethodReference node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ExpressionStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final FieldAccess node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final FieldDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ForStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final IfStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ImportDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final InfixExpression node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final Initializer node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final InstanceofExpression node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final IntersectionType node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final Javadoc node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final LabeledStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final LambdaExpression node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final LineComment node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final MarkerAnnotation node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final MemberRef node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final MemberValuePair node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final MethodRef node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final MethodRefParameter node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final MethodDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final MethodInvocation node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final Modifier node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ModuleDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ModuleModifier node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final NameQualifiedType node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final NormalAnnotation node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final NullLiteral node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final NumberLiteral node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final OpensDirective node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final PackageDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ParameterizedType node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ParenthesizedExpression node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final PostfixExpression node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final PrefixExpression node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ProvidesDirective node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final PrimitiveType node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final QualifiedName node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final QualifiedType node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final RequiresDirective node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ReturnStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final SimpleName node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final SimpleType node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final SingleMemberAnnotation node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final SingleVariableDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final StringLiteral node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final SuperConstructorInvocation node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final SuperFieldAccess node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final SuperMethodInvocation node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final SuperMethodReference node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final SwitchCase node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final SwitchStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final SynchronizedStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final TagElement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final TextElement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ThisExpression node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final ThrowStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final TryStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final TypeDeclaration node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final TypeDeclarationStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final TypeLiteral node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final TypeMethodReference node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final TypeParameter node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final UnionType node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final UsesDirective node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final VariableDeclarationExpression node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final VariableDeclarationStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final VariableDeclarationFragment node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final WhileStatement node) {
+    return consume(node);
+  }
+
+  @Override
+  public boolean visit(final WildcardType node) {
+    return consume(node);
+  }
+
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperation.java
@@ -1,0 +1,140 @@
+package jp.kusumotolab.kgenprog.project.jdt;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.text.edits.MalformedTreeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import jp.kusumotolab.kgenprog.project.ASTLocation;
+import jp.kusumotolab.kgenprog.project.GeneratedAST;
+import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.project.Operation;
+import jp.kusumotolab.kgenprog.project.TestSourcePath;
+
+
+public class InsertTimeoutRuleFieldOperation implements Operation {
+
+  private static final Logger log = LoggerFactory.getLogger(InsertTimeoutRuleFieldOperation.class);
+
+  private static final String INSERT_FIELD_NAME = "globalTimeout";
+  private final int timeoutSeconds;
+
+  public InsertTimeoutRuleFieldOperation(final int timeoutSeconds) {
+    this.timeoutSeconds = timeoutSeconds;
+  }
+
+  @Override
+  public GeneratedSourceCode apply(final GeneratedSourceCode generatedSourceCode,
+      final ASTLocation location) {
+
+    try {
+      final List<GeneratedAST<TestSourcePath>> newTestAsts = generatedSourceCode.getTestAsts()
+          .stream()
+          .map(ast -> applyEachAST(ast))
+          .collect(Collectors.toList());
+      return new GeneratedSourceCode(generatedSourceCode.getProductAsts(), newTestAsts);
+    } catch (final Exception e) {
+      log.warn("Inserting timeout rule is failed: {}", e.getMessage());
+      log.trace("Trace:", e);
+      return generatedSourceCode;
+    }
+  }
+
+  private GeneratedAST<TestSourcePath> applyEachAST(final GeneratedAST<TestSourcePath> ast) {
+    final GeneratedJDTAST<TestSourcePath> jdtast = (GeneratedJDTAST<TestSourcePath>) ast;
+    final ASTRewrite astRewrite = ASTRewrite.create(jdtast.getRoot()
+        .getAST());
+
+    ASTStream.stream(jdtast.getRoot())
+        .filter(TypeDeclaration.class::isInstance)
+        .map(TypeDeclaration.class::cast)
+        .forEach(d -> insertField(astRewrite, d));
+
+    final Document document = new Document(jdtast.getSourceCode());
+    try {
+      astRewrite.rewriteAST(document, null)
+          .apply(document);
+    } catch (MalformedTreeException | BadLocationException e) {
+      throw new RuntimeException(e);
+    }
+
+    return jdtast.getConstruction()
+        .constructAST(ast.getSourcePath(), document.get());
+  }
+
+  /**
+   * クラスにフィールドを追加する
+   *
+   * @param astRewrite ASTRewrite
+   * @param target 追加対象
+   */
+  private void insertField(final ASTRewrite astRewrite, final TypeDeclaration target) {
+    final String fieldName = createFieldName(target);
+
+    final ListRewrite listRewrite =
+        astRewrite.getListRewrite(target, TypeDeclaration.BODY_DECLARATIONS_PROPERTY);
+
+    final ASTNode astNode = ASTNode.copySubtree(astRewrite.getAST(), createInsertField(fieldName));
+    listRewrite.insertFirst(astNode, null);
+  }
+
+
+  /**
+   * 重複しない変数名を生成する
+   *
+   * @param typeDeclaration 重複チェックをするクラス
+   * @return 生成された変数名
+   */
+  @SuppressWarnings("unchecked")
+  private String createFieldName(final TypeDeclaration typeDeclaration) {
+    final FieldDeclaration[] fields = typeDeclaration.getFields();
+    final Set<String> fieldNames = Arrays.stream(fields)
+        .flatMap(f -> ((List<VariableDeclarationFragment>) (f.fragments())).stream())
+        .map(VariableDeclarationFragment::getName)
+        .map(SimpleName::getIdentifier)
+        .collect(Collectors.toSet());
+
+    String insertFieldName = INSERT_FIELD_NAME;
+    while (fieldNames.contains(insertFieldName)) {
+      insertFieldName = "_" + insertFieldName;
+    }
+
+    return insertFieldName;
+  }
+
+  /**
+   * 挿入対象のFieldDeclarationを生成する
+   *
+   * @param fieldName 生成するフィールドの変数名
+   * @return 生成されたFieldDeclaration
+   */
+  private FieldDeclaration createInsertField(final String fieldName) {
+    final char[] insertSourceCode = new StringBuilder().append("")
+        .append("@org.junit.Rule\n")
+        .append("public final org.junit.rules.Timeout ")
+        .append(fieldName)
+        .append(" = org.junit.rules.Timeout.seconds(")
+        .append(timeoutSeconds)
+        .append(");")
+        .toString()
+        .toCharArray();
+
+    final ASTParser parser = JDTASTConstruction.createNewParser();
+    parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
+    parser.setSource(insertSourceCode);
+    final TypeDeclaration typeDeclaration = (TypeDeclaration) parser.createAST(null);
+    return typeDeclaration.getFields()[0];
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTConstruction.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTConstruction.java
@@ -86,7 +86,7 @@ public class JDTASTConstruction {
     return new GeneratedJDTAST<>(this, sourcePath, (CompilationUnit) parser.createAST(null), data);
   }
 
-  private ASTParser createNewParser() {
+  public static ASTParser createNewParser() {
     final ASTParser parser = ASTParser.newParser(AST.JLS10);
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/ASTStreamTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/ASTStreamTest.java
@@ -1,0 +1,40 @@
+package jp.kusumotolab.kgenprog.project.jdt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.junit.Test;
+import jp.kusumotolab.kgenprog.project.ProductSourcePath;
+
+
+public class ASTStreamTest {
+
+  @Test
+  public void test() {
+    final String source = new StringBuilder().append("")
+        .append("class A {\n")
+        .append("  public int a() {\n")
+        .append("    int v;\n")
+        .append("    return v + 1;\n")
+        .append("  }\n")
+        .append("}")
+        .toString();
+
+    final ProductSourcePath sourcePath = new ProductSourcePath(Paths.get("A.java"));
+    final JDTASTConstruction constructor = new JDTASTConstruction();
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source);
+
+    final List<ASTNode> actual = ASTStream.stream(ast.getRoot())
+        .collect(Collectors.toList());
+
+    assertThat(actual).extracting(e -> e.getClass()
+        .getSimpleName())
+        .containsExactly("CompilationUnit", "TypeDeclaration", "SimpleName", "MethodDeclaration",
+            "Modifier", "PrimitiveType", "SimpleName", "Block", "VariableDeclarationStatement",
+            "PrimitiveType", "VariableDeclarationFragment", "SimpleName", "ReturnStatement",
+            "InfixExpression", "SimpleName", "NumberLiteral");;
+  }
+
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperationTest.java
@@ -1,0 +1,83 @@
+package jp.kusumotolab.kgenprog.project.jdt;
+
+import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
+import java.nio.file.Paths;
+import java.util.Collections;
+import org.junit.Test;
+import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.project.TestSourcePath;
+
+
+public class InsertTimeoutRuleFieldOperationTest {
+
+  @Test
+  public void testInsert() {
+    final String source = new StringBuilder().append("")
+        .append("class A {")
+        .append("  public void a() {")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    final TestSourcePath sourcePath = new TestSourcePath(Paths.get("A.java"));
+    final JDTASTConstruction constructor = new JDTASTConstruction();
+    final GeneratedJDTAST<TestSourcePath> ast = constructor.constructAST(sourcePath, source);
+    final GeneratedSourceCode sourceCode =
+        new GeneratedSourceCode(Collections.emptyList(), Collections.singletonList(ast));
+    final InsertTimeoutRuleFieldOperation operation = new InsertTimeoutRuleFieldOperation(10);
+    final GeneratedSourceCode applyiedSourceCode = operation.apply(sourceCode, null);
+
+    final String expected = new StringBuilder().append("")
+        .append("class A {")
+        .append("  @org.junit.Rule")
+        .append(
+            "  public final org.junit.rules.Timeout globalTimeout = org.junit.rules.Timeout.seconds(10);")
+        .append("  public void a() {")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    final GeneratedJDTAST<TestSourcePath> newAST =
+        (GeneratedJDTAST<TestSourcePath>) applyiedSourceCode.getTestAsts()
+            .get(0);
+
+    assertThat(newAST.getRoot()).isSameSourceCodeAs(expected);
+  }
+
+  @Test
+  public void testInsertDuplicateName() {
+    final String source = new StringBuilder().append("")
+        .append("class A {")
+        .append("  private int globalTimeout;")
+        .append("  public void a() {")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    final TestSourcePath sourcePath = new TestSourcePath(Paths.get("A.java"));
+    final JDTASTConstruction constructor = new JDTASTConstruction();
+    final GeneratedJDTAST<TestSourcePath> ast = constructor.constructAST(sourcePath, source);
+    final GeneratedSourceCode sourceCode =
+        new GeneratedSourceCode(Collections.emptyList(), Collections.singletonList(ast));
+    final InsertTimeoutRuleFieldOperation operation = new InsertTimeoutRuleFieldOperation(10);
+    final GeneratedSourceCode applyiedSourceCode = operation.apply(sourceCode, null);
+
+    final String expected = new StringBuilder().append("")
+        .append("class A {")
+        .append("  @org.junit.Rule")
+        .append(
+            "  public final org.junit.rules.Timeout _globalTimeout = org.junit.rules.Timeout.seconds(10);")
+        .append("  private int globalTimeout;")
+        .append("  public void a() {")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    final GeneratedJDTAST<TestSourcePath> newAST =
+        (GeneratedJDTAST<TestSourcePath>) applyiedSourceCode.getTestAsts()
+            .get(0);
+
+    assertThat(newAST.getRoot()).isSameSourceCodeAs(expected);
+  }
+
+}


### PR DESCRIPTION
resolve #372 

テストクラスにTimeoutを設定するフィールドを追加する処理を、initialVariant生成時に追加
ソースコードが変更されていることは確認したが、実際にTimeoutされるかは確認していない

Timeout時間がハードコードなのでConfigに吸い出す必要あり