### PR TITLE
サンプル設定ファイルに log-level オプションの説明を追加

### DIFF
--- a/example/CloseToZero01/kgenprog.toml
+++ b/example/CloseToZero01/kgenprog.toml
@@ -26,6 +26,7 @@ test = ["src/example/CloseToZeroTest.java"]
 #out-dir = <path>
 
 # Selects the log level to be shown at least.
+# Acceptable values are "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", or "ALL"
 log-level = "TRACE"
 
 # Specifies how many variants are generated in a generation by a mutation.


### PR DESCRIPTION
`log-level` オプションの説明に有効な値が何かを明記