### PR TITLE
Baseのシリアライザを追加

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/output/BaseSerializer.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/BaseSerializer.java
@@ -18,10 +18,8 @@ public class BaseSerializer implements JsonSerializer<Base> {
 
     serializedBase.addProperty("name", base.getOperation()
         .getName());
-    serializedBase.addProperty("fqn", base.getTargetLocation()
-        .getGeneratedAST()
-        .getPrimaryClassName()
-        .value);
+    serializedBase.addProperty("fileName", base.getTargetLocation()
+        .getSourcePath().path.toString());
     serializedBase.addProperty("snippet", base.getOperation()
         .getTargetSnippet());
     serializedBase.add("lineNumberRange", context.serialize(base.getTargetLocation()

--- a/src/main/java/jp/kusumotolab/kgenprog/output/BaseSerializer.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/BaseSerializer.java
@@ -1,0 +1,33 @@
+package jp.kusumotolab.kgenprog.output;
+
+import java.lang.reflect.Type;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import jp.kusumotolab.kgenprog.ga.variant.Base;
+import jp.kusumotolab.kgenprog.project.LineNumberRange;
+
+public class BaseSerializer implements JsonSerializer<Base> {
+
+  @Override
+  public JsonElement serialize(final Base base, final Type type,
+      final JsonSerializationContext context) {
+
+    final JsonObject serializedBase = new JsonObject();
+
+    serializedBase.addProperty("name", base.getOperation()
+        .getName());
+    serializedBase.addProperty("fqn", base.getTargetLocation()
+        .getGeneratedAST()
+        .getPrimaryClassName()
+        .value);
+    serializedBase.addProperty("snippet", base.getOperation()
+        .getTargetSnippet());
+    serializedBase.add("lineNumberRange", context.serialize(base.getTargetLocation()
+            .inferLineNumbers(),
+        LineNumberRange.class));
+
+    return serializedBase;
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/output/BaseSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/BaseSerializerTest.java
@@ -1,0 +1,186 @@
+package jp.kusumotolab.kgenprog.output;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.junit.Before;
+import org.junit.Test;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import jp.kusumotolab.kgenprog.ga.variant.Base;
+import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.project.ProductSourcePath;
+import jp.kusumotolab.kgenprog.project.factory.TargetProject;
+import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
+import jp.kusumotolab.kgenprog.project.jdt.DeleteOperation;
+import jp.kusumotolab.kgenprog.project.jdt.GeneratedJDTAST;
+import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
+import jp.kusumotolab.kgenprog.project.jdt.JDTASTLocation;
+import jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation;
+import jp.kusumotolab.kgenprog.testutil.ExampleAlias.Src;
+import jp.kusumotolab.kgenprog.testutil.JsonKeyAlias;
+import jp.kusumotolab.kgenprog.testutil.TestUtil;
+
+public class BaseSerializerTest {
+
+  private Gson gson;
+
+  @Before
+  public void setup() {
+    gson = new GsonBuilder()
+        .registerTypeHierarchyAdapter(Base.class, new BaseSerializer())
+        .create();
+  }
+
+  @Test
+  public void testBase01() {
+    final Path basePath = Paths.get("example/BuildSuccess01");
+    final TargetProject project = TargetProjectFactory.create(basePath);
+    final GeneratedSourceCode originalSourceCode = TestUtil.createGeneratedSourceCode(project);
+    final GeneratedJDTAST<ProductSourcePath> ast =
+        (GeneratedJDTAST<ProductSourcePath>) originalSourceCode.getProductAsts()
+            .get(0);
+
+    // 適当な場所を削除するoperationを作る
+    final TypeDeclaration type = (TypeDeclaration) ast.getRoot()
+        .types()
+        .get(0);
+    final MethodDeclaration method = type.getMethods()[0];
+    final Statement statement = (Statement) method.getBody()
+        .statements()
+        .get(0);
+    final JDTASTLocation location =
+        new JDTASTLocation(new ProductSourcePath(basePath, Src.FOO), statement, ast);
+    final DeleteOperation operation = new DeleteOperation();
+    final Base base = new Base(location, operation);
+    final JsonObject serializedBase = gson.toJsonTree(base)
+        .getAsJsonObject();
+
+    // チェック
+    check(base, serializedBase);
+  }
+
+  @Test
+  public void testBase02() {
+    final Path basePath = Paths.get("example/BuildSuccess01");
+    final TargetProject project = TargetProjectFactory.create(basePath);
+    final GeneratedSourceCode originalSourceCode = TestUtil.createGeneratedSourceCode(project);
+    final GeneratedJDTAST<ProductSourcePath> ast =
+        (GeneratedJDTAST<ProductSourcePath>) originalSourceCode.getProductAsts()
+            .get(0);
+
+    // 適当な場所にコードを挿入するoperationを作る
+    final TypeDeclaration type = (TypeDeclaration) ast.getRoot()
+        .types()
+        .get(0);
+    final MethodDeclaration method = type.getMethods()[0];
+    final Statement statement = (Statement) method.getBody()
+        .statements()
+        .get(0);
+    final JDTASTLocation location =
+        new JDTASTLocation(new ProductSourcePath(basePath, Src.FOO), statement, ast);
+    final AST jdtAST = ast.getRoot()
+        .getAST();
+    final MethodInvocation invocation = jdtAST.newMethodInvocation();
+    invocation.setName(jdtAST.newSimpleName("a"));
+    final Statement insertStatement = jdtAST.newExpressionStatement(invocation);
+
+    final InsertOperation operation = new InsertOperation(insertStatement);
+    final Base base = new Base(location, operation);
+    final JsonObject serializedBase = gson.toJsonTree(base)
+        .getAsJsonObject();
+
+    // チェック
+    check(base, serializedBase);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testBase03() {
+    final Path basePath = Paths.get("example/BuildSuccess01/");
+    final TargetProject project = TargetProjectFactory.create(basePath);
+    final GeneratedSourceCode originalSourceCode = TestUtil.createGeneratedSourceCode(project);
+    final GeneratedJDTAST<ProductSourcePath> ast =
+        (GeneratedJDTAST<ProductSourcePath>) originalSourceCode.getProductAsts()
+            .get(0);
+
+    // 適当な場所のコードを適当なコードに置き換えるoperationを作る
+    final TypeDeclaration type = (TypeDeclaration) ast.getRoot()
+        .types()
+        .get(0);
+    final MethodDeclaration method = type.getMethods()[0];
+    Statement statement = (Statement) method.getBody()
+        .statements()
+        .get(0);
+    final JDTASTLocation location =
+        new JDTASTLocation(new ProductSourcePath(basePath, Src.FOO), statement, ast);
+    final AST jdtAST = ast.getRoot()
+        .getAST();
+    final MethodInvocation invocation = jdtAST.newMethodInvocation();
+    invocation.setName(jdtAST.newSimpleName("a"));
+    statement = jdtAST.newExpressionStatement(invocation);
+    final Block replaceBlock = jdtAST.newBlock();
+    replaceBlock.statements()
+        .add(statement);
+
+    final ReplaceOperation operation = new ReplaceOperation(replaceBlock);
+    final Base base = new Base(location, operation);
+    final JsonObject serializedBase = gson.toJsonTree(base)
+        .getAsJsonObject();
+
+    // チェック
+    check(base, serializedBase);
+  }
+
+  private void check(final Base base, final JsonObject serializedBase) {
+    // キーの存在チェック
+    assertThat(serializedBase.keySet()).containsOnly(
+        JsonKeyAlias.Base.FQN,
+        JsonKeyAlias.Base.LINE_NUMBER_RANGE,
+        JsonKeyAlias.Base.NAME,
+        JsonKeyAlias.Base.SNIPPET);
+
+    // fqnのチェック
+    final String expectFqn = base.getTargetLocation()
+        .getGeneratedAST()
+        .getPrimaryClassName().value;
+    final String serializedFqn = serializedBase.get(JsonKeyAlias.Base.FQN)
+        .getAsString();
+    assertThat(serializedFqn).isEqualTo(expectFqn);
+
+    // 行範囲のチェック
+    final JsonObject serializedLineNumberRange = serializedBase.get(
+        JsonKeyAlias.Base.LINE_NUMBER_RANGE)
+        .getAsJsonObject();
+    final int serializedLineStart = serializedLineNumberRange.get(
+        JsonKeyAlias.LineNumberRange.START)
+        .getAsInt();
+    final int serializedLineEnd = serializedLineNumberRange.get(
+        JsonKeyAlias.LineNumberRange.END)
+        .getAsInt();
+    assertThat(serializedLineStart).isEqualTo(base.getTargetLocation()
+        .inferLineNumbers().start);
+    assertThat(serializedLineEnd).isEqualTo(base.getTargetLocation()
+        .inferLineNumbers().end);
+
+    // 操作名のチェック
+    final String serializedOperationName = serializedBase.get(
+        JsonKeyAlias.Base.NAME)
+        .getAsString();
+    assertThat(serializedOperationName).isEqualTo(base.getOperation()
+        .getName());
+
+    // コード片のチェック
+    final String serializedSnippet = serializedBase.get(JsonKeyAlias.Base.SNIPPET)
+        .getAsString();
+    assertThat(serializedSnippet).isEqualTo(base.getOperation()
+        .getTargetSnippet());
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/output/BaseSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/BaseSerializerTest.java
@@ -142,16 +142,15 @@ public class BaseSerializerTest {
   private void check(final Base base, final JsonObject serializedBase) {
     // キーの存在チェック
     assertThat(serializedBase.keySet()).containsOnly(
-        JsonKeyAlias.Base.FQN,
+        JsonKeyAlias.Base.FILE_NAME,
         JsonKeyAlias.Base.LINE_NUMBER_RANGE,
         JsonKeyAlias.Base.NAME,
         JsonKeyAlias.Base.SNIPPET);
 
-    // fqnのチェック
+    // ファイル名のチェック
     final String expectFqn = base.getTargetLocation()
-        .getGeneratedAST()
-        .getPrimaryClassName().value;
-    final String serializedFqn = serializedBase.get(JsonKeyAlias.Base.FQN)
+        .getSourcePath().path.toString();
+    final String serializedFqn = serializedBase.get(JsonKeyAlias.Base.FILE_NAME)
         .getAsString();
     assertThat(serializedFqn).isEqualTo(expectFqn);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/testutil/JsonKeyAlias.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/testutil/JsonKeyAlias.java
@@ -30,6 +30,20 @@ public class JsonKeyAlias {
     public final static String TEST_SUMMARY = "testSummary";
   }
 
+  public static class Base {
+
+    public final static String FQN = "fqn";
+    public final static String NAME = "name";
+    public final static String LINE_NUMBER_RANGE = "lineNumberRange";
+    public final static String SNIPPET = "snippet";
+  }
+
+  public static class LineNumberRange {
+
+    public final static String START = "start";
+    public final static String END = "end";
+  }
+
   public static class Operation {
 
     public final static String ID = "id";

--- a/src/test/java/jp/kusumotolab/kgenprog/testutil/JsonKeyAlias.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/testutil/JsonKeyAlias.java
@@ -32,7 +32,7 @@ public class JsonKeyAlias {
 
   public static class Base {
 
-    public final static String FQN = "fqn";
+    public final static String FILE_NAME = "fileName";
     public final static String NAME = "name";
     public final static String LINE_NUMBER_RANGE = "lineNumberRange";
     public final static String SNIPPET = "snippet";


### PR DESCRIPTION
#499 を解決するために
* Baseのシリアライザを追加
* JSON構造の見直し
をしたところ巨大なPRになったので，2つのPRに分割します.

このPRがマージされた後に，JSON構造の見直しを行います

## 変更点
Baseのシリアライザを追加しました. 
このPRではシリアライズされたBaseを出力する部分を実装していません

## シリアライズされたBaseの構造
```json
{
   "name": "replace",   // 適用した操作名
   "fqn": "example.CloseToZero",   // 操作を適用したクラスのFQN
   "snippet": "n++",  // 挿入・削除・置換したコード
   "lineNumberRange": {   // コードを挿入・削除・置換した位置
     "start": 19,
     "end": 21
    }
 }
```