### PR TITLE
ParallelTestExecutor 内で initialize と finalize を呼ぶよう修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/ParallelTestExecutor.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/ParallelTestExecutor.java
@@ -26,4 +26,14 @@ public class ParallelTestExecutor implements TestExecutor {
     return variantSingle.subscribeOn(Schedulers.from(executorService))
         .map(testExecutor::exec);
   }
+
+  @Override
+  public void initialize() {
+    testExecutor.initialize();
+  }
+
+  @Override
+  public void finish() {
+    testExecutor.finish();
+  }
 }


### PR DESCRIPTION
`ParallelTestExecutor` で保持している `initialize()` と `finalize()` を呼ぶよう修正