### PR TITLE
build.gradle の依存解決が c-KGP で正しく行われない問題を修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,18 +21,22 @@ repositories {
     // You can declare any Maven/Ivy/file repository here.
     jcenter()
 
-    // Use local lib folder
-    flatDir {
-        dirs 'src/main/resources/junit4'
-    }
+    // Commented out because dependencies are not resolved correctly in upstream projects when using flatDir
+    //// Use local lib folder
+    //flatDir {
+    //    dirs 'src/main/resources/junit4'
+    //}
 }
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
 
   // Use custom junit jar to terminate timed out process during apr loop
-  compile name: 'junit-4.12-kgp-custom'
-  compile name: 'hamcrest-core-1.3'
+  compile files('src/main/resources/junit4/junit-4.12-kgp-custom.jar',
+                'src/main/resources/junit4/hamcrest-core-1.3.jar')
+  // Uncomment if using flatDir
+  //compile name: 'junit-4.12-kgp-custom'
+  //compile name: 'hamcrest-core-1.3'
 
   // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'

--- a/build.gradle
+++ b/build.gradle
@@ -17,15 +17,15 @@ compileTestJava.options.encoding = 'UTF-8'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+  // Use 'jcenter' for resolving your dependencies.
+  // You can declare any Maven/Ivy/file repository here.
+  jcenter()
 
-    // Commented out because dependencies are not resolved correctly in upstream projects when using flatDir
-    //// Use local lib folder
-    //flatDir {
-    //    dirs 'src/main/resources/junit4'
-    //}
+  // Commented out because dependencies are not resolved correctly in upstream projects when using flatDir
+  //// Use local lib folder
+  //flatDir {
+  //    dirs 'src/main/resources/junit4'
+  //}
 }
 
 // In this section you declare the dependencies for your production and test code


### PR DESCRIPTION
c-KGP の方で，custom-jnit が正しく依存解決されないという問題が発生しています．

該当 issue：[kGenProg本体を更新するとコンパイルに失敗する](https://github.com/kusumotolab/clustered-kGenProg/issues/40)

c-KGP はサブプロジェクトとして KGP を持つマルチプロジェクト構成で開発しています．

このとき，サブプロジェクト（KGP）の `build.gradle` でローカルの jar を依存として指定する際に `flatDir` を用いると，ルートプロジェクト（c-KGP）で正しく依存解決が行えないという問題が発生します．

これは Gradle 側の仕様のようです．

参考：[flatDir repositories not inherited by upstream projects](https://github.com/gradle/gradle/issues/1352)

従って，`flatDir` を用いるのではなく，`dependencies` の中で jar へのパスを指定するように変更しました．
これにより，KGP, c-KGP 共に問題なくローカル jar への依存解決ができるようになります．