### PR TITLE
TestExecutorのインターフェースを変更

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
   compile 'com.electronwill.night-config:toml:3.4.0'
 
-  implementation "io.reactivex.rxjava2:rxjava:2.2.4"
+  compile "io.reactivex.rxjava2:rxjava:2.2.4"
 }
 
 jar {

--- a/src/main/java/jp/kusumotolab/kgenprog/Strategies.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Strategies.java
@@ -49,12 +49,12 @@ public class Strategies {
     return sourceCodeGeneration.exec(variantStore, gene);
   }
 
-  public TestResults execTestExecutor(final GeneratedSourceCode generatedSourceCode) {
-    return testExecutor.exec(generatedSourceCode);
+  public TestResults execTestExecutor(final Variant variant) {
+    return testExecutor.exec(variant);
   }
 
-  public Single<TestResults> execAsyncTestExecutor(final Single<GeneratedSourceCode> sourceCodeSingle) {
-    return testExecutor.execAsync(sourceCodeSingle);
+  public Single<TestResults> execAsyncTestExecutor(final Single<Variant> variantSingle) {
+    return testExecutor.execAsync(variantSingle);
   }
 
   public Fitness execSourceCodeValidation(final GeneratedSourceCode sourceCode,

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/variant/LazyVariant.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/variant/LazyVariant.java
@@ -10,23 +10,36 @@ import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 public class LazyVariant extends Variant {
 
-  private final Single<TestResults> testResultsSingle;
-  private final Single<Fitness> fitnessSingle;
-  private final Single<List<Suspiciousness>> suspiciousnessListSingle;
+  private Single<TestResults> testResultsSingle;
+  private Single<Fitness> fitnessSingle;
+  private Single<List<Suspiciousness>> suspiciousnessListSingle;
 
-  public LazyVariant(final long id, final int generationNumber,
-      final Gene gene, final GeneratedSourceCode generatedSourceCode,
-      final Single<TestResults> testResultsSingle, final Single<Fitness> fitnessSingle,
-      final Single<List<Suspiciousness>> suspiciousnessListSingle,
-      final HistoricalElement historicalElement) {
+  public LazyVariant(final long id, final int generationNumber, final Gene gene,
+      final GeneratedSourceCode generatedSourceCode, final HistoricalElement historicalElement) {
     super(id, generationNumber, gene, generatedSourceCode, null, null, null,
         historicalElement);
+  }
 
+  void subscribe() {
+    if (testResultsSingle == null) {
+      return;
+    }
+    testResultsSingle.subscribe();
+  }
+
+  void setTestResultsSingle(
+      final Single<TestResults> testResultsSingle) {
     this.testResultsSingle = testResultsSingle;
-    this.fitnessSingle = fitnessSingle;
-    this.suspiciousnessListSingle = suspiciousnessListSingle;
+  }
 
-    this.testResultsSingle.subscribe();
+  void setFitnessSingle(
+      final Single<Fitness> fitnessSingle) {
+    this.fitnessSingle = fitnessSingle;
+  }
+
+  void setSuspiciousnessListSingle(
+      final Single<List<Suspiciousness>> suspiciousnessListSingle) {
+    this.suspiciousnessListSingle = suspiciousnessListSingle;
   }
 
   @Override
@@ -37,7 +50,8 @@ public class LazyVariant extends Variant {
 
   @Override
   public boolean isBuildSucceeded() {
-    return EmptyTestResults.class != testResultsSingle.blockingGet().getClass();
+    return EmptyTestResults.class != testResultsSingle.blockingGet()
+        .getClass();
   }
 
   @Override

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutor.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutor.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import jp.kusumotolab.kgenprog.Configuration;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.build.BuildResults;
 import jp.kusumotolab.kgenprog.project.build.ProjectBuilder;
@@ -20,7 +21,8 @@ public class LocalTestExecutor implements TestExecutor {
   }
 
   @Override
-  public TestResults exec(final GeneratedSourceCode generatedSourceCode) {
+  public TestResults exec(final Variant variant) {
+    final GeneratedSourceCode generatedSourceCode = variant.getGeneratedSourceCode();
     if (!generatedSourceCode.isGenerationSuccess()) {
       return EmptyTestResults.instance;
     }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/ParallelTestExecutor.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/ParallelTestExecutor.java
@@ -4,7 +4,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
-import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public class ParallelTestExecutor implements TestExecutor {
 
@@ -17,13 +17,13 @@ public class ParallelTestExecutor implements TestExecutor {
   }
 
   @Override
-  public TestResults exec(final GeneratedSourceCode generatedSourceCode) {
-    return testExecutor.exec(generatedSourceCode);
+  public TestResults exec(final Variant variant) {
+    return testExecutor.exec(variant);
   }
 
   @Override
-  public Single<TestResults> execAsync(final Single<GeneratedSourceCode> generatedSourceCode) {
-    return generatedSourceCode.subscribeOn(Schedulers.from(executorService))
+  public Single<TestResults> execAsync(final Single<Variant> variantSingle) {
+    return variantSingle.subscribeOn(Schedulers.from(executorService))
         .map(testExecutor::exec);
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestExecutor.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestExecutor.java
@@ -1,13 +1,13 @@
 package jp.kusumotolab.kgenprog.project.test;
 
 import io.reactivex.Single;
-import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public interface TestExecutor {
 
-  TestResults exec(final GeneratedSourceCode generatedSourceCode);
+  TestResults exec(final Variant variant);
 
-  default Single<TestResults> execAsync(final Single<GeneratedSourceCode> generatedSourceCode){
-    return generatedSourceCode.map(this::exec);
+  default Single<TestResults> execAsync(final Single<Variant> variantSingle){
+    return variantSingle.map(this::exec);
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/variant/VariantStoreTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/variant/VariantStoreTest.java
@@ -183,8 +183,8 @@ public class VariantStoreTest {
     when(strategies.execSourceCodeValidation(any(), any())).then(v -> new SimpleFitness(1.0d));
     when(strategies.execFaultLocalization(any(), any())).then(v -> Collections.emptyList());
     when(strategies.execAsyncTestExecutor(any())).then(v -> {
-      final Single<GeneratedSourceCode> sourceCodeSingle = v.getArgument(0);
-      return testExecutor.execAsync(sourceCodeSingle);
+      final Single<Variant> variantSingle = v.getArgument(0);
+      return testExecutor.execAsync(variantSingle);
     });
     return strategies;
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/output/TestResultsSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/TestResultsSerializerTest.java
@@ -1,6 +1,8 @@
 package jp.kusumotolab.kgenprog.output;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
@@ -12,6 +14,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import jp.kusumotolab.kgenprog.Configuration;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.project.FullyQualifiedName;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
@@ -43,7 +46,9 @@ public class TestResultsSerializerTest {
     final Configuration config = new Configuration.Builder(targetProject)
         .build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    return executor.exec(generatedSourceCode);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(generatedSourceCode);
+    return executor.exec(variant);
   }
 
   /**

--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
@@ -75,8 +75,8 @@ public class VariantStoreSerializerTest {
     when(strategies.execASTConstruction(any())).thenReturn(astConstructionResult);
     when(strategies.execVariantSelection(any(), any())).thenReturn(Collections.emptyList());
     when(strategies.execAsyncTestExecutor(any())).then(v -> {
-      final Single<GeneratedSourceCode> sourceCodeSingle = v.getArgument(0);
-      return testExecutor.execAsync(sourceCodeSingle);
+      final Single<Variant> variantSingle = v.getArgument(0);
+      return testExecutor.execAsync(variantSingle);
     });
 
     final VariantStore variantStore = new VariantStore(config, strategies);

--- a/src/test/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutorTest.java
@@ -1,5 +1,6 @@
 package jp.kusumotolab.kgenprog.project.test;
 
+import static org.mockito.Mockito.mock;
 import static jp.kusumotolab.kgenprog.project.test.Coverage.Status.COVERED;
 import static jp.kusumotolab.kgenprog.project.test.Coverage.Status.EMPTY;
 import static jp.kusumotolab.kgenprog.project.test.Coverage.Status.NOT_COVERED;
@@ -16,6 +17,7 @@ import static jp.kusumotolab.kgenprog.testutil.ExampleAlias.Fqn.FOO_TEST02;
 import static jp.kusumotolab.kgenprog.testutil.ExampleAlias.Fqn.FOO_TEST03;
 import static jp.kusumotolab.kgenprog.testutil.ExampleAlias.Fqn.FOO_TEST04;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -24,6 +26,7 @@ import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;
 import jp.kusumotolab.kgenprog.Configuration;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.project.ASTLocation;
 import jp.kusumotolab.kgenprog.project.GeneratedAST;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
@@ -47,7 +50,9 @@ public class LocalTestExecutorTest {
 
     final Configuration config = new Configuration.Builder(targetProject).build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(source);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result = executor.exec(variant);
 
     // 実行されたテストは4個のはず
     assertThat(result.getExecutedTestFQNs()).containsExactlyInAnyOrder( //
@@ -83,7 +88,9 @@ public class LocalTestExecutorTest {
 
     final Configuration config = new Configuration.Builder(targetProject).build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(source);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result = executor.exec(variant);
 
     // 実行されたテストは10個のはず
     assertThat(result.getExecutedTestFQNs()).containsExactlyInAnyOrder( //
@@ -129,7 +136,9 @@ public class LocalTestExecutorTest {
 
     final Configuration config = new Configuration.Builder(targetProject).build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(source);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result = executor.exec(variant);
 
     // 実行されたテストはないはず
     assertThat(result).isInstanceOf(EmptyTestResults.class);
@@ -145,7 +154,9 @@ public class LocalTestExecutorTest {
 
     final Configuration config = new Configuration.Builder(targetProject).build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(source);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result = executor.exec(variant);
 
     // 内部クラスを持つBazのASTと，Baz#OuterClassのL66のASTLocationを取り出す
     final ProductSourcePath baz = new ProductSourcePath(rootPath.resolve(Src.BAZ));
@@ -199,7 +210,9 @@ public class LocalTestExecutorTest {
         .setTestTimeLimitSeconds(1) // タイムアウト時間を短めに設定（CI高速化のため）
         .build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(source);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result = executor.exec(variant);
 
     // 無限ループが発生し，タイムアウトで打ち切られてEmptyになるはず
     assertThat(result).isInstanceOf(EmptyTestResults.class);
@@ -217,7 +230,9 @@ public class LocalTestExecutorTest {
         .addExecutionTest("example.FooTest")
         .build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(source);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result = executor.exec(variant);
 
     // 実行されたテストは10個から4個に減ったはず
     assertThat(result.getExecutedTestFQNs()).containsExactlyInAnyOrder( //
@@ -252,7 +267,9 @@ public class LocalTestExecutorTest {
         .addExecutionTest("example.FooTestXXXXXXXX") // no such method
         .build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(source);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result = executor.exec(variant);
 
     // 実行されたテストはないはず
     assertThat(result).isInstanceOf(EmptyTestResults.class);
@@ -268,7 +285,9 @@ public class LocalTestExecutorTest {
 
     final Configuration config = new Configuration.Builder(targetProject).build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(source);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result = executor.exec(variant);
 
     // 実行されたテストは4個のはず
     assertThat(result.getExecutedTestFQNs()).containsExactlyInAnyOrder( //
@@ -290,7 +309,9 @@ public class LocalTestExecutorTest {
 
     final Configuration config = new Configuration.Builder(targetProject).build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(source);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result = executor.exec(variant);
 
     // 実行されたテストは4個のはず
     assertThat(result.getExecutedTestFQNs()).containsExactlyInAnyOrder( //
@@ -317,7 +338,9 @@ public class LocalTestExecutorTest {
         .addExecutionTest(FOO_TEST.value) // FooTestのみ実行する（非依存テストは実行しない）
         .build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(source);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result = executor.exec(variant);
 
     // 実行されたテストは4個のはず（BarTest#test01は実行されない）
     assertThat(result.getExecutedTestFQNs()).containsExactlyInAnyOrder( //
@@ -339,7 +362,9 @@ public class LocalTestExecutorTest {
 
     final Configuration config = new Configuration.Builder(targetProject).build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result1 = executor.exec(source);
+    final Variant variant1 = mock(Variant.class);
+    when(variant1.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result1 = executor.exec(variant1);
 
     // 実行されたテストは4個のはず
     assertThat(result1.getExecutedTestFQNs()).containsExactlyInAnyOrder( //
@@ -366,7 +391,9 @@ public class LocalTestExecutorTest {
     final GeneratedSourceCode source2 = dop.apply(source, location);
 
     // 再度テスト実行
-    final TestResults result2 = executor.exec(source2);
+    final Variant variant2 = mock(Variant.class);
+    when(variant2.getGeneratedSourceCode()).thenReturn(source2);
+    final TestResults result2 = executor.exec(variant2);
 
     // 実行されたテストは4個のはず
     assertThat(result2.getExecutedTestFQNs()).containsExactlyInAnyOrder( //

--- a/src/test/java/jp/kusumotolab/kgenprog/project/test/ParallelTestExecutorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/test/ParallelTestExecutorTest.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import org.junit.Test;
 import io.reactivex.Single;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 
 public class ParallelTestExecutorTest {
@@ -32,9 +33,10 @@ public class ParallelTestExecutorTest {
     final List<Single<String>> singleList = new ArrayList<>();
 
     for (int i = 0; i < 10; i++) {
-      final Single<GeneratedSourceCode> sourceCodeSingle = Single.just(
-          mock(GeneratedSourceCode.class));
-      final Single<TestResults> single = testExecutor.execAsync(sourceCodeSingle);
+      final Variant variant = mock(Variant.class);
+      when(variant.getGeneratedSourceCode()).thenReturn(mock(GeneratedSourceCode.class));
+      final Single<Variant> variantSingle = Single.just(variant);
+      final Single<TestResults> single = testExecutor.execAsync(variantSingle);
       final Single<String> threadName = single.map(e -> {
         final Thread currentThread = Thread.currentThread();
         return currentThread.getName();

--- a/src/test/java/jp/kusumotolab/kgenprog/project/test/TestResultsTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/test/TestResultsTest.java
@@ -4,16 +4,17 @@ import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
 import static jp.kusumotolab.kgenprog.testutil.ExampleAlias.Fqn.FOO_TEST01;
 import static jp.kusumotolab.kgenprog.testutil.ExampleAlias.Fqn.FOO_TEST03;
 import static org.assertj.core.api.Assertions.assertThat;
-import java.io.IOException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Before;
 import org.junit.Test;
 import jp.kusumotolab.kgenprog.Configuration;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.project.ASTLocation;
 import jp.kusumotolab.kgenprog.project.ASTLocations;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
@@ -31,14 +32,11 @@ public class TestResultsTest {
 
   private final static long TIMEOUT_SEC = 60;
 
-  @Before
-  public void before() throws IOException {}
-
   /**
    * FLで用いる4メトリクスのテスト
    */
   @Test
-  public void testFLMetricsInTestResultsForExample02() throws Exception {
+  public void testFLMetricsInTestResultsForExample02() {
     // actual確保のためにテストの実行
     final Path rootPath = Paths.get("example/BuildSuccess01");
     final TargetProject targetProject = TargetProjectFactory.create(rootPath);
@@ -50,7 +48,9 @@ public class TestResultsTest {
         new Configuration.Builder(targetProject).setTimeLimitSeconds(TIMEOUT_SEC)
             .build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(generatedSourceCode);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(generatedSourceCode);
+    final TestResults result = executor.exec(variant);
 
     // TODO
     // buildResultsのセットは本来，TestExcecutorでやるべき．
@@ -107,7 +107,7 @@ public class TestResultsTest {
    * toString()のテスト．JSON形式の確認
    */
   @Test
-  public void testToString() throws Exception {
+  public void testToString() {
     final Path rootPath = Paths.get("example/BuildSuccess01");
     final TargetProject targetProject = TargetProjectFactory.create(rootPath);
     final GeneratedSourceCode generatedSourceCode =
@@ -118,9 +118,11 @@ public class TestResultsTest {
         new Configuration.Builder(targetProject).setTimeLimitSeconds(TIMEOUT_SEC)
             .build();
     final TestExecutor executor = new LocalTestExecutor(config);
-    final TestResults result = executor.exec(generatedSourceCode);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(generatedSourceCode);
+    final TestResults result = executor.exec(variant);
 
-    final String expected = new StringBuilder().append("")
+    final String expected = new StringBuilder()//
         .append("[")
         .append("  {")
         .append("    \"executedTestFQN\": \"example.FooTest.test04\",")

--- a/src/test/java/jp/kusumotolab/kgenprog/testutil/TestUtil.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/testutil/TestUtil.java
@@ -1,6 +1,8 @@
 package jp.kusumotolab.kgenprog.testutil;
 
 import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +39,9 @@ public class TestUtil {
   public static Variant createVariant(final Configuration config) {
     final Gene gene = new Gene(Collections.emptyList());
     final GeneratedSourceCode sourceCode = createGeneratedSourceCode(config.getTargetProject());
-    final TestResults testResults = new LocalTestExecutor(config).exec(sourceCode);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(sourceCode);
+    final TestResults testResults = new LocalTestExecutor(config).exec(variant);
     final Fitness fitness = new DefaultCodeValidation().exec(null, testResults);
     final List<Suspiciousness> suspiciousnesses = new Ochiai().exec(sourceCode, testResults);
     final HistoricalElement element = new OriginalHistoricalElement();


### PR DESCRIPTION
`TestEsecutor` の引数を `GeneratedSourceCode` から `Variant` に変更