### PR TITLE
[CI] リリースした Assets にゴミが含まれるのを修正

### DIFF
--- a/.circleci/check-version.sh
+++ b/.circleci/check-version.sh
@@ -7,7 +7,7 @@ GITHUB_TAG_URL_BASE="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJ
 
 # Analyze target version to be release
 
-WANTED_VERSION="$(cat ./artifacts/current-version.txt)"
+WANTED_VERSION="$(cat ./workspace/current-version.txt)"
 WANTED_VERSION="$(echo $WANTED_VERSION)" # Trim whitespaces
 
 VERSION_GIT_TAG="v${WANTED_VERSION}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,11 +66,11 @@ jobs:
       - run:
           name: Collect artifacts to be released
           command: |
-            mkdir artifacts
-            cp ./build/libs/* ./artifacts/
-            cp current-version.txt ./artifacts/
+            mkdir -p workspace/artifacts
+            cp ./build/libs/* ./workspace/artifacts/
+            cp current-version.txt ./workspace/
       - persist_to_workspace:
-          root: ./artifacts
+          root: ./workspace
           paths:
             - .
 
@@ -93,7 +93,7 @@ jobs:
             git config user.email "ci@circleci.com"
             git config user.name "CircleCI"
       - attach_workspace:
-          at: ./artifacts
+          at: ./workspace
       # ===== Delete the existing nightly-build release
       - github-release/delete:
           tag: nightly-build
@@ -103,7 +103,7 @@ jobs:
       # ===== Rename a jar file
       - run:
           name: Rename jar file
-          command: mv ./artifacts/kGenProg*.jar ./artifacts/kGenProg-nightly-build.jar
+          command: mv ./workspace/artifacts/kGenProg*.jar ./workspace/artifacts/kGenProg-nightly-build.jar
       # ===== Publish a new nightly-build release
       - github-release/create:
           tag: nightly-build
@@ -115,7 +115,7 @@ jobs:
             \`\`\`
             $ curl -LO https://github.com/kusumotolab/kGenProg/releases/download/nightly-build/kGenProg-nightly-build.jar
             \`\`\`
-          file-path: ./artifacts/
+          file-path: ./workspace/artifacts/
           pre-release: true
 
   # Job: generate-change-log
@@ -126,7 +126,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: ./artifacts
+          at: ./workspace
       - run: touch CHANGELOG.md
       - run:
           name: Generate a change log when needed
@@ -144,7 +144,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: ./artifacts
+          at: ./workspace
       - run:
           name: Publish a new release when needed
           command: ./.circleci/publish-new-release.sh

--- a/.circleci/publish-new-release.sh
+++ b/.circleci/publish-new-release.sh
@@ -20,7 +20,6 @@ go get -u github.com/tcnksm/ghr
 
 echo "Starting to publish a new release as the version: ${WANTED_VERSION} ..."
 
-ls ./artifacts
 CHANGELOG="## Change Log
 
 $(cat ./artifacts/CHANGELOG.md)"

--- a/.circleci/publish-new-release.sh
+++ b/.circleci/publish-new-release.sh
@@ -22,10 +22,7 @@ echo "Starting to publish a new release as the version: ${WANTED_VERSION} ..."
 
 CHANGELOG="## Change Log
 
-$(cat ./artifacts/CHANGELOG.md)"
-
-rm ./artifacts/CHANGELOG.md
-rm ./artifacts/current-version.txt
+$(cat ./workspace/CHANGELOG.md)"
 
 ghr \
   --token $GITHUB_TOKEN \
@@ -34,4 +31,4 @@ ghr \
   --commitish $CIRCLE_SHA1 \
   --name "Version $WANTED_VERSION" \
   --body "$CHANGELOG" \
-    $VERSION_GIT_TAG ./artifacts/
+    $VERSION_GIT_TAG ./workspace/artifacts/

--- a/.circleci/publish-new-release.sh
+++ b/.circleci/publish-new-release.sh
@@ -23,7 +23,9 @@ echo "Starting to publish a new release as the version: ${WANTED_VERSION} ..."
 CHANGELOG="## Change Log
 
 $(cat ./artifacts/CHANGELOG.md)"
+
 rm ./artifacts/CHANGELOG.md
+rm ./artifacts/current-version.txt
 
 ghr \
   --token $GITHUB_TOKEN \


### PR DESCRIPTION
[GitHub Releases](https://github.com/kusumotolab/kGenProg/releases) にリリースしたアセットファイルに `current-version.txt` といったゴミ（CI 上のジョブで使用している一時ファイル）が含まれていた．

ゴミまでリリースしてしまわないように修正．