### PR TITLE
一様交叉の追加

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedUniformCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedUniformCrossover.java
@@ -1,0 +1,19 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import java.util.Random;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public class GeneSimilarityBasedUniformCrossover extends SimilarityBasedUniformCrossover {
+
+
+  public GeneSimilarityBasedUniformCrossover(final Random random,
+      final int crossoverGeneratingCount) {
+    super(random, crossoverGeneratingCount);
+  }
+
+  @Override
+  protected double calculateSimilarity(final Variant variant1, final Variant variant2) {
+    return SimilarityCalculator.exec(variant1, variant2, v -> v.getGene()
+        .getBases());
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SimilarityBasedUniformCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SimilarityBasedUniformCrossover.java
@@ -1,0 +1,31 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import java.util.List;
+import java.util.Random;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public abstract class SimilarityBasedUniformCrossover extends UniformCrossover {
+
+
+  public SimilarityBasedUniformCrossover(final Random random, final int crossoverGenerationCount) {
+    super(random, crossoverGenerationCount);
+  }
+
+  @Override
+  public Variant selectSecondVariant(final List<Variant> variants, final Variant firstVariant) {
+    double minSimilarity = 1.0d;
+    Variant secondVariant = firstVariant;
+
+    for (final Variant variant : variants) {
+      final double similarity = calculateSimilarity(firstVariant, variant);
+      if (similarity < minSimilarity) {
+        minSimilarity = similarity;
+        secondVariant = variant;
+      }
+    }
+
+    return secondVariant;
+  }
+
+  protected abstract double calculateSimilarity(final Variant variant1, final Variant variant2);
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossover.java
@@ -1,0 +1,18 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import java.util.Random;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public class TestSimilarityBasedUniformCrossover extends SimilarityBasedUniformCrossover {
+
+  public TestSimilarityBasedUniformCrossover(final Random random,
+      final int crossoverGeneratingCount) {
+    super(random, crossoverGeneratingCount);
+  }
+
+  @Override
+  protected double calculateSimilarity(final Variant variant1, final Variant variant2) {
+    return SimilarityCalculator.exec(variant1, variant2, v -> v.getGene()
+        .getBases());
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossover.java
@@ -12,7 +12,7 @@ public class TestSimilarityBasedUniformCrossover extends SimilarityBasedUniformC
 
   @Override
   protected double calculateSimilarity(final Variant variant1, final Variant variant2) {
-    return SimilarityCalculator.exec(variant1, variant2, v -> v.getGene()
-        .getBases());
+    return SimilarityCalculator.exec(variant1, variant2, v -> v.getTestResults()
+        .getFailedTestFQNs());
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
@@ -13,6 +13,10 @@ import jp.kusumotolab.kgenprog.ga.variant.UniformCrossoverHistoricalElement;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 
+/**
+ * 一様交叉を行うクラス
+ *
+ */
 public class UniformCrossover implements Crossover {
 
   private final Random random;

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
@@ -1,0 +1,117 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import jp.kusumotolab.kgenprog.ga.variant.Base;
+import jp.kusumotolab.kgenprog.ga.variant.Gene;
+import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.UniformCrossoverHistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
+
+public class UniformCrossover implements Crossover {
+
+  private final Random random;
+  private final int crossoverGeneratingCount;
+
+  public UniformCrossover(final Random random, final int crossoverGeneraingCount) {
+    this.random = random;
+    this.crossoverGeneratingCount = crossoverGeneraingCount;
+  }
+
+  @Override
+  public List<Variant> exec(final VariantStore variantStore) {
+
+    final List<Variant> filteredVariants = variantStore.getCurrentVariants()
+        .stream()
+        .filter(e -> !e.getGene()
+            .getBases()
+            .isEmpty())
+        .collect(Collectors.toList());
+
+    // filteredVariantsの要素数が2に満たない場合は交叉しない
+    if (filteredVariants.size() < 2) {
+      return Collections.emptyList();
+    }
+
+    final List<Variant> variants = new ArrayList<>();
+
+    // crossoverGenetingCountを超えるまでバリアントを作りづづける
+    while (variants.size() < crossoverGeneratingCount) {
+      final List<Variant> newVariants = makeVariants(filteredVariants, variantStore);
+      variants.addAll(newVariants);
+    }
+
+    // バリアントを作りすぎた場合はそれを除いてリターン
+    return variants.subList(0, crossoverGeneratingCount);
+  }
+
+  private List<Variant> makeVariants(final List<Variant> variants, final VariantStore store) {
+    final Variant variantA = selectFirstVariant(variants);
+    final Variant variantB = selectSecondVariant(variants, variantA);
+    final Gene geneA = variantA.getGene();
+    final Gene geneB = variantB.getGene();
+    final List<Base> basesA = geneA.getBases();
+    final List<Base> basesB = geneB.getBases();
+    if (!canMakeVariant(basesA, basesB)) {
+      return Collections.emptyList();
+    }
+
+    final Gene newGene = makeGene(basesA, basesB);
+    final HistoricalElement newElement = new UniformCrossoverHistoricalElement(variantA, variantB);
+    return Arrays.asList(store.createVariant(newGene, newElement));
+  }
+
+  /**
+   * 一つ目のバリアントを選ぶためのメソッド．
+   * 
+   * @param variants
+   * @return
+   */
+  protected Variant selectFirstVariant(final List<Variant> variants) {
+    return variants.get(random.nextInt(variants.size()));
+  }
+
+  /**
+   * 二つ目のバリアントを選ぶためのメソッド． 一つ目に選んだバリアントの情報を利用できるように，引数で受け取る．
+   * 
+   * @param variants
+   * @return
+   */
+  protected Variant selectSecondVariant(final List<Variant> variants, final Variant firstVariant) {
+    return variants.get(random.nextInt(variants.size()));
+  }
+
+  private boolean canMakeVariant(final List<Base> basesA, final List<Base> basesB) {
+    final int sizeA = basesA.size();
+    final int sizeB = basesB.size();
+    return Math.min(sizeA, sizeB) > 2;
+  }
+
+  private Gene makeGene(final List<Base> basesA, final List<Base> basesB) {
+    final List<Base> bases = new ArrayList<>();
+    for (int i = 0; i < basesA.size() || i < basesB.size(); i++) {
+
+      if (basesA.size() <= i) {
+        if (this.random.nextBoolean()) {
+          bases.add(basesB.get(i));
+        }
+        continue;
+      }
+
+      if (basesB.size() <= i) {
+        if (this.random.nextBoolean()) {
+          bases.add(basesA.get(i));
+        }
+        continue;
+      }
+
+      bases.add(this.random.nextBoolean() ? basesA.get(i) : basesB.get(i));
+    }
+    return new Gene(bases);
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
@@ -98,7 +98,7 @@ public class UniformCrossover implements Crossover {
 
   private Gene makeGene(final List<Base> basesA, final List<Base> basesB) {
     final List<Base> bases = new ArrayList<>();
-    for (int i = 0; i < basesA.size() || i < basesB.size(); i++) {
+    for (int i = 0; i < Math.max(basesA.size(), basesB.size()); i++) {
 
       if (basesA.size() <= i) {
         if (this.random.nextBoolean()) {

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/variant/UniformCrossoverHistoricalElement.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/variant/UniformCrossoverHistoricalElement.java
@@ -1,0 +1,25 @@
+package jp.kusumotolab.kgenprog.ga.variant;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class UniformCrossoverHistoricalElement implements HistoricalElement {
+
+  private final Variant parentA;
+  private final Variant parentB;
+
+  public UniformCrossoverHistoricalElement(final Variant parentA, final Variant parentB) {
+    this.parentA = parentA;
+    this.parentB = parentB;
+  }
+
+  @Override
+  public List<Variant> getParents() {
+    return Arrays.asList(parentA, parentB);
+  }
+
+  @Override
+  public String getOperationName() {
+    return "uniform-crossover";
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
@@ -1,0 +1,52 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import static org.mockito.Mockito.when;
+import java.util.Arrays;
+import org.mockito.Mockito;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
+import jp.kusumotolab.kgenprog.project.test.TestResults;
+
+// 10のテストケースが存在すると仮定する．
+// testResultsA は奇数番目のテストを失敗する．
+// testResultsB は偶数番目のテストを失敗する．
+// TestResultsC は1〜6のテストを失敗する．
+// TestResultsD は5〜10のテストを失敗する．
+public class CrossoverTestVariants {
+
+  final Variant variantA;
+  final Variant variantB;
+  final Variant variantC;
+  final Variant variantD;
+
+  public CrossoverTestVariants() {
+    final TestResults testResultsA = Mockito.mock(TestResults.class);
+    when(testResultsA.getFailedTestFQNs())
+        .thenReturn(Arrays.asList(new TestFullyQualifiedName("Test1"),
+            new TestFullyQualifiedName("Test3"), new TestFullyQualifiedName("Test5"),
+            new TestFullyQualifiedName("Test7"), new TestFullyQualifiedName("Test9")));
+    final TestResults testResultsB = Mockito.mock(TestResults.class);
+    when(testResultsB.getFailedTestFQNs())
+        .thenReturn(Arrays.asList(new TestFullyQualifiedName("Test2"),
+            new TestFullyQualifiedName("Test4"), new TestFullyQualifiedName("Test6"),
+            new TestFullyQualifiedName("Test8"), new TestFullyQualifiedName("Test10")));
+    final TestResults testResultsC = Mockito.mock(TestResults.class);
+    when(testResultsC.getFailedTestFQNs()).thenReturn(
+        Arrays.asList(new TestFullyQualifiedName("Test1"), new TestFullyQualifiedName("Test2"),
+            new TestFullyQualifiedName("Test3"), new TestFullyQualifiedName("Test4"),
+            new TestFullyQualifiedName("Test5"), new TestFullyQualifiedName("Test6")));
+    final TestResults testResultsD = Mockito.mock(TestResults.class);
+    when(testResultsD.getFailedTestFQNs()).thenReturn(
+        Arrays.asList(new TestFullyQualifiedName("Test5"), new TestFullyQualifiedName("Test6"),
+            new TestFullyQualifiedName("Test7"), new TestFullyQualifiedName("Test8"),
+            new TestFullyQualifiedName("Test9"), new TestFullyQualifiedName("Test10")));
+    variantA = Mockito.mock(Variant.class);
+    when(variantA.getTestResults()).thenReturn(testResultsA);
+    variantB = Mockito.mock(Variant.class);
+    when(variantB.getTestResults()).thenReturn(testResultsB);
+    variantC = Mockito.mock(Variant.class);
+    when(variantC.getTestResults()).thenReturn(testResultsC);
+    variantD = Mockito.mock(Variant.class);
+    when(variantD.getTestResults()).thenReturn(testResultsD);
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
@@ -14,11 +14,19 @@ import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
 import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
 
+// 4つの疑似バリアントからなるですとデータ．
+//
 // 10のテストケースが存在すると仮定する．
-// testResultsA は奇数番目のテストを失敗する．
-// testResultsB は偶数番目のテストを失敗する．
-// TestResultsC は1〜6のテストを失敗する．
-// TestResultsD は5〜10のテストを失敗する．
+// バリアントAは奇数番目のテストを失敗する．
+// バリアントBは偶数番目のテストを失敗する．
+// バリアントCは1〜6のテストを失敗する．
+// バリアントDは5〜10のテストを失敗する．
+//
+// 各バリアントは4つのBaseを持つ．
+// バリアントAは，none, none, none, none．
+// バリアントBは，none, none, none, insert．
+// バリアントCは，none, insert, insert, insert．
+// バリアントDは，insert, insert, insert, insert．
 public class CrossoverTestVariants {
 
   final Base noneBase;

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
@@ -14,7 +14,7 @@ import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
 import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
 
-// 4つの疑似バリアントからなるですとデータ．
+// 4つの疑似バリアントからなるテストデータ．
 //
 // 10のテストケースが存在すると仮定する．
 // バリアントAは奇数番目のテストを失敗する．

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
@@ -1,10 +1,17 @@
 package jp.kusumotolab.kgenprog.ga.crossover;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import org.mockito.Mockito;
+import jp.kusumotolab.kgenprog.ga.variant.Base;
+import jp.kusumotolab.kgenprog.ga.variant.Gene;
+import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
+import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
+import jp.kusumotolab.kgenprog.project.NoneOperation;
 import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
+import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 // 10のテストケースが存在すると仮定する．
@@ -14,12 +21,16 @@ import jp.kusumotolab.kgenprog.project.test.TestResults;
 // TestResultsD は5〜10のテストを失敗する．
 public class CrossoverTestVariants {
 
+  final Base noneBase;
+  final Base insertBase;
   final Variant variantA;
   final Variant variantB;
   final Variant variantC;
   final Variant variantD;
+  final VariantStore variantStore;
 
   public CrossoverTestVariants() {
+
     final TestResults testResultsA = Mockito.mock(TestResults.class);
     when(testResultsA.getFailedTestFQNs())
         .thenReturn(Arrays.asList(new TestFullyQualifiedName("Test1"),
@@ -40,13 +51,34 @@ public class CrossoverTestVariants {
         Arrays.asList(new TestFullyQualifiedName("Test5"), new TestFullyQualifiedName("Test6"),
             new TestFullyQualifiedName("Test7"), new TestFullyQualifiedName("Test8"),
             new TestFullyQualifiedName("Test9"), new TestFullyQualifiedName("Test10")));
+
+    noneBase = new Base(null, new NoneOperation());
+    insertBase = new Base(null, new InsertOperation(null));
+    final Gene geneA = new Gene(Arrays.asList(noneBase, noneBase, noneBase, noneBase));
+    final Gene geneB = new Gene(Arrays.asList(noneBase, noneBase, noneBase, insertBase));
+    final Gene geneC = new Gene(Arrays.asList(noneBase, insertBase, insertBase, insertBase));
+    final Gene geneD = new Gene(Arrays.asList(insertBase, insertBase, insertBase, insertBase));
+
     variantA = Mockito.mock(Variant.class);
     when(variantA.getTestResults()).thenReturn(testResultsA);
+    when(variantA.getGene()).thenReturn(geneA);
     variantB = Mockito.mock(Variant.class);
     when(variantB.getTestResults()).thenReturn(testResultsB);
+    when(variantB.getGene()).thenReturn(geneB);
     variantC = Mockito.mock(Variant.class);
     when(variantC.getTestResults()).thenReturn(testResultsC);
+    when(variantC.getGene()).thenReturn(geneC);
     variantD = Mockito.mock(Variant.class);
     when(variantD.getTestResults()).thenReturn(testResultsD);
+    when(variantD.getGene()).thenReturn(geneD);
+
+    variantStore = Mockito.mock(VariantStore.class);
+    when(variantStore.getCurrentVariants())
+        .thenReturn(Arrays.asList(variantA, variantB, variantC, variantD));
+    when(variantStore.createVariant(any(), any())).thenAnswer(invocation -> {
+      final Gene gene = invocation.getArgument(0);
+      final HistoricalElement element = invocation.getArgument(1);
+      return new Variant(0, 0, gene, null, null, null, null, element);
+    });
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedSinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedSinglePointCrossoverTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Random;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.variant.Gene;
@@ -13,13 +12,6 @@ import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public class GeneSimilarityBasedSinglePointCrossoverTest {
-
-  private static CrossoverTestVariants testVariants;
-
-  @Before
-  public void setup() {
-    testVariants = new CrossoverTestVariants();
-  }
 
   @Test
   public void test01() {
@@ -31,6 +23,7 @@ public class GeneSimilarityBasedSinglePointCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new GeneSimilarityBasedSinglePointCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 
@@ -54,6 +47,7 @@ public class GeneSimilarityBasedSinglePointCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new GeneSimilarityBasedSinglePointCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedSinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedSinglePointCrossoverTest.java
@@ -22,7 +22,7 @@ public class GeneSimilarityBasedSinglePointCrossoverTest {
   }
 
   @Test
-  public void test_exec1() {
+  public void test01() {
 
     // 生成するバリアントを制御するための疑似乱数
     final Random random = Mockito.mock(Random.class);
@@ -45,7 +45,7 @@ public class GeneSimilarityBasedSinglePointCrossoverTest {
   }
 
   @Test
-  public void test_exec2() {
+  public void test02() {
 
     // 生成するバリアントを制御するための疑似乱数
     final Random random = Mockito.mock(Random.class);

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedSinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedSinglePointCrossoverTest.java
@@ -1,132 +1,69 @@
 package jp.kusumotolab.kgenprog.ga.crossover;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import jp.kusumotolab.kgenprog.ga.variant.Base;
-import jp.kusumotolab.kgenprog.ga.variant.CrossoverHistoricalElement;
 import jp.kusumotolab.kgenprog.ga.variant.Gene;
 import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
-import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
-import jp.kusumotolab.kgenprog.project.NoneOperation;
-import jp.kusumotolab.kgenprog.project.Operation;
-import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
 
 public class GeneSimilarityBasedSinglePointCrossoverTest {
 
-
-  private static Random random;
+  private static CrossoverTestVariants testVariants;
 
   @Before
   public void setup() {
-    random = Mockito.mock(Random.class);
-    when(random.nextBoolean()).thenReturn(false);
-    when(random.nextInt(anyInt())).thenReturn(1);
+    testVariants = new CrossoverTestVariants();
   }
 
   @Test
-  public void testCrossover() {
-    final List<Variant> variants = execCrossover(10);
-    final List<Gene> genes = variants.stream()
-        .map(Variant::getGene)
-        .collect(Collectors.toList());
+  public void test_exec1() {
 
-    assertThat(genes).anyMatch(this::containNoneOperationAndInsertOperation);
-  }
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(0);
 
-  @Test
-  public void testGeneratingVariantsSize() {
-    List<Variant> variants = execCrossover(10);
-    assertThat(variants).hasSize(10);
-
-    variants = execCrossover(13);
-    assertThat(variants).hasSize(13);
-  }
-
-  @Test
-  public void testHistoricalElement() {
-    final Base noneOperationBase = new Base(null, new NoneOperation());
-    final Base insertOperationBase = new Base(null, new InsertOperation(null));
-
-    final List<Base> noneBases = Arrays.asList(noneOperationBase, noneOperationBase,
-        noneOperationBase, noneOperationBase, noneOperationBase);
-    final List<Base> insertBases = Arrays.asList(insertOperationBase, insertOperationBase,
-        insertOperationBase, insertOperationBase, insertOperationBase);
-
-    final Variant noneOperationVariant =
-        new Variant(0, 0, new Gene(noneBases), null, null, null, null, null);
-    final Variant insertOperationVariant =
-        new Variant(0, 0, new Gene(insertBases), null, null, null, null, null);
-    final VariantStore variantStore =
-        makeVariantStore(noneOperationVariant, insertOperationVariant);
-
-    final SinglePointCrossover singlePointCrossover =
-        new GeneSimilarityBasedSinglePointCrossover(random, 10);
-    final List<Variant> variants = singlePointCrossover.exec(variantStore);
-
+    // バリアントの生成
+    final Crossover crossover = new GeneSimilarityBasedSinglePointCrossover(random, 1);
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントとしてvariantA，2つ目のバリアントとしてvariantDが選ばれているはず
     final HistoricalElement element = variant.getHistoricalElement();
-    assertThat(element).isInstanceOf(CrossoverHistoricalElement.class);
+    assertThat(element.getParents()).containsExactly(testVariants.variantA, testVariants.variantD);
 
-    final CrossoverHistoricalElement cElement = (CrossoverHistoricalElement) element;
-    assertThat(cElement.getParents()).containsExactly(insertOperationVariant, noneOperationVariant);
-    assertThat(cElement.getCrossoverPoint()).isEqualTo(2);
+    // 交叉ポイントが1なので，0はvariantAと同じ，123はvariantDと同じになっているはず
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.insertBase,
+        testVariants.insertBase, testVariants.insertBase);
   }
 
-  private List<Variant> execCrossover(final int crossoverGeneratingCount) {
-    final Base noneOperationBase = new Base(null, new NoneOperation());
-    final Base insertOperationBase = new Base(null, new InsertOperation(null));
+  @Test
+  public void test_exec2() {
 
-    final List<Base> noneBases = Arrays.asList(noneOperationBase, noneOperationBase,
-        noneOperationBase, noneOperationBase, noneOperationBase);
-    final List<Base> insertBases = Arrays.asList(insertOperationBase, insertOperationBase,
-        insertOperationBase, insertOperationBase, insertOperationBase);
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(false);
+    when(random.nextInt(anyInt())).thenReturn(2);
 
-    final Variant noneOperationVariant =
-        new Variant(0, 0, new Gene(noneBases), null, null, null, null, null);
-    final Variant insertOperationVariant =
-        new Variant(0, 0, new Gene(insertBases), null, null, null, null, null);
-    final VariantStore variantStore =
-        makeVariantStore(noneOperationVariant, insertOperationVariant);
+    // バリアントの生成
+    final Crossover crossover = new GeneSimilarityBasedSinglePointCrossover(random, 1);
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
 
-    final SinglePointCrossover singlePointCrossover =
-        new GeneSimilarityBasedSinglePointCrossover(random, crossoverGeneratingCount);
-    return singlePointCrossover.exec(variantStore);
-  }
+    // 1つ目のバリアントとしてvariantC，2つ目のバリアントとしてvariantAが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantC, testVariants.variantA);
 
-  private VariantStore makeVariantStore(final Variant noneOperationVariant,
-      final Variant insertOperationVariant) {
-    final VariantStore variantStore = Mockito.mock(VariantStore.class);
-    when(variantStore.getCurrentVariants())
-        .thenReturn(Arrays.asList(noneOperationVariant, insertOperationVariant));
-    when(variantStore.createVariant(any(), any())).thenAnswer(invocation -> {
-      final Gene gene = invocation.getArgument(0);
-      final HistoricalElement element = invocation.getArgument(1);
-      return new Variant(0, 0, gene, null, null, null, null, element);
-    });
-    return variantStore;
-  }
-
-  private boolean containNoneOperationAndInsertOperation(final Gene gene) {
-    final List<Operation> operations = gene.getBases()
-        .stream()
-        .map(Base::getOperation)
-        .collect(Collectors.toList());
-
-    final boolean containNoneOperation = operations.stream()
-        .anyMatch(e -> e instanceof NoneOperation);
-    final boolean containInsertOperation = operations.stream()
-        .anyMatch(e -> e instanceof InsertOperation);
-
-    return containNoneOperation && containInsertOperation;
+    // 交叉ポイントは3なので，012はvariantCと同じ，3はvariantAと同じになっているはず
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.insertBase,
+        testVariants.insertBase, testVariants.noneBase);
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedUniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedUniformCrossoverTest.java
@@ -1,0 +1,70 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import java.util.List;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import jp.kusumotolab.kgenprog.ga.variant.Gene;
+import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public class GeneSimilarityBasedUniformCrossoverTest {
+
+
+  private static CrossoverTestVariants testVariants;
+
+  @Before
+  public void setup() {
+    testVariants = new CrossoverTestVariants();
+  }
+
+  @Test
+  public void test_exec1() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(0);
+
+    // バリアントの生成
+    final UniformCrossover crossover = new GeneSimilarityBasedUniformCrossover(random, 1);
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントとしてvariantA，2つ目のバリアントとしてvariantDが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantA, testVariants.variantD);
+
+    // 生成されたバリアントのGeneはvariantAと同じになっているはず
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
+        testVariants.noneBase, testVariants.noneBase);
+  }
+
+  @Test
+  public void test_exec2() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(false);
+    when(random.nextInt(anyInt())).thenReturn(2);
+
+    // バリアントの生成
+    final UniformCrossover crossover = new GeneSimilarityBasedUniformCrossover(random, 1);
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントとしてvariantC，2つ目のバリアントとしてvariantAが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantC, testVariants.variantA);
+
+    // 生成されたバリアントのGeneはvariantAと同じになっているはず
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
+        testVariants.noneBase, testVariants.noneBase);
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedUniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedUniformCrossoverTest.java
@@ -23,7 +23,7 @@ public class GeneSimilarityBasedUniformCrossoverTest {
   }
 
   @Test
-  public void test_exec1() {
+  public void test01() {
 
     // 生成するバリアントを制御するための疑似乱数
     final Random random = Mockito.mock(Random.class);
@@ -46,7 +46,7 @@ public class GeneSimilarityBasedUniformCrossoverTest {
   }
 
   @Test
-  public void test_exec2() {
+  public void test02() {
 
     // 生成するバリアントを制御するための疑似乱数
     final Random random = Mockito.mock(Random.class);

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedUniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedUniformCrossoverTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Random;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.variant.Gene;
@@ -13,14 +12,6 @@ import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public class GeneSimilarityBasedUniformCrossoverTest {
-
-
-  private static CrossoverTestVariants testVariants;
-
-  @Before
-  public void setup() {
-    testVariants = new CrossoverTestVariants();
-  }
 
   @Test
   public void test01() {
@@ -32,6 +23,7 @@ public class GeneSimilarityBasedUniformCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new GeneSimilarityBasedUniformCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 
@@ -55,6 +47,7 @@ public class GeneSimilarityBasedUniformCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new GeneSimilarityBasedUniformCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedUniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedUniformCrossoverTest.java
@@ -31,7 +31,7 @@ public class GeneSimilarityBasedUniformCrossoverTest {
     when(random.nextInt(anyInt())).thenReturn(0);
 
     // バリアントの生成
-    final UniformCrossover crossover = new GeneSimilarityBasedUniformCrossover(random, 1);
+    final Crossover crossover = new GeneSimilarityBasedUniformCrossover(random, 1);
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 
@@ -54,7 +54,7 @@ public class GeneSimilarityBasedUniformCrossoverTest {
     when(random.nextInt(anyInt())).thenReturn(2);
 
     // バリアントの生成
-    final UniformCrossover crossover = new GeneSimilarityBasedUniformCrossover(random, 1);
+    final Crossover crossover = new GeneSimilarityBasedUniformCrossover(random, 1);
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedSinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedSinglePointCrossoverTest.java
@@ -39,7 +39,7 @@ public class TestSimilarityBasedSinglePointCrossoverTest {
     final HistoricalElement element = variant.getHistoricalElement();
     assertThat(element.getParents()).containsExactly(testVariants.variantA, testVariants.variantB);
 
-    // 交叉ポイントは0なので，生成されたバリアントのGeneはvariantBと同じになっているはず
+    // 交叉ポイントは1なので，0はvariantAと同じ，123はvariantBと同じになっているはず
     final Gene gene = variant.getGene();
     assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
         testVariants.noneBase, testVariants.insertBase);
@@ -62,7 +62,7 @@ public class TestSimilarityBasedSinglePointCrossoverTest {
     final HistoricalElement element = variant.getHistoricalElement();
     assertThat(element.getParents()).containsExactly(testVariants.variantC, testVariants.variantD);
 
-    // 交叉ポイントは2なので，0と1はvariantCと同じ，2と3はvarriantDと同じ担っているはず
+    // 交叉ポイントは3なので，012はvariantCと同じ，3はvarriantDと同じになっているはず
     final Gene gene = variant.getGene();
     assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.insertBase,
         testVariants.insertBase, testVariants.insertBase);

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedSinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedSinglePointCrossoverTest.java
@@ -10,16 +10,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
-import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
-import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 public class TestSimilarityBasedSinglePointCrossoverTest {
 
   private static Random random;
-  private static Variant variantA;
-  private static Variant variantB;
-  private static Variant variantC;
-  private static Variant variantD;
+  private static CrossoverTestVariants testVariants;
 
   @Before
   public void setup() {
@@ -27,50 +22,19 @@ public class TestSimilarityBasedSinglePointCrossoverTest {
     when(random.nextBoolean()).thenReturn(false);
     when(random.nextInt(anyInt())).thenReturn(1);
 
-    // 10のテストケースが存在すると仮定する．
-    // testResultsA は奇数番目のテストを失敗する
-    // testResultsB は偶数番目のテストを失敗する
-    // TestResultsC は1〜6のテストを失敗する
-    // TestResultsD は5〜10のテストを失敗する
-    final TestResults testResultsA = Mockito.mock(TestResults.class);
-    when(testResultsA.getFailedTestFQNs())
-        .thenReturn(Arrays.asList(new TestFullyQualifiedName("Test1"),
-            new TestFullyQualifiedName("Test3"), new TestFullyQualifiedName("Test5"),
-            new TestFullyQualifiedName("Test7"), new TestFullyQualifiedName("Test9")));
-    final TestResults testResultsB = Mockito.mock(TestResults.class);
-    when(testResultsB.getFailedTestFQNs())
-        .thenReturn(Arrays.asList(new TestFullyQualifiedName("Test2"),
-            new TestFullyQualifiedName("Test4"), new TestFullyQualifiedName("Test6"),
-            new TestFullyQualifiedName("Test8"), new TestFullyQualifiedName("Test10")));
-    final TestResults testResultsC = Mockito.mock(TestResults.class);
-    when(testResultsC.getFailedTestFQNs()).thenReturn(
-        Arrays.asList(new TestFullyQualifiedName("Test1"), new TestFullyQualifiedName("Test2"),
-            new TestFullyQualifiedName("Test3"), new TestFullyQualifiedName("Test4"),
-            new TestFullyQualifiedName("Test5"), new TestFullyQualifiedName("Test6")));
-    final TestResults testResultsD = Mockito.mock(TestResults.class);
-    when(testResultsD.getFailedTestFQNs()).thenReturn(
-        Arrays.asList(new TestFullyQualifiedName("Test5"), new TestFullyQualifiedName("Test6"),
-            new TestFullyQualifiedName("Test7"), new TestFullyQualifiedName("Test8"),
-            new TestFullyQualifiedName("Test9"), new TestFullyQualifiedName("Test10")));
-    variantA = Mockito.mock(Variant.class);
-    when(variantA.getTestResults()).thenReturn(testResultsA);
-    variantB = Mockito.mock(Variant.class);
-    when(variantB.getTestResults()).thenReturn(testResultsB);
-    variantC = Mockito.mock(Variant.class);
-    when(variantC.getTestResults()).thenReturn(testResultsC);
-    variantD = Mockito.mock(Variant.class);
-    when(variantD.getTestResults()).thenReturn(testResultsD);
+    testVariants = new CrossoverTestVariants();
   }
 
   @Test
   public void test_selectSecondVariant() {
     final SinglePointCrossover crossover = new TestSimilarityBasedSinglePointCrossover(random, 1);
-    List<Variant> variants = Arrays.asList(variantA, variantB, variantC, variantD);
+    List<Variant> variants = Arrays.asList(testVariants.variantA, testVariants.variantB,
+        testVariants.variantC, testVariants.variantD);
 
-    final Variant variant1 = crossover.selectSecondVariant(variants, variantA);
-    assertThat(variant1).isEqualTo(variantB);
+    final Variant variant1 = crossover.selectSecondVariant(variants, testVariants.variantA);
+    assertThat(variant1).isEqualTo(testVariants.variantB);
 
-    final Variant variant2 = crossover.selectSecondVariant(variants, variantC);
-    assertThat(variant2).isEqualTo(variantD);
+    final Variant variant2 = crossover.selectSecondVariant(variants, testVariants.variantC);
+    assertThat(variant2).isEqualTo(testVariants.variantD);
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedSinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedSinglePointCrossoverTest.java
@@ -3,38 +3,68 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import jp.kusumotolab.kgenprog.ga.variant.Gene;
+import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public class TestSimilarityBasedSinglePointCrossoverTest {
 
-  private static Random random;
+
   private static CrossoverTestVariants testVariants;
 
   @Before
   public void setup() {
-    random = Mockito.mock(Random.class);
-    when(random.nextBoolean()).thenReturn(false);
-    when(random.nextInt(anyInt())).thenReturn(1);
-
     testVariants = new CrossoverTestVariants();
   }
 
   @Test
-  public void test_selectSecondVariant() {
-    final SinglePointCrossover crossover = new TestSimilarityBasedSinglePointCrossover(random, 1);
-    List<Variant> variants = Arrays.asList(testVariants.variantA, testVariants.variantB,
-        testVariants.variantC, testVariants.variantD);
+  public void test_exec1() {
 
-    final Variant variant1 = crossover.selectSecondVariant(variants, testVariants.variantA);
-    assertThat(variant1).isEqualTo(testVariants.variantB);
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(0);
 
-    final Variant variant2 = crossover.selectSecondVariant(variants, testVariants.variantC);
-    assertThat(variant2).isEqualTo(testVariants.variantD);
+    // バリアントの生成
+    final Crossover crossover = new TestSimilarityBasedSinglePointCrossover(random, 1);
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントとしてvariantA，2つ目のバリアントとしてvariantBが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantA, testVariants.variantB);
+
+    // 交叉ポイントは0なので，生成されたバリアントのGeneはvariantBと同じになっているはず
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
+        testVariants.noneBase, testVariants.insertBase);
+  }
+
+  @Test
+  public void test_exec2() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(false);
+    when(random.nextInt(anyInt())).thenReturn(2);
+
+    // バリアントの生成
+    final Crossover crossover = new TestSimilarityBasedSinglePointCrossover(random, 1);
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントとしてvariantC，2つ目のバリアントとしてvariantDが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantC, testVariants.variantD);
+
+    // 交叉ポイントは2なので，0と1はvariantCと同じ，2と3はvarriantDと同じ担っているはず
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.insertBase,
+        testVariants.insertBase, testVariants.insertBase);
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedSinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedSinglePointCrossoverTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Random;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.variant.Gene;
@@ -13,14 +12,6 @@ import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public class TestSimilarityBasedSinglePointCrossoverTest {
-
-
-  private static CrossoverTestVariants testVariants;
-
-  @Before
-  public void setup() {
-    testVariants = new CrossoverTestVariants();
-  }
 
   @Test
   public void test01() {
@@ -32,6 +23,7 @@ public class TestSimilarityBasedSinglePointCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new TestSimilarityBasedSinglePointCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 
@@ -55,6 +47,7 @@ public class TestSimilarityBasedSinglePointCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new TestSimilarityBasedSinglePointCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedSinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedSinglePointCrossoverTest.java
@@ -23,7 +23,7 @@ public class TestSimilarityBasedSinglePointCrossoverTest {
   }
 
   @Test
-  public void test_exec1() {
+  public void test01() {
 
     // 生成するバリアントを制御するための疑似乱数
     final Random random = Mockito.mock(Random.class);
@@ -46,7 +46,7 @@ public class TestSimilarityBasedSinglePointCrossoverTest {
   }
 
   @Test
-  public void test_exec2() {
+  public void test02() {
 
     // 生成するバリアントを制御するための疑似乱数
     final Random random = Mockito.mock(Random.class);

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossoverTest.java
@@ -30,7 +30,7 @@ public class TestSimilarityBasedUniformCrossoverTest {
     when(random.nextInt(anyInt())).thenReturn(0);
 
     // バリアントの生成
-    final UniformCrossover crossover = new TestSimilarityBasedUniformCrossover(random, 1);
+    final Crossover crossover = new TestSimilarityBasedUniformCrossover(random, 1);
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 
@@ -53,7 +53,7 @@ public class TestSimilarityBasedUniformCrossoverTest {
     when(random.nextInt(anyInt())).thenReturn(2);
 
     // バリアントの生成
-    final UniformCrossover crossover = new TestSimilarityBasedUniformCrossover(random, 1);
+    final Crossover crossover = new TestSimilarityBasedUniformCrossover(random, 1);
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossoverTest.java
@@ -1,0 +1,69 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import java.util.List;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import jp.kusumotolab.kgenprog.ga.variant.Gene;
+import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public class TestSimilarityBasedUniformCrossoverTest {
+
+  private static CrossoverTestVariants testVariants;
+
+  @Before
+  public void setup() {
+    testVariants = new CrossoverTestVariants();
+  }
+
+  @Test
+  public void test_exec1() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(0);
+
+    // バリアントの生成
+    final UniformCrossover crossover = new TestSimilarityBasedUniformCrossover(random, 1);
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントとしてvariantA，2つ目のバリアントとしてvariantBが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantA, testVariants.variantB);
+
+    // 生成されたバリアントのGeneはvariantAと同じになっているはず
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
+        testVariants.noneBase, testVariants.noneBase);
+  }
+
+  @Test
+  public void test_exec2() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(false);
+    when(random.nextInt(anyInt())).thenReturn(2);
+
+    // バリアントの生成
+    final UniformCrossover crossover = new TestSimilarityBasedUniformCrossover(random, 1);
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントとしてvariantC，2つ目のバリアントとしてvariantDが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantC, testVariants.variantD);
+
+    // 生成されたバリアントのGeneはvariantDと同じになっているはず
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.insertBase, testVariants.insertBase,
+        testVariants.insertBase, testVariants.insertBase);
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossoverTest.java
@@ -22,7 +22,7 @@ public class TestSimilarityBasedUniformCrossoverTest {
   }
 
   @Test
-  public void test_exec1() {
+  public void test01() {
 
     // 生成するバリアントを制御するための疑似乱数
     final Random random = Mockito.mock(Random.class);
@@ -45,7 +45,7 @@ public class TestSimilarityBasedUniformCrossoverTest {
   }
 
   @Test
-  public void test_exec2() {
+  public void test02() {
 
     // 生成するバリアントを制御するための疑似乱数
     final Random random = Mockito.mock(Random.class);

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedUniformCrossoverTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Random;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.variant.Gene;
@@ -13,13 +12,6 @@ import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public class TestSimilarityBasedUniformCrossoverTest {
-
-  private static CrossoverTestVariants testVariants;
-
-  @Before
-  public void setup() {
-    testVariants = new CrossoverTestVariants();
-  }
 
   @Test
   public void test01() {
@@ -31,6 +23,7 @@ public class TestSimilarityBasedUniformCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new TestSimilarityBasedUniformCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 
@@ -54,6 +47,7 @@ public class TestSimilarityBasedUniformCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new TestSimilarityBasedUniformCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -21,9 +21,6 @@ import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
 
 public class UniformCrossoverTest {
 
-
-  private static Random random;
-
   private static Base noneOperationBase;
   private static Base insertOperationBase;
   private static Variant noneOperationVariant;
@@ -32,10 +29,6 @@ public class UniformCrossoverTest {
 
   @Before
   public void setup() {
-    random = Mockito.mock(Random.class);
-    when(random.nextBoolean()).thenReturn(false);
-    when(random.nextInt(anyInt())).thenReturn(1);
-
     noneOperationBase = new Base(null, new NoneOperation());
     insertOperationBase = new Base(null, new InsertOperation(null));
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -1,0 +1,165 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import jp.kusumotolab.kgenprog.ga.variant.Base;
+import jp.kusumotolab.kgenprog.ga.variant.Gene;
+import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.UniformCrossoverHistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
+import jp.kusumotolab.kgenprog.project.NoneOperation;
+import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
+
+public class UniformCrossoverTest {
+
+
+  private static Random random;
+
+  private static Base noneOperationBase;
+  private static Base insertOperationBase;
+  private static Variant noneOperationVariant;
+  private static Variant insertOperationVariant;
+  private static VariantStore variantStore;
+
+  @Before
+  public void setup() {
+    random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(false);
+    when(random.nextInt(anyInt())).thenReturn(1);
+
+    noneOperationBase = new Base(null, new NoneOperation());
+    insertOperationBase = new Base(null, new InsertOperation(null));
+
+    final List<Base> noneBases =
+        Arrays.asList(noneOperationBase, noneOperationBase, noneOperationBase, noneOperationBase);
+    final List<Base> insertBases = Arrays.asList(insertOperationBase, insertOperationBase,
+        insertOperationBase, insertOperationBase);
+
+    noneOperationVariant = new Variant(0, 0, new Gene(noneBases), null, null, null, null, null);
+    insertOperationVariant = new Variant(0, 0, new Gene(insertBases), null, null, null, null, null);
+    variantStore = makeVariantStore(noneOperationVariant, insertOperationVariant);
+  }
+
+  private VariantStore makeVariantStore(final Variant noneOperationVariant,
+      final Variant insertOperationVariant) {
+    final VariantStore variantStore = Mockito.mock(VariantStore.class);
+    when(variantStore.getCurrentVariants())
+        .thenReturn(Arrays.asList(noneOperationVariant, insertOperationVariant));
+    when(variantStore.createVariant(any(), any())).thenAnswer(invocation -> {
+      final Gene gene = invocation.getArgument(0);
+      final HistoricalElement element = invocation.getArgument(1);
+      return new Variant(0, 0, gene, null, null, null, null, element);
+    });
+    return variantStore;
+  }
+
+  @Test
+  public void testGeneratingVariantsSize() {
+
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(0);
+
+    List<Variant> variants = execCrossover(random, 10);
+    assertThat(variants).hasSize(10);
+
+    variants = execCrossover(random, 13);
+    assertThat(variants).hasSize(13);
+  }
+
+  @Test
+  public void testVariants() {
+
+    final Random random = Mockito.mock(Random.class);
+
+    // 常に一つ目のバリアントのBaseを返すはず
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(0)
+        .thenReturn(1);
+    final Variant variant1 = execCrossover(random, 1).get(0);
+    assertThat(variant1.getGene()
+        .getBases()
+        .toArray(new Base[0])).containsExactly(noneOperationBase, noneOperationBase,
+            noneOperationBase, noneOperationBase);
+
+    // 常に二つ目のバリアントのBaseを返すはず
+    when(random.nextBoolean()).thenReturn(false);
+    when(random.nextInt(anyInt())).thenReturn(0)
+        .thenReturn(1);
+    final Variant variant2 = execCrossover(random, 1).get(0);
+    assertThat(variant2.getGene()
+        .getBases()
+        .toArray(new Base[0])).containsExactly(insertOperationBase, insertOperationBase,
+            insertOperationBase, insertOperationBase);
+
+    // 一つ目と二つ目のバリアントのBaseを口語に返すはず
+    when(random.nextBoolean()).thenReturn(true)
+        .thenReturn(false)
+        .thenReturn(true)
+        .thenReturn(false);
+    when(random.nextInt(anyInt())).thenReturn(0)
+        .thenReturn(1);
+    final Variant variant3 = execCrossover(random, 1).get(0);
+    assertThat(variant3.getGene()
+        .getBases())
+            .isEqualTo(Arrays.asList(noneOperationBase, insertOperationBase, noneOperationBase,
+                insertOperationBase));
+  }
+
+  @Test
+  public void testHistoricalElements() {
+
+    final Random random = Mockito.mock(Random.class);
+
+    // nonOperationVariantを2つの親として持つバリアントを生成
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(0); // noneOperationVariantを親として選ぶモック
+    final Variant variant1 = execCrossover(random, 1).get(0);
+    final HistoricalElement element1 = variant1.getHistoricalElement();
+    assertThat(element1).isInstanceOf(UniformCrossoverHistoricalElement.class);
+    final UniformCrossoverHistoricalElement uElement1 =
+        (UniformCrossoverHistoricalElement) element1;
+    assertThat(uElement1.getParents()).containsExactly(noneOperationVariant, noneOperationVariant);
+
+    // insertOperationVariantを2つの親として持つバリアントを生成
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(1); // insertOperationVariantを親として選ぶモック
+    final Variant variant2 = execCrossover(random, 1).get(0);
+    final HistoricalElement element2 = variant2.getHistoricalElement();
+    assertThat(element2).isInstanceOf(UniformCrossoverHistoricalElement.class);
+    final UniformCrossoverHistoricalElement uElement2 =
+        (UniformCrossoverHistoricalElement) element2;
+    assertThat(uElement2.getParents()).containsExactly(insertOperationVariant,
+        insertOperationVariant);
+
+    // noneOperationVariantとinsertOperationVariantを2つの親として持つバリアントを生成
+    when(random.nextBoolean()).thenReturn(true)
+        .thenReturn(false)
+        .thenReturn(true)
+        .thenReturn(false);
+    when(random.nextInt(anyInt())).thenReturn(0) // 一つ目の親としてnoneOperationVariantを選ぶ
+        .thenReturn(1); // 二つ目の親としてinsertOperationVariantを親として選ぶ
+    final Variant variant3 = execCrossover(random, 1).get(0);
+    final HistoricalElement element3 = variant3.getHistoricalElement();
+    assertThat(element3).isInstanceOf(UniformCrossoverHistoricalElement.class);
+    final UniformCrossoverHistoricalElement uElement3 =
+        (UniformCrossoverHistoricalElement) element3;
+    assertThat(uElement3.getParents()).containsExactly(noneOperationVariant,
+        insertOperationVariant);
+  }
+
+  private List<Variant> execCrossover(final Random random, final int crossoverGeneratingCount) {
+    final UniformCrossover crossover = new UniformCrossover(random, crossoverGeneratingCount);
+    return crossover.exec(variantStore);
+  }
+
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -101,7 +101,7 @@ public class UniformCrossoverTest {
         .toArray(new Base[0])).containsExactly(insertOperationBase, insertOperationBase,
             insertOperationBase, insertOperationBase);
 
-    // 一つ目と二つ目のバリアントのBaseを口語に返すはず
+    // 一つ目と二つ目のバリアントのBaseを交互に返すはず
     when(random.nextBoolean()).thenReturn(true)
         .thenReturn(false)
         .thenReturn(true)

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -80,9 +80,8 @@ public class UniformCrossoverTest {
         .thenReturn(1);
     final Variant variant1 = execCrossover(random, 1).get(0);
     assertThat(variant1.getGene()
-        .getBases()
-        .toArray(new Base[0])).containsExactly(noneOperationBase, noneOperationBase,
-            noneOperationBase, noneOperationBase);
+        .getBases()).containsExactly(noneOperationBase, noneOperationBase, noneOperationBase,
+            noneOperationBase);
 
     // 常に二つ目のバリアントのBaseを返すはず
     when(random.nextBoolean()).thenReturn(false);
@@ -90,9 +89,8 @@ public class UniformCrossoverTest {
         .thenReturn(1);
     final Variant variant2 = execCrossover(random, 1).get(0);
     assertThat(variant2.getGene()
-        .getBases()
-        .toArray(new Base[0])).containsExactly(insertOperationBase, insertOperationBase,
-            insertOperationBase, insertOperationBase);
+        .getBases()).containsExactly(insertOperationBase, insertOperationBase, insertOperationBase,
+            insertOperationBase);
 
     // 一つ目と二つ目のバリアントのBaseを交互に返すはず
     when(random.nextBoolean()).thenReturn(true)


### PR DESCRIPTION
一様交叉処理の追加をしました．
具体的には以下の3つ．
UniformCrossover：一つ目の親と二つ目の親をどちらもランダムに選び一様交叉を行う．
GeneSimilarityBasedUniformCrossover：一つ目の親をランダムに選び，二つ目の親は一つ目の親と最もGeneの類似度が低いものを選び一様交叉を行う
TestSimilarityBasedUniformCrossover：一つ目の親をランダムに選び，二つ目の親は一つ目の親と最もテストの実行結果が異なるものを選び一様交叉を行う．

現時点で，SinglePointCrossoverとUniformCrossover以下のクラス階層が酷似しています．
このあと，RandomCrossoverも実装し，そのあと，Crossover以下のクラス階層のリファクタリングを行いますので，とりあえず現段階としては，UniformCrossover以下のレビューをお願いします．