### PR TITLE
シンボリックリンクに対するテストを改善

### DIFF
--- a/example/BuildSuccess08/src-example
+++ b/example/BuildSuccess08/src-example
@@ -1,1 +1,0 @@
-src/example/


### PR DESCRIPTION
resolve #523

### やったこと
- git内のsymlinkフォルダを削除 (#523 のため)
- symlinkを用いるテストを，link生成 → テスト → link削除 という流れに変更