### PR TITLE
Nightly Build リリース機能を追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-java/ for more details
 #
-version: 2
+version: 2.1
 
 orbs:
   github-release: h-matsuo/github-release@0.1.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,10 @@
 # Check https://circleci.com/docs/2.0/language-java/ for more details
 #
 version: 2
+
+orbs:
+  github-release: h-matsuo/github-release@0.1.3
+
 jobs:
 
   # Execute `gradle test`
@@ -58,6 +62,69 @@ jobs:
       - store_artifacts:
           path: ~/junit
 
+  # Execute `build gradle`
+  build:
+    docker:
+      - image: circleci/openjdk:8-jdk
+    steps:
+      # ===== Same as `test` job
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.gradle" }}
+          - v1-dependencies-
+      - run: gradle dependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle" }}
+      # ===== Test and build a jar file
+      - run: gradle build
+      # ===== Save the built jar file
+      - run:
+          name: Collect artifacts to be released
+          command: |
+            mkdir artifacts
+            cp ./build/libs/kGenProg.jar ./artifacts/
+      - persist_to_workspace:
+          root: ./artifacts
+          paths:
+            - .
+
+  # Publish as a nightly-build release
+  publish-nightly-build:
+    executor: github-release/default
+    steps:
+      # ===== Initialize
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "34:c6:33:a2:0a:e1:13:74:4b:03:1c:3e:33:e3:3f:e0"
+      - run:
+          name: Set up git
+          command: |
+            git config push.default current
+              git config user.email "ci@circleci.com"
+              git config user.name "CircleCI"
+      - attach_workspace:
+          at: ./artifacts
+      # ===== Delete the existing nightly-build release
+      - github-release/delete:
+          tag: nightly-build
+      - run:
+          name: Delete existing nightly-build tag
+          command: git push origin :nightly-build
+      # ===== Publish a new nightly-build release
+      - github-release/create:
+          tag: nightly-build
+          target: master
+          title: Nightly Build
+          description: |
+            This is a nightly-build release, automatically generated with \`master\` branch.
+            Using following commit SHA: ${CIRCLE_SHA1}
+          file-path: ./artifacts/
+          pre-release: true
+
 workflows:
   version: 2
 
@@ -68,3 +135,14 @@ workflows:
           filters:
             branches:
               ignore: master
+
+  # Build a commit and publish as a nightly-build release only on master branch
+  nightly-build-and-release:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: master
+      - publish-nightly-build:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,9 @@
 #
 version: 2
 jobs:
-  build:
+
+  # Execute `gradle test`
+  test:
     docker:
       # specify the version you desire here
       - image: circleci/openjdk:8-jdk
@@ -56,3 +58,13 @@ jobs:
       - store_artifacts:
           path: ~/junit
 
+workflows:
+  version: 2
+
+  # Test a commit except on master branch
+  test-commit:
+    jobs:
+      - test:
+          filters:
+            branches:
+              ignore: master


### PR DESCRIPTION
See also #380, #435.
まずは Nightly Build のリリース機能だけ追加したものをプルリクします。

`master` ブランチにコミットされるたび，[Releases ページ](https://github.com/kusumotolab/kGenProg/releases/tag/nightly-build) に自動ビルドされた Jar が登録されます。
これにより，以下で常に最新版の Jar が降ってくるようになります：

```
curl -O https://github.com/kusumotolab/kGenProg/releases/download/nightly-build/kGenProg.jar
```

## このプルリクでの変更点

### Releases ページを更新する機能をモジュール化

CircleCI にデフォルトで GitHub Releases を操作する機能がありませんでしたので，モジュール化して自分のリポジトリに公開しました。

- [h-matsuo/github-release - CircleCI Orb Registry](https://circleci.com/orbs/registry/orb/h-matsuo/github-release)

CircleCI ではこのモジュールのことを [orb](https://circleci.com/docs/2.0/orb-intro/) と呼びます。
以下の部分で作成した orb をインクルードしています：

https://github.com/kusumotolab/kGenProg/blob/7af9acd6985c8c76d3bf3faf7f0b162b71a185c0/.circleci/config.yml#L7-L8

### ジョブを分けた

以下の 3 つのジョブを作成しています：

- `test`
    - `gradle test` を実行する
- `build`
    - `gradle build` を実行する
- `publish-nightly-build`
    - ビルドした成果物を GitHub Releases に nightly build として公開する

これらのジョブはそのまま実行されるのではなく，後述のワークフローから呼び出されて実行されます。

### ワークフローを追加した

上記のジョブを実行するためのワークフローを作成しました：

- `test-commit`
    - `test` ジョブを実行する
    - `master` ブランチ以外にプッシュされたときに実行
- `nightly-build-and-release`
    - `build` および `publish-nightly-build` ジョブを実行する
    - `master` ブランチにプッシュされたときにのみ実行