### PR TITLE
Ochiai以外のFL戦略を追加

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Ample.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Ample.java
@@ -30,7 +30,7 @@ public class Ample implements FaultLocalization {
           final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
           final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
           final long np = testResults.getNumberOfPassedTestsNotExecutingTheStatement(path, l);
-          final double value = Math.abs(ef / (ef + nf) - ep / (ep + np));
+          final double value = Math.abs(ef / (double)(ef + nf) - ep / (double)(ep + np));
           if (0d < value) {
             final Suspiciousness s = new Suspiciousness(l, value);
             suspiciousnesses.add(s);

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Ample.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Ample.java
@@ -1,0 +1,44 @@
+package jp.kusumotolab.kgenprog.fl;
+
+import java.util.ArrayList;
+import java.util.List;
+import jp.kusumotolab.kgenprog.project.ASTLocation;
+import jp.kusumotolab.kgenprog.project.ASTLocations;
+import jp.kusumotolab.kgenprog.project.GeneratedAST;
+import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.project.ProductSourcePath;
+import jp.kusumotolab.kgenprog.project.test.TestResults;
+
+public class Ample implements FaultLocalization {
+
+  @Override
+  public List<Suspiciousness> exec(final GeneratedSourceCode generatedSourceCode,
+      final TestResults testResults) {
+
+    final List<Suspiciousness> suspiciousnesses = new ArrayList<>();
+
+    for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
+      final ProductSourcePath path = ast.getSourcePath();
+      final int lastLineNumber = ast.getNumberOfLines();
+      final ASTLocations astLocations = ast.createLocations();
+
+      for (int line = 1; line <= lastLineNumber; line++) {
+        final List<ASTLocation> locations = astLocations.infer(line);
+        if (!locations.isEmpty()) {
+          final ASTLocation l = locations.get(locations.size() - 1);
+          final long ef = testResults.getNumberOfFailedTestsExecutingTheStatement(path, l);
+          final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
+          final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
+          final long np = testResults.getNumberOfPassedTestsNotExecutingTheStatement(path, l);
+          final double value = Math.abs(ef / (ef + nf) - ep / (ep + np));
+          if (0d < value) {
+            final Suspiciousness s = new Suspiciousness(l, value);
+            suspiciousnesses.add(s);
+          }
+        }
+      }
+    }
+
+    return suspiciousnesses;
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Jaccard.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Jaccard.java
@@ -29,7 +29,7 @@ public class Jaccard implements FaultLocalization {
           final long ef = testResults.getNumberOfFailedTestsExecutingTheStatement(path, l);
           final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
           final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
-          final double value = ef / (ef + nf + ep);
+          final double value = ef / (double)(ef + nf + ep);
           if (0d < value) {
             final Suspiciousness s = new Suspiciousness(l, value);
             suspiciousnesses.add(s);

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Jaccard.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Jaccard.java
@@ -1,0 +1,43 @@
+package jp.kusumotolab.kgenprog.fl;
+
+import java.util.ArrayList;
+import java.util.List;
+import jp.kusumotolab.kgenprog.project.ASTLocation;
+import jp.kusumotolab.kgenprog.project.ASTLocations;
+import jp.kusumotolab.kgenprog.project.GeneratedAST;
+import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.project.ProductSourcePath;
+import jp.kusumotolab.kgenprog.project.test.TestResults;
+
+public class Jaccard implements FaultLocalization {
+
+  @Override
+  public List<Suspiciousness> exec(final GeneratedSourceCode generatedSourceCode,
+      final TestResults testResults) {
+
+    final List<Suspiciousness> suspiciousnesses = new ArrayList<>();
+
+    for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
+      final ProductSourcePath path = ast.getSourcePath();
+      final int lastLineNumber = ast.getNumberOfLines();
+      final ASTLocations astLocations = ast.createLocations();
+
+      for (int line = 1; line <= lastLineNumber; line++) {
+        final List<ASTLocation> locations = astLocations.infer(line);
+        if (!locations.isEmpty()) {
+          final ASTLocation l = locations.get(locations.size() - 1);
+          final long ef = testResults.getNumberOfFailedTestsExecutingTheStatement(path, l);
+          final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
+          final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
+          final double value = ef / (ef + nf + ep);
+          if (0d < value) {
+            final Suspiciousness s = new Suspiciousness(l, value);
+            suspiciousnesses.add(s);
+          }
+        }
+      }
+    }
+
+    return suspiciousnesses;
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Tarantula.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Tarantula.java
@@ -30,7 +30,7 @@ public class Tarantula implements FaultLocalization {
           final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
           final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
           final long np = testResults.getNumberOfPassedTestsNotExecutingTheStatement(path, l);
-          final double value = (ef / (ef + nf)) / (ef / (ef + nf) + ep / (ep + np));
+          final double value = (ef / (double)(ef + nf)) / (ef / (double)(ef + nf) + ep / (double)(ep + np));
           if (0d < value) {
             final Suspiciousness s = new Suspiciousness(l, value);
             suspiciousnesses.add(s);

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Tarantula.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Tarantula.java
@@ -1,0 +1,44 @@
+package jp.kusumotolab.kgenprog.fl;
+
+import java.util.ArrayList;
+import java.util.List;
+import jp.kusumotolab.kgenprog.project.ASTLocation;
+import jp.kusumotolab.kgenprog.project.ASTLocations;
+import jp.kusumotolab.kgenprog.project.GeneratedAST;
+import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.project.ProductSourcePath;
+import jp.kusumotolab.kgenprog.project.test.TestResults;
+
+public class Tarantula implements FaultLocalization {
+
+  @Override
+  public List<Suspiciousness> exec(final GeneratedSourceCode generatedSourceCode,
+      final TestResults testResults) {
+
+    final List<Suspiciousness> suspiciousnesses = new ArrayList<>();
+
+    for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
+      final ProductSourcePath path = ast.getSourcePath();
+      final int lastLineNumber = ast.getNumberOfLines();
+      final ASTLocations astLocations = ast.createLocations();
+
+      for (int line = 1; line <= lastLineNumber; line++) {
+        final List<ASTLocation> locations = astLocations.infer(line);
+        if (!locations.isEmpty()) {
+          final ASTLocation l = locations.get(locations.size() - 1);
+          final long ef = testResults.getNumberOfFailedTestsExecutingTheStatement(path, l);
+          final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
+          final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
+          final long np = testResults.getNumberOfPassedTestsNotExecutingTheStatement(path, l);
+          final double value = (ef / (ef + nf)) / (ef / (ef + nf) + ep / (ep + np));
+          if (0d < value) {
+            final Suspiciousness s = new Suspiciousness(l, value);
+            suspiciousnesses.add(s);
+          }
+        }
+      }
+    }
+
+    return suspiciousnesses;
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Zoltar.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Zoltar.java
@@ -1,0 +1,43 @@
+package jp.kusumotolab.kgenprog.fl;
+
+import java.util.ArrayList;
+import java.util.List;
+import jp.kusumotolab.kgenprog.project.ASTLocation;
+import jp.kusumotolab.kgenprog.project.ASTLocations;
+import jp.kusumotolab.kgenprog.project.GeneratedAST;
+import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.project.ProductSourcePath;
+import jp.kusumotolab.kgenprog.project.test.TestResults;
+
+public class Zoltar implements FaultLocalization {
+
+  @Override
+  public List<Suspiciousness> exec(final GeneratedSourceCode generatedSourceCode,
+      final TestResults testResults) {
+
+    final List<Suspiciousness> suspiciousnesses = new ArrayList<>();
+
+    for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
+      final ProductSourcePath path = ast.getSourcePath();
+      final int lastLineNumber = ast.getNumberOfLines();
+      final ASTLocations astLocations = ast.createLocations();
+
+      for (int line = 1; line <= lastLineNumber; line++) {
+        final List<ASTLocation> locations = astLocations.infer(line);
+        if (!locations.isEmpty()) {
+          final ASTLocation l = locations.get(locations.size() - 1);
+          final long ef = testResults.getNumberOfFailedTestsExecutingTheStatement(path, l);
+          final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
+          final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
+          final double value = ef / (ef + nf + ep + 10000d * nf * ep / ef);
+          if (0d < value) {
+            final Suspiciousness s = new Suspiciousness(l, value);
+            suspiciousnesses.add(s);
+          }
+        }
+      }
+    }
+
+    return suspiciousnesses;
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/fl/AmpleTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/fl/AmpleTest.java
@@ -38,12 +38,10 @@ public class AmpleTest {
 
     suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
 
-    final double susp1 = Math.abs(1.0 / (1.0 + 0.0) - 1.0 / (1.0 + 2.0)); // 0.666666 (the most suspicious stmt)
-    final double susp2 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 0.0)); // 0.0
-    final double susp3 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 0.0)); // 0.0
-    final double susp4 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 0.0)); // 0.0
+    final double susp1 = Math.abs(1.0 / (1.0 + 0.0) - 1.0 / (1.0 + 2.0)); // 0.666667 (the most suspicious stmt)
+    final double susp2 = Math.abs(0.0 / (0.0 + 1.0) - 2.0 / (2.0 + 1.0)); // 0.666666
     assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
-        .containsExactly(susp1, susp2, susp3, susp4);
+        .containsExactly(susp1, susp2);
   }
 
   @Test
@@ -63,8 +61,12 @@ public class AmpleTest {
     final double susp2 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 5.0)); // 0.625
     final double susp3 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 5.0)); // 0.625
     final double susp4 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 5.0)); // 0.625
+    final double susp5 = Math.abs(0.0 / (0.0 + 1.0) - 2.0 / (2.0 + 6.0)); // 0.25
+    final double susp6 = Math.abs(0.0 / (0.0 + 1.0) - 2.0 / (2.0 + 6.0)); // 0.25
+    final double susp7 = Math.abs(0.0 / (0.0 + 1.0) - 2.0 / (2.0 + 6.0)); // 0.25
+    final double susp8 = Math.abs(0.0 / (0.0 + 1.0) - 1.0 / (1.0 + 7.0)); // 0.125
     assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
-        .containsExactly(susp1, susp2, susp3, susp4);
+        .containsExactly(susp1, susp2, susp3, susp4, susp5, susp6, susp7, susp8);
   }
 
   @Test

--- a/src/test/java/jp/kusumotolab/kgenprog/fl/AmpleTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/fl/AmpleTest.java
@@ -1,0 +1,83 @@
+package jp.kusumotolab.kgenprog.fl;
+
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.reverseOrder;
+import static org.assertj.core.api.Assertions.assertThat;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import jp.kusumotolab.kgenprog.Configuration;
+import jp.kusumotolab.kgenprog.ga.Variant;
+import jp.kusumotolab.kgenprog.project.factory.TargetProject;
+import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
+import jp.kusumotolab.kgenprog.testutil.TestUtil;
+
+public class AmpleTest {
+
+  private final static Path WORK_PATH = Paths.get("tmp/work");
+
+  @Before
+  public void before() throws IOException {
+    System.gc();
+    TestUtil.deleteWorkDirectory(WORK_PATH);
+  }
+
+  @Test
+  public void testForExample01() {
+    final Path rootPath = Paths.get("example/BuildSuccess01");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Ample();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
+
+    final double susp1 = Math.abs(1.0 / (1.0 + 0.0) - 1.0 / (1.0 + 2.0)); // 0.666666 (the most suspicious stmt)
+    final double susp2 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 0.0)); // 0.0
+    final double susp3 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 0.0)); // 0.0
+    final double susp4 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 0.0)); // 0.0
+    assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
+        .containsExactly(susp1, susp2, susp3, susp4);
+  }
+
+  @Test
+  public void testForExample02() {
+    final Path rootPath = Paths.get("example/BuildSuccess02");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Ample();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
+
+    final double susp1 = Math.abs(1.0 / (1.0 + 0.0) - 1.0 / (1.0 + 7.0)); // 0.875 (the most suspicious stmt)
+    final double susp2 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 5.0)); // 0.625
+    final double susp3 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 5.0)); // 0.625
+    final double susp4 = Math.abs(1.0 / (1.0 + 0.0) - 3.0 / (3.0 + 5.0)); // 0.625
+    assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
+        .containsExactly(susp1, susp2, susp3, susp4);
+  }
+
+  @Test
+  public void testForFailedProject() throws IOException {
+    final Path rootPath = Paths.get("example/BuildFailure01");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Ample();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    assertThat(suspiciousnesses).isEmpty();
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/fl/JaccardTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/fl/JaccardTest.java
@@ -59,10 +59,10 @@ public class JaccardTest {
 
     suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
 
-    final double susp1 = 1.0 / (1.0 + 0.0 + 1.0); // 0.875 (the most suspicious stmt)
-    final double susp2 = 1.0 / (1.0 + 0.0 + 3.0); // 0.625
-    final double susp3 = 1.0 / (1.0 + 0.0 + 3.0); // 0.625
-    final double susp4 = 1.0 / (1.0 + 0.0 + 3.0); // 0.625
+    final double susp1 = 1.0 / (1.0 + 0.0 + 1.0); // 0.50 (the most suspicious stmt)
+    final double susp2 = 1.0 / (1.0 + 0.0 + 3.0); // 0.25
+    final double susp3 = 1.0 / (1.0 + 0.0 + 3.0); // 0.25
+    final double susp4 = 1.0 / (1.0 + 0.0 + 3.0); // 0.25
     assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
         .containsExactly(susp1, susp2, susp3, susp4);
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/fl/JaccardTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/fl/JaccardTest.java
@@ -1,0 +1,83 @@
+package jp.kusumotolab.kgenprog.fl;
+
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.reverseOrder;
+import static org.assertj.core.api.Assertions.assertThat;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import jp.kusumotolab.kgenprog.Configuration;
+import jp.kusumotolab.kgenprog.ga.Variant;
+import jp.kusumotolab.kgenprog.project.factory.TargetProject;
+import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
+import jp.kusumotolab.kgenprog.testutil.TestUtil;
+
+public class JaccardTest {
+
+  private final static Path WORK_PATH = Paths.get("tmp/work");
+
+  @Before
+  public void before() throws IOException {
+    System.gc();
+    TestUtil.deleteWorkDirectory(WORK_PATH);
+  }
+
+  @Test
+  public void testForExample01() {
+    final Path rootPath = Paths.get("example/BuildSuccess01");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Jaccard();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
+
+    final double susp1 = 1.0 / (1.0 + 0.0 + 1.0); // 0.50 (the most suspicious stmt)
+    final double susp2 = 1.0 / (1.0 + 0.0 + 3.0); // 0.25
+    final double susp3 = 1.0 / (1.0 + 0.0 + 3.0); // 0.25
+    final double susp4 = 1.0 / (1.0 + 0.0 + 3.0); // 0.25
+    assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
+        .containsExactly(susp1, susp2, susp3, susp4);
+  }
+
+  @Test
+  public void testForExample02() {
+    final Path rootPath = Paths.get("example/BuildSuccess02");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Jaccard();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
+
+    final double susp1 = 1.0 / (1.0 + 0.0 + 1.0); // 0.875 (the most suspicious stmt)
+    final double susp2 = 1.0 / (1.0 + 0.0 + 3.0); // 0.625
+    final double susp3 = 1.0 / (1.0 + 0.0 + 3.0); // 0.625
+    final double susp4 = 1.0 / (1.0 + 0.0 + 3.0); // 0.625
+    assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
+        .containsExactly(susp1, susp2, susp3, susp4);
+  }
+
+  @Test
+  public void testForFailedProject() throws IOException {
+    final Path rootPath = Paths.get("example/BuildFailure01");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Jaccard();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    assertThat(suspiciousnesses).isEmpty();
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/fl/OchiaiTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/fl/OchiaiTest.java
@@ -38,10 +38,10 @@ public class OchiaiTest {
 
     suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
 
-    final double susp1 = 1 / Math.sqrt((1 + 0) * (1 + 1)); // 0.707107 (the most suspicious stmt)
-    final double susp2 = 1 / Math.sqrt((1 + 0) * (1 + 3)); // 0.50
-    final double susp3 = 1 / Math.sqrt((1 + 0) * (1 + 3)); // 0.50
-    final double susp4 = 1 / Math.sqrt((1 + 0) * (1 + 3)); // 0.50
+    final double susp1 = 1.0 / Math.sqrt((1.0 + 0.0) * (1.0 + 1.0)); // 0.707107 (the most suspicious stmt)
+    final double susp2 = 1.0 / Math.sqrt((1.0 + 0.0) * (1.0 + 3.0)); // 0.50
+    final double susp3 = 1.0 / Math.sqrt((1.0 + 0.0) * (1.0 + 3.0)); // 0.50
+    final double susp4 = 1.0 / Math.sqrt((1.0 + 0.0) * (1.0 + 3.0)); // 0.50
     assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
         .containsExactly(susp1, susp2, susp3, susp4);
   }
@@ -59,10 +59,10 @@ public class OchiaiTest {
 
     suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
 
-    final double susp1 = 1 / Math.sqrt((1 + 0) * (1 + 1)); // 0.707107 (the most suspicious stmt)
-    final double susp2 = 1 / Math.sqrt((1 + 0) * (1 + 3)); // 0.50
-    final double susp3 = 1 / Math.sqrt((1 + 0) * (1 + 3)); // 0.50
-    final double susp4 = 1 / Math.sqrt((1 + 0) * (1 + 3)); // 0.50
+    final double susp1 = 1.0 / Math.sqrt((1.0 + 0.0) * (1.0 + 1.0)); // 0.707107 (the most suspicious stmt)
+    final double susp2 = 1.0 / Math.sqrt((1.0 + 0.0) * (1.0 + 3.0)); // 0.50
+    final double susp3 = 1.0 / Math.sqrt((1.0 + 0.0) * (1.0 + 3.0)); // 0.50
+    final double susp4 = 1.0 / Math.sqrt((1.0 + 0.0) * (1.0 + 3.0)); // 0.50
     assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
         .containsExactly(susp1, susp2, susp3, susp4);
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/fl/TarantulaTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/fl/TarantulaTest.java
@@ -1,0 +1,83 @@
+package jp.kusumotolab.kgenprog.fl;
+
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.reverseOrder;
+import static org.assertj.core.api.Assertions.assertThat;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import jp.kusumotolab.kgenprog.Configuration;
+import jp.kusumotolab.kgenprog.ga.Variant;
+import jp.kusumotolab.kgenprog.project.factory.TargetProject;
+import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
+import jp.kusumotolab.kgenprog.testutil.TestUtil;
+
+public class TarantulaTest {
+
+  private final static Path WORK_PATH = Paths.get("tmp/work");
+
+  @Before
+  public void before() throws IOException {
+    System.gc();
+    TestUtil.deleteWorkDirectory(WORK_PATH);
+  }
+
+  @Test
+  public void testForExample01() {
+    final Path rootPath = Paths.get("example/BuildSuccess01");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Tarantula();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
+
+    final double susp1 = (1.0 / (1.0 + 0.0)) / (1.0 / (1.0 + 0.0) + 1.0 / (1.0 + 2.0)); // 0.75 (the most suspicious stmt)
+    final double susp2 = (1.0 / (1.0 + 0.0)) / (1.0 / (1.0 + 0.0) + 3.0 / (3.0 + 0.0)); // 0.5
+    final double susp3 = (1.0 / (1.0 + 0.0)) / (1.0 / (1.0 + 0.0) + 3.0 / (3.0 + 0.0)); // 0.5
+    final double susp4 = (1.0 / (1.0 + 0.0)) / (1.0 / (1.0 + 0.0) + 3.0 / (3.0 + 0.0)); // 0.5
+    assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
+        .containsExactly(susp1, susp2, susp3, susp4);
+  }
+
+  @Test
+  public void testForExample02() {
+    final Path rootPath = Paths.get("example/BuildSuccess02");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Tarantula();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
+
+    final double susp1 = (1.0 / (1.0 + 0.0)) / (1.0 / (1.0 + 0.0) + 1.0 / (1.0 + 7.0)); // 0.888889 (the most suspicious stmt)
+    final double susp2 = (1.0 / (1.0 + 0.0)) / (1.0 / (1.0 + 0.0) + 3.0 / (3.0 + 5.0)); // 0.727272
+    final double susp3 = (1.0 / (1.0 + 0.0)) / (1.0 / (1.0 + 0.0) + 3.0 / (3.0 + 5.0)); // 0.727272
+    final double susp4 = (1.0 / (1.0 + 0.0)) / (1.0 / (1.0 + 0.0) + 3.0 / (3.0 + 5.0)); // 0.727272
+    assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
+        .containsExactly(susp1, susp2, susp3, susp4);
+  }
+
+  @Test
+  public void testForFailedProject() throws IOException {
+    final Path rootPath = Paths.get("example/BuildFailure01");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Tarantula();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    assertThat(suspiciousnesses).isEmpty();
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/fl/ZoltarTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/fl/ZoltarTest.java
@@ -1,0 +1,83 @@
+package jp.kusumotolab.kgenprog.fl;
+
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.reverseOrder;
+import static org.assertj.core.api.Assertions.assertThat;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import jp.kusumotolab.kgenprog.Configuration;
+import jp.kusumotolab.kgenprog.ga.Variant;
+import jp.kusumotolab.kgenprog.project.factory.TargetProject;
+import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
+import jp.kusumotolab.kgenprog.testutil.TestUtil;
+
+public class ZoltarTest {
+
+  private final static Path WORK_PATH = Paths.get("tmp/work");
+
+  @Before
+  public void before() throws IOException {
+    System.gc();
+    TestUtil.deleteWorkDirectory(WORK_PATH);
+  }
+
+  @Test
+  public void testForExample01() {
+    final Path rootPath = Paths.get("example/BuildSuccess01");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Zoltar();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
+
+    final double susp1 = 1.0 / (1.0 + 0.0 + 1.0 + 10000d * 0.0 * 1.0 / 1.0); // 0.5  (the most suspicious stmt)
+    final double susp2 = 1.0 / (1.0 + 0.0 + 3.0 + 10000d * 0.0 * 3.0 / 1.0); // 0.25
+    final double susp3 = 1.0 / (1.0 + 0.0 + 3.0 + 10000d * 0.0 * 3.0 / 1.0); // 0.25
+    final double susp4 = 1.0 / (1.0 + 0.0 + 3.0 + 10000d * 0.0 * 3.0 / 1.0); // 0.25
+    assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
+        .containsExactly(susp1, susp2, susp3, susp4);
+  }
+
+  @Test
+  public void testForExample02() {
+    final Path rootPath = Paths.get("example/BuildSuccess02");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Zoltar();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    suspiciousnesses.sort(comparing(Suspiciousness::getValue, reverseOrder()));
+
+    final double susp1 = 1.0 / (1.0 + 0.0 + 1.0 + 10000d * 0.0 * 1.0 / 1.0); // 0.5  (the most suspicious stmt)
+    final double susp2 = 1.0 / (1.0 + 0.0 + 3.0 + 10000d * 0.0 * 3.0 / 1.0); // 0.25
+    final double susp3 = 1.0 / (1.0 + 0.0 + 3.0 + 10000d * 0.0 * 3.0 / 1.0); // 0.25
+    final double susp4 = 1.0 / (1.0 + 0.0 + 3.0 + 10000d * 0.0 * 3.0 / 1.0); // 0.25
+    assertThat(suspiciousnesses).extracting(Suspiciousness::getValue)
+        .containsExactly(susp1, susp2, susp3, susp4);
+  }
+
+  @Test
+  public void testForFailedProject() throws IOException {
+    final Path rootPath = Paths.get("example/BuildFailure01");
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final Variant initialVariant = TestUtil.createVariant(config);
+
+    final FaultLocalization fl = new Zoltar();
+    final List<Suspiciousness> suspiciousnesses =
+        fl.exec(initialVariant.getGeneratedSourceCode(), initialVariant.getTestResults());
+
+    assertThat(suspiciousnesses).isEmpty();
+  }
+}


### PR DESCRIPTION
resolve #441 
## 内容
- 以下のFL戦略を追加
  - Ample
  - Jaccard
  - Tarantula
  - Zolar
- 追加したFL戦略に対応するテストを追加
- （`OchiaiTest.java`の有効数字を拡張）
  - 他のテストと合わせるため．それほど意味はないです

## 備考
`TestUtil#createVariant`等で`new Ochiai()`しているところがありますが保留しています
see #352 