### PR TITLE
TestExecutorの修正

### DIFF
--- a/src/test/java/jp/kusumotolab/kgenprog/output/TestResultsSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/TestResultsSerializerTest.java
@@ -17,6 +17,7 @@ import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
+import jp.kusumotolab.kgenprog.project.test.LocalTestExecutor;
 import jp.kusumotolab.kgenprog.project.test.TestExecutor;
 import jp.kusumotolab.kgenprog.project.test.TestResult;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
@@ -41,7 +42,7 @@ public class TestResultsSerializerTest {
         targetProject);
     final Configuration config = new Configuration.Builder(targetProject)
         .build();
-    final TestExecutor executor = new TestExecutor(config);
+    final TestExecutor executor = new LocalTestExecutor(config);
     return executor.exec(generatedSourceCode);
   }
 


### PR DESCRIPTION
## 何が起きたか
#447 の PR では CI を通っていたが，master にマージされると CI に失敗した

## 原因
#447 で `TestExecutor` をインターフェースにしたが，マージされるまでの間に #349 が master にマージされ，その中で `TestExecutor` がクラスとして使用されていた

## 修正内容
#349 で追加されたコードの中の `TestExecutor` を `LocalTestExecutor` に変更した　