### PR TITLE
ランダム交叉の追加

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedRandomCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedRandomCrossover.java
@@ -1,0 +1,20 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import java.util.Random;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public class GeneSimilarityBasedRandomCrossover extends SimilarityBasedRandomCrossover {
+
+
+  public GeneSimilarityBasedRandomCrossover(final Random random,
+      final int crossoverGeneratingCount) {
+    super(random, crossoverGeneratingCount);
+  }
+
+  @Override
+  protected double calculateSimilarity(final Variant variant1, final Variant variant2) {
+    return SimilarityCalculator.exec(variant1, variant2, v -> v.getGene()
+        .getBases());
+  }
+}
+

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossover.java
@@ -1,0 +1,135 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import jp.kusumotolab.kgenprog.ga.variant.Base;
+import jp.kusumotolab.kgenprog.ga.variant.Gene;
+import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.UniformCrossoverHistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
+
+/**
+ * ランダム交叉を行うクラス
+ *
+ */
+public class RandomCrossover implements Crossover {
+
+
+  private final Random random;
+  private final int crossoverGeneratingCount;
+
+  public RandomCrossover(final Random random, final int crossoverGeneraingCount) {
+    this.random = random;
+    this.crossoverGeneratingCount = crossoverGeneraingCount;
+  }
+
+  @Override
+  public List<Variant> exec(final VariantStore variantStore) {
+
+    final List<Variant> filteredVariants = variantStore.getCurrentVariants()
+        .stream()
+        .filter(e -> !e.getGene()
+            .getBases()
+            .isEmpty())
+        .collect(Collectors.toList());
+
+    // filteredVariantsの要素数が2に満たない場合は交叉しない
+    if (filteredVariants.size() < 2) {
+      return Collections.emptyList();
+    }
+
+    final List<Variant> variants = new ArrayList<>();
+
+    // crossoverGenetingCountを超えるまでバリアントを作りづづける
+    while (variants.size() < crossoverGeneratingCount) {
+      final List<Variant> newVariants = makeVariants(filteredVariants, variantStore);
+      variants.addAll(newVariants);
+    }
+
+    // バリアントを作りすぎた場合はそれを除いてリターン
+    return variants.subList(0, crossoverGeneratingCount);
+  }
+
+  private List<Variant> makeVariants(final List<Variant> variants, final VariantStore store) {
+    final Variant variantA = selectFirstVariant(variants);
+    final Variant variantB = selectSecondVariant(variants, variantA);
+    final Gene geneA = variantA.getGene();
+    final Gene geneB = variantB.getGene();
+    final List<Base> basesA = geneA.getBases();
+    final List<Base> basesB = geneB.getBases();
+    if (!canMakeVariant(basesA, basesB)) {
+      return Collections.emptyList();
+    }
+
+    final Gene newGene = makeGene(basesA, basesB);
+    final HistoricalElement newElement = new UniformCrossoverHistoricalElement(variantA, variantB);
+    return Arrays.asList(store.createVariant(newGene, newElement));
+  }
+
+  /**
+   * 一つ目のバリアントを選ぶためのメソッド．
+   * 
+   * @param variants
+   * @return
+   */
+  protected Variant selectFirstVariant(final List<Variant> variants) {
+    return variants.get(random.nextInt(variants.size()));
+  }
+
+  /**
+   * 二つ目のバリアントを選ぶためのメソッド． 一つ目に選んだバリアントの情報を利用できるように，引数で受け取る．
+   * 
+   * @param variants
+   * @return
+   */
+  protected Variant selectSecondVariant(final List<Variant> variants, final Variant firstVariant) {
+    return variants.get(random.nextInt(variants.size()));
+  }
+
+  private boolean canMakeVariant(final List<Base> basesA, final List<Base> basesB) {
+    final int sizeA = basesA.size();
+    final int sizeB = basesB.size();
+    return Math.min(sizeA, sizeB) > 2;
+  }
+
+  private Gene makeGene(final List<Base> basesA, final List<Base> basesB) {
+
+    final List<Base> concatenatedBases = Stream.concat(basesA.stream(), basesB.stream())
+        .collect(Collectors.toList());
+    final List<Base> bases = new ArrayList<>();
+
+    for (int i = 0; true; i++) {
+
+      // basesAとbasesBの短い方よりもiが小さいときは，
+      // Baseをランダムに1つ選択
+      if (i < Math.min(basesA.size(), basesB.size())) {
+        final int selectedIndex = random.nextInt(concatenatedBases.size());
+        final Base selectedBase = concatenatedBases.remove(selectedIndex);
+        bases.add(selectedBase);
+        continue;
+      }
+
+      // basesAとbasesBの長い方よりもiが小さいときは，
+      // Baseをランダムに1つ選択するかどうかランダムに決める
+      if (i < Math.max(basesA.size(), basesB.size())) {
+        if (random.nextBoolean()) {
+          final int selectedIndex = random.nextInt(concatenatedBases.size());
+          final Base selectedBase = concatenatedBases.remove(selectedIndex);
+          bases.add(selectedBase);
+        }
+        continue;
+      }
+
+      // basesAとbasesBの長い方よりもiが大きくなってしまったらループを抜ける
+      break;
+    }
+
+    return new Gene(bases);
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SimilarityBasedRandomCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SimilarityBasedRandomCrossover.java
@@ -1,0 +1,31 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import java.util.List;
+import java.util.Random;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public abstract class SimilarityBasedRandomCrossover extends RandomCrossover {
+
+
+  public SimilarityBasedRandomCrossover(final Random random, final int crossoverGenerationCount) {
+    super(random, crossoverGenerationCount);
+  }
+
+  @Override
+  public Variant selectSecondVariant(final List<Variant> variants, final Variant firstVariant) {
+    double minSimilarity = 1.0d;
+    Variant secondVariant = firstVariant;
+
+    for (final Variant variant : variants) {
+      final double similarity = calculateSimilarity(firstVariant, variant);
+      if (similarity < minSimilarity) {
+        minSimilarity = similarity;
+        secondVariant = variant;
+      }
+    }
+
+    return secondVariant;
+  }
+
+  protected abstract double calculateSimilarity(final Variant variant1, final Variant variant2);
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedRandomCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedRandomCrossover.java
@@ -1,0 +1,19 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import java.util.Random;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public class TestSimilarityBasedRandomCrossover extends SimilarityBasedRandomCrossover {
+
+
+  public TestSimilarityBasedRandomCrossover(final Random random,
+      final int crossoverGeneratingCount) {
+    super(random, crossoverGeneratingCount);
+  }
+
+  @Override
+  protected double calculateSimilarity(final Variant variant1, final Variant variant2) {
+    return SimilarityCalculator.exec(variant1, variant2, v -> v.getTestResults()
+        .getFailedTestFQNs());
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedRandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/GeneSimilarityBasedRandomCrossoverTest.java
@@ -1,0 +1,63 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import java.util.List;
+import java.util.Random;
+import org.junit.Test;
+import org.mockito.Mockito;
+import jp.kusumotolab.kgenprog.ga.variant.Gene;
+import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public class GeneSimilarityBasedRandomCrossoverTest {
+
+  @Test
+  public void test01() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(0);
+
+    // バリアントの生成
+    final Crossover crossover = new GeneSimilarityBasedRandomCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントはvariantA，2つ目のバリアントはvariantDが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantA, testVariants.variantD);
+
+    // 常に0番目のBaseを取得するはず．つまり，すべてnoneBaseになっているはず．
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
+        testVariants.noneBase, testVariants.noneBase);
+  }
+
+  @Test
+  public void test02() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(2);
+
+    // バリアントの生成
+    final Crossover crossover = new GeneSimilarityBasedRandomCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントはvariantC，2つ目のバリアントはvariantAが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantC, testVariants.variantA);
+
+    // 常に3番目のBaseを取得するはず．つまり，insert, insert, none, noneになっているはず．
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.insertBase, testVariants.insertBase,
+        testVariants.noneBase, testVariants.noneBase);
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
@@ -1,0 +1,67 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import java.util.List;
+import java.util.Random;
+import org.junit.Test;
+import org.mockito.Mockito;
+import jp.kusumotolab.kgenprog.ga.variant.Gene;
+import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public class RandomCrossoverTest {
+
+  @Test
+  public void test01() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(0)
+        .thenReturn(1)
+        .thenReturn(2);
+
+    // バリアントの生成
+    final Crossover crossover = new RandomCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントはvariantA，2つ目のバリアントはvariantBが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantA, testVariants.variantB);
+
+    // 常に2番目のBaseを取得するはず．つまり，すべてnoneBaseになっているはず．
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
+        testVariants.noneBase, testVariants.noneBase);
+  }
+
+  @Test
+  public void test02() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(1)
+        .thenReturn(2)
+        .thenReturn(3);
+
+    // バリアントの生成
+    final Crossover crossover = new RandomCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントはvariantB，2つ目のバリアントはvariantCが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantB, testVariants.variantC);
+
+    // 常に3番目のBaseを取得するはず．つまり，insert, none, insert, insertになっているはず．
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.insertBase, testVariants.noneBase,
+        testVariants.insertBase, testVariants.insertBase);
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedRandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/TestSimilarityBasedRandomCrossoverTest.java
@@ -1,0 +1,63 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import java.util.List;
+import java.util.Random;
+import org.junit.Test;
+import org.mockito.Mockito;
+import jp.kusumotolab.kgenprog.ga.variant.Gene;
+import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public class TestSimilarityBasedRandomCrossoverTest {
+
+  @Test
+  public void test01() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(0);
+
+    // バリアントの生成
+    final Crossover crossover = new TestSimilarityBasedRandomCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントはvariantA，2つ目のバリアントはvariantBが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantA, testVariants.variantB);
+
+    // 常に0番目のBaseを取得するはず．つまり，すべてnoneBaseになっているはず．
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
+        testVariants.noneBase, testVariants.noneBase);
+  }
+
+  @Test
+  public void test02() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(2);
+
+    // バリアントの生成
+    final Crossover crossover = new TestSimilarityBasedRandomCrossover(random, 1);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // 1つ目のバリアントはvariantC，2つ目のバリアントはvariantDが選ばれているはず
+    final HistoricalElement element = variant.getHistoricalElement();
+    assertThat(element.getParents()).containsExactly(testVariants.variantC, testVariants.variantD);
+
+    // 常に3番目のBaseを取得するはず．つまり，insert, insert, insert, insertになっているはず．
+    final Gene gene = variant.getGene();
+    assertThat(gene.getBases()).containsExactly(testVariants.insertBase, testVariants.insertBase,
+        testVariants.insertBase, testVariants.insertBase);
+  }
+}


### PR DESCRIPTION
2つのバリアントをランダムに選ぶRandomCrossover，テスト結果の類似度に基づいて選ぶTestSimilarityBasedRandomCrossover, 遺伝子の類似度に基づいて選ぶGeneSimilarityBasedRandomCrossoverを追加．

このPRマージ後に，交叉クラス群のリファクタリングをします．