### PR TITLE
不要になったタイムアウト差し込みクラスのテストをIgnore

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperation.java
@@ -23,9 +23,11 @@ import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.Operation;
 import jp.kusumotolab.kgenprog.project.TestSourcePath;
 
-// #507 の修正により不要になったため本クラスは @Deprecated．
-// TODO いずれ消したほうが良い．
-@Deprecated
+/**
+ * テストメソッドに対してJUnitの@Timeoutを差し込むクラス．
+ *
+ * @deprecated #507 の修正により不要になったため，本クラスは廃止
+ */
 public class InsertTimeoutRuleFieldOperation implements Operation {
 
   private static final Logger log = LoggerFactory.getLogger(InsertTimeoutRuleFieldOperation.class);

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperation.java
@@ -23,6 +23,8 @@ import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.Operation;
 import jp.kusumotolab.kgenprog.project.TestSourcePath;
 
+// #507 の修正により不要になったため本クラスは @Deprecated．
+// TODO いずれ消したほうが良い．
 @Deprecated
 public class InsertTimeoutRuleFieldOperation implements Operation {
 

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperationTest.java
@@ -3,11 +3,15 @@ package jp.kusumotolab.kgenprog.project.jdt;
 import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
 import java.nio.file.Paths;
 import java.util.Collections;
+import org.junit.Ignore;
 import org.junit.Test;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.TestSourcePath;
 
-
+// #507 の修正により不要になったため本テストは @Ignore
+// TODO いずれ消したほうが良い．
+@Ignore
+@SuppressWarnings("deprecation")
 public class InsertTimeoutRuleFieldOperationTest {
 
   @Test

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperationTest.java
@@ -8,10 +8,11 @@ import org.junit.Test;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.TestSourcePath;
 
-// #507 の修正により不要になったため本テストは @Ignore
-// TODO いずれ消したほうが良い．
+/**
+ *
+ * @deprecated #507 の修正により不要になったため，本クラスは廃止 & Ignore
+ */
 @Ignore
-@SuppressWarnings("deprecation")
 public class InsertTimeoutRuleFieldOperationTest {
 
   @Test


### PR DESCRIPTION
resolve #517 

### やったこと
- `InsertTimeoutRuleFieldOperation` の `@Deprecated` にその理由を追記．
- `InsertTimeoutRuleFieldOperationTest` に `@Ignore` 追加，その理由を併記．