### PR TITLE
クラスパス比較の潜在バグを修正

### DIFF
--- a/example/BuildSuccess06/.classpath
+++ b/example/BuildSuccess06/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="lib" path="./lib/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="./lib/dummy.jar"/>
 	<classpathentry kind="output" path="classes"/>
 </classpath>

--- a/src/main/java/jp/kusumotolab/kgenprog/project/ClassPath.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/ClassPath.java
@@ -13,7 +13,7 @@ public final class ClassPath {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -24,7 +24,7 @@ public final class ClassPath {
     final ClassPath that = (ClassPath) o;
     try {
       return Files.isSameFile(path, that.path);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       return false;
     }
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/ClassPath.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/ClassPath.java
@@ -1,5 +1,7 @@
 package jp.kusumotolab.kgenprog.project;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public final class ClassPath {
@@ -12,8 +14,19 @@ public final class ClassPath {
 
   @Override
   public boolean equals(Object o) {
-    return this.toString()
-        .equals(o.toString());
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final ClassPath that = (ClassPath) o;
+    try {
+      return Files.isSameFile(path, that.path);
+    } catch (IOException e) {
+      return false;
+    }
   }
 
   @Override

--- a/src/test/java/jp/kusumotolab/kgenprog/project/factory/EclipseProjectFactoryTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/factory/EclipseProjectFactoryTest.java
@@ -12,9 +12,6 @@ import jp.kusumotolab.kgenprog.project.TestSourcePath;
 
 public class EclipseProjectFactoryTest {
 
-  private final static ClassPath JUNIT_CLASSPATH =
-      new ClassPath(Paths.get("example/BuildSuccess06/./lib/junit-4.12.jar"));
-
   @Test
   public void testCreateBySingleEclipseProject() {
     final Path rootPath = Paths.get("example/BuildSuccess06");
@@ -23,11 +20,12 @@ public class EclipseProjectFactoryTest {
 
     final ProductSourcePath foo = new ProductSourcePath(rootPath, FOO);
     final TestSourcePath fooTest = new TestSourcePath(rootPath, FOO_TEST);
+    final ClassPath cp = new ClassPath(rootPath.resolve("lib/dummy.jar"));
 
     assertThat(project.rootPath).isSameAs(rootPath);
     assertThat(project.getProductSourcePaths()).containsExactlyInAnyOrder(foo);
     assertThat(project.getTestSourcePaths()).containsExactlyInAnyOrder(fooTest);
-    assertThat(project.getClassPaths()).containsExactlyInAnyOrder(JUNIT_CLASSPATH);
+    assertThat(project.getClassPaths()).containsExactlyInAnyOrder(cp);
   }
 
 }


### PR DESCRIPTION
resolve #514

### やったこと
- クラスパス比較の潜在バグを修正
- クラスパス比較を行っていたテスト（BuildSuccess06）の軽いリファクタリング
  - CPを表すstaticフィールドをローカル変数に変更（staticである理由がないため）
  - BS06では `lib/junit.jar` を参照していた部分を，0バイトの `lib/dummy.jar` を参照するように．
ファイルの実態がないとCP比較が失敗するため．