### PR TITLE
クラスターに向けての実装の修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/Operation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/Operation.java
@@ -7,4 +7,8 @@ public interface Operation {
   default String getName(){
     return "";
   }
+
+  default String getTargetSnippet() {
+    return "";
+  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertOperation.java
@@ -28,4 +28,9 @@ public class InsertOperation extends JDTOperation {
   public String getName(){
     return "insert";
   }
+
+  @Override
+  public String getTargetSnippet() {
+    return astNode.toString();
+  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
@@ -18,7 +18,7 @@ import jp.kusumotolab.kgenprog.project.SourcePath;
  * @author r-arima
  *
  */
-final public class JDTASTLocation implements ASTLocation {
+public class JDTASTLocation implements ASTLocation {
 
   public final ASTNode node;
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
@@ -112,4 +112,8 @@ public class JDTASTLocation implements ASTLocation {
   public GeneratedAST<?> getGeneratedAST() {
     return generatedAST;
   }
+
+  public ASTNode getNode() {
+    return node;
+  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/ReplaceOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/ReplaceOperation.java
@@ -23,4 +23,9 @@ public class ReplaceOperation extends JDTOperation {
   public String getName(){
     return "replace";
   }
+
+  @Override
+  public String getTargetSnippet() {
+    return astNode.toString();
+  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/Coverage.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/Coverage.java
@@ -49,6 +49,12 @@ public class Coverage implements Serializable {
     this.statuses = convertClassCoverage(classCoverage);
   }
 
+  public Coverage(final FullyQualifiedName executedTargetFQN,
+      final List<Status> statuses) {
+    this.executedTargetFQN = executedTargetFQN;
+    this.statuses = statuses;
+  }
+
   /**
    * ClassCoverageに格納されたCoverageをList<Status>に変換する． 実質enumの型変換やってるだけ．
    * 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
@@ -1,6 +1,5 @@
 package jp.kusumotolab.kgenprog.project.test;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;


### PR DESCRIPTION
# 内容
- Operation にコードのスニペットを取得する処理の追加
- Coverage にコンストラクタを追加
- TestResults に getCorrespondingFqns を追加 
  - このメソッドをオーバーライドすることで ProductSourcePath に対応する　Set\<FQN\> を取得する処理を変更できます
- JDTASTLocation に getNode を追加