### PR TITLE
Configのシリアライズ処理を追加

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -27,6 +27,7 @@ import com.electronwill.nightconfig.core.conversion.PreserveNotNull;
 import com.electronwill.nightconfig.core.conversion.SpecNotNull;
 import com.electronwill.nightconfig.core.file.FileConfig;
 import com.google.common.collect.ImmutableList;
+import com.google.gson.annotations.Expose;
 import ch.qos.logback.classic.Level;
 import jp.kusumotolab.kgenprog.ga.mutation.Scope;
 import jp.kusumotolab.kgenprog.ga.mutation.Scope.Type;
@@ -53,14 +54,20 @@ public class Configuration {
   private final TargetProject targetProject;
   private final List<String> executionTests;
   private final Path outDir;
+  @Expose
   private final int mutationGeneratingCount;
+  @Expose
   private final int crossoverGeneratingCount;
+  @Expose
   private final int headcount;
+  @Expose
   private final int maxGeneration;
   private final Duration timeLimit;
   private final Duration testTimeLimit;
+  @Expose
   private final int requiredSolutionsCount;
   private final Level logLevel;
+  @Expose
   private final long randomSeed;
   private final Scope.Type scope;
   private final boolean needNotOutput;

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -27,7 +27,6 @@ import com.electronwill.nightconfig.core.conversion.PreserveNotNull;
 import com.electronwill.nightconfig.core.conversion.SpecNotNull;
 import com.electronwill.nightconfig.core.file.FileConfig;
 import com.google.common.collect.ImmutableList;
-import com.google.gson.annotations.Expose;
 import ch.qos.logback.classic.Level;
 import jp.kusumotolab.kgenprog.ga.mutation.Scope;
 import jp.kusumotolab.kgenprog.ga.mutation.Scope.Type;
@@ -51,33 +50,19 @@ public class Configuration {
   public static final Scope.Type DEFAULT_SCOPE = Type.PACKAGE;
   public static final boolean DEFAULT_NEED_NOT_OUTPUT = false;
 
-  @Expose
   private final TargetProject targetProject;
-  @Expose
   private final List<String> executionTests;
-  @Expose
   private final Path outDir;
-  @Expose
   private final int mutationGeneratingCount;
-  @Expose
   private final int crossoverGeneratingCount;
-  @Expose
   private final int headcount;
-  @Expose
   private final int maxGeneration;
-  @Expose
   private final Duration timeLimit;
-  @Expose
   private final Duration testTimeLimit;
-  @Expose
   private final int requiredSolutionsCount;
-  @Expose
   private final Level logLevel;
-  @Expose
   private final long randomSeed;
-  @Expose
   private final Scope.Type scope;
-  @Expose
   private final boolean needNotOutput;
   // endregion
 

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -51,8 +51,11 @@ public class Configuration {
   public static final Scope.Type DEFAULT_SCOPE = Type.PACKAGE;
   public static final boolean DEFAULT_NEED_NOT_OUTPUT = false;
 
+  @Expose
   private final TargetProject targetProject;
+  @Expose
   private final List<String> executionTests;
+  @Expose
   private final Path outDir;
   @Expose
   private final int mutationGeneratingCount;
@@ -62,14 +65,19 @@ public class Configuration {
   private final int headcount;
   @Expose
   private final int maxGeneration;
+  @Expose
   private final Duration timeLimit;
+  @Expose
   private final Duration testTimeLimit;
   @Expose
   private final int requiredSolutionsCount;
+  @Expose
   private final Level logLevel;
   @Expose
   private final long randomSeed;
+  @Expose
   private final Scope.Type scope;
+  @Expose
   private final boolean needNotOutput;
   // endregion
 

--- a/src/main/java/jp/kusumotolab/kgenprog/output/PathSerializer.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/PathSerializer.java
@@ -1,0 +1,17 @@
+package jp.kusumotolab.kgenprog.output;
+
+import java.lang.reflect.Type;
+import java.nio.file.Path;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class PathSerializer implements JsonSerializer<Path> {
+
+  @Override
+  public JsonElement serialize(final Path src, final Type type,
+      final JsonSerializationContext context) {
+    return new JsonPrimitive(src.toString());
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/output/VariantStoreExporter.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/VariantStoreExporter.java
@@ -52,7 +52,7 @@ public class VariantStoreExporter {
         .registerTypeHierarchyAdapter(Base.class, new BaseSerializer())
         .registerTypeHierarchyAdapter(Patch.class, new PatchSerializer())
         .registerTypeHierarchyAdapter(FileDiff.class, new FileDiffSerializer())
-        .excludeFieldsWithoutExposeAnnotation()
+        .registerTypeHierarchyAdapter(Path.class, new PathSerializer())
         .create();
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/output/VariantStoreExporter.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/VariantStoreExporter.java
@@ -52,6 +52,7 @@ public class VariantStoreExporter {
         .registerTypeHierarchyAdapter(Base.class, new BaseSerializer())
         .registerTypeHierarchyAdapter(Patch.class, new PatchSerializer())
         .registerTypeHierarchyAdapter(FileDiff.class, new FileDiffSerializer())
+        .excludeFieldsWithoutExposeAnnotation()
         .create();
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializer.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializer.java
@@ -29,6 +29,7 @@ public class VariantStoreSerializer implements JsonSerializer<VariantStore> {
 
     serializedVariantStore.addProperty("projectName", projectName);
     serializedVariantStore.add("variants", context.serialize(variantStore.getAllVariants()));
+    serializedVariantStore.add("configuration", context.serialize(config));
 
     return serializedVariantStore;
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
@@ -140,12 +140,9 @@ public class VariantStoreSerializerTest {
 
     // キーのチェック
     final Class<?> clazz = config.getClass();
-    final Field[] configFields = Arrays.stream(clazz.getDeclaredFields())
-        .filter(e -> !e.getName()
-            .startsWith("DEFAULT_"))
-        .toArray(Field[]::new);
-    final String[] configFieldNames = Arrays.stream(configFields)
+    final String[] configFieldNames = Arrays.stream(clazz.getDeclaredFields())
         .map(Field::getName)
+        .filter(e -> !e.startsWith("DEFAULT_"))
         .toArray(String[]::new);
     assertThat(serializedConfiguration.keySet()).containsOnly(configFieldNames);
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
@@ -125,7 +127,7 @@ public class VariantStoreSerializerTest {
   }
 
   @Test
-  public void testConfigurationSerialization() {
+  public void testConfigurationSerialization() throws IllegalAccessException {
     final Path rootPath = Paths.get("example/BuildSuccess01");
     final TargetProject project = TargetProjectFactory.create(rootPath);
     final Configuration config = new Configuration.Builder(project)
@@ -137,43 +139,14 @@ public class VariantStoreSerializerTest {
         .getAsJsonObject();
 
     // キーのチェック
-    assertThat(serializedConfiguration.keySet()).containsOnly(
-        JsonKeyAlias.Configuration.CROSSOVER_GENERATING_COUNT,
-        JsonKeyAlias.Configuration.HEAD_COUNT,
-        JsonKeyAlias.Configuration.MAX_GENERATION,
-        JsonKeyAlias.Configuration.MUTATION_GENERATING_COUNT,
-        JsonKeyAlias.Configuration.RANDOM_SEED,
-        JsonKeyAlias.Configuration.REQUIRED_SOLUTIONS_COUNT);
-
-    // 値のチェック
-    final int crossoverGeneratingCount = serializedConfiguration.get(
-        JsonKeyAlias.Configuration.CROSSOVER_GENERATING_COUNT)
-        .getAsInt();
-    assertThat(crossoverGeneratingCount).isEqualTo(config.getCrossoverGeneratingCount());
-
-    final int headCount = serializedConfiguration.get(
-        JsonKeyAlias.Configuration.HEAD_COUNT)
-        .getAsInt();
-    assertThat(headCount).isEqualTo(config.getHeadcount());
-
-    final int maxGeneration = serializedConfiguration.get(
-        JsonKeyAlias.Configuration.MAX_GENERATION)
-        .getAsInt();
-    assertThat(maxGeneration).isEqualTo(config.getMaxGeneration());
-
-    final int mutationGeneratingCount = serializedConfiguration.get(
-        JsonKeyAlias.Configuration.MUTATION_GENERATING_COUNT)
-        .getAsInt();
-    assertThat(mutationGeneratingCount).isEqualTo(config.getMutationGeneratingCount());
-
-    final int randomSeed = serializedConfiguration.get(
-        JsonKeyAlias.Configuration.RANDOM_SEED)
-        .getAsInt();
-    assertThat(randomSeed).isEqualTo(config.getRandomSeed());
-
-    final int requiredSolutionsCount = serializedConfiguration.get(
-        JsonKeyAlias.Configuration.REQUIRED_SOLUTIONS_COUNT)
-        .getAsInt();
-    assertThat(requiredSolutionsCount).isEqualTo(config.getRequiredSolutionsCount());
+    final Class<?> clazz = config.getClass();
+    final Field[] configFields = Arrays.stream(clazz.getDeclaredFields())
+        .filter(e -> !e.getName()
+            .startsWith("DEFAULT_"))
+        .toArray(Field[]::new);
+    final String[] configFieldNames = Arrays.stream(configFields)
+        .map(Field::getName)
+        .toArray(String[]::new);
+    assertThat(serializedConfiguration.keySet()).containsOnly(configFieldNames);
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
@@ -56,7 +56,7 @@ public class VariantStoreSerializerTest {
         .registerTypeHierarchyAdapter(CrossoverHistoricalElement.class,
             new CrossoverHistoricalElementSerializer())
         .registerTypeHierarchyAdapter(Base.class, new BaseSerializer())
-        .excludeFieldsWithoutExposeAnnotation()
+        .registerTypeHierarchyAdapter(Path.class, new PathSerializer())
         .create();
   }
 

--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
@@ -127,7 +127,7 @@ public class VariantStoreSerializerTest {
   }
 
   @Test
-  public void testConfigurationSerialization() throws IllegalAccessException {
+  public void testConfigurationSerialization() {
     final Path rootPath = Paths.get("example/BuildSuccess01");
     final TargetProject project = TargetProjectFactory.create(rootPath);
     final Configuration config = new Configuration.Builder(project)

--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
@@ -54,6 +54,7 @@ public class VariantStoreSerializerTest {
         .registerTypeHierarchyAdapter(CrossoverHistoricalElement.class,
             new CrossoverHistoricalElementSerializer())
         .registerTypeHierarchyAdapter(Base.class, new BaseSerializer())
+        .excludeFieldsWithoutExposeAnnotation()
         .create();
   }
 
@@ -109,7 +110,8 @@ public class VariantStoreSerializerTest {
     // キーのチェック
     assertThat(serializedVariantStore.keySet()).containsOnly(
         JsonKeyAlias.VariantStore.PROJECT_NAME,
-        JsonKeyAlias.VariantStore.VARIANTS);
+        JsonKeyAlias.VariantStore.VARIANTS,
+        JsonKeyAlias.VariantStore.CONFIGURATION);
 
     // 値のチェック
     final String projectName = serializedVariantStore.get(JsonKeyAlias.VariantStore.PROJECT_NAME)
@@ -120,5 +122,58 @@ public class VariantStoreSerializerTest {
         JsonKeyAlias.VariantStore.VARIANTS)
         .getAsJsonArray();
     assertThat(serializedVariants).hasSize(11);
+  }
+
+  @Test
+  public void testConfigurationSerialization() {
+    final Path rootPath = Paths.get("example/BuildSuccess01");
+    final TargetProject project = TargetProjectFactory.create(rootPath);
+    final Configuration config = new Configuration.Builder(project)
+        .build();
+    // gsonのセットアップ
+    final Gson gson = createGson(config);
+
+    final JsonObject serializedConfiguration = gson.toJsonTree(config)
+        .getAsJsonObject();
+
+    // キーのチェック
+    assertThat(serializedConfiguration.keySet()).containsOnly(
+        JsonKeyAlias.Configuration.CROSSOVER_GENERATING_COUNT,
+        JsonKeyAlias.Configuration.HEAD_COUNT,
+        JsonKeyAlias.Configuration.MAX_GENERATION,
+        JsonKeyAlias.Configuration.MUTATION_GENERATING_COUNT,
+        JsonKeyAlias.Configuration.RANDOM_SEED,
+        JsonKeyAlias.Configuration.REQUIRED_SOLUTIONS_COUNT);
+
+    // 値のチェック
+    final int crossoverGeneratingCount = serializedConfiguration.get(
+        JsonKeyAlias.Configuration.CROSSOVER_GENERATING_COUNT)
+        .getAsInt();
+    assertThat(crossoverGeneratingCount).isEqualTo(config.getCrossoverGeneratingCount());
+
+    final int headCount = serializedConfiguration.get(
+        JsonKeyAlias.Configuration.HEAD_COUNT)
+        .getAsInt();
+    assertThat(headCount).isEqualTo(config.getHeadcount());
+
+    final int maxGeneration = serializedConfiguration.get(
+        JsonKeyAlias.Configuration.MAX_GENERATION)
+        .getAsInt();
+    assertThat(maxGeneration).isEqualTo(config.getMaxGeneration());
+
+    final int mutationGeneratingCount = serializedConfiguration.get(
+        JsonKeyAlias.Configuration.MUTATION_GENERATING_COUNT)
+        .getAsInt();
+    assertThat(mutationGeneratingCount).isEqualTo(config.getMutationGeneratingCount());
+
+    final int randomSeed = serializedConfiguration.get(
+        JsonKeyAlias.Configuration.RANDOM_SEED)
+        .getAsInt();
+    assertThat(randomSeed).isEqualTo(config.getRandomSeed());
+
+    final int requiredSolutionsCount = serializedConfiguration.get(
+        JsonKeyAlias.Configuration.REQUIRED_SOLUTIONS_COUNT)
+        .getAsInt();
+    assertThat(requiredSolutionsCount).isEqualTo(config.getRequiredSolutionsCount());
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/testutil/JsonKeyAlias.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/testutil/JsonKeyAlias.java
@@ -1,9 +1,5 @@
 package jp.kusumotolab.kgenprog.testutil;
 
-import java.time.Duration;
-import com.google.gson.annotations.Expose;
-import ch.qos.logback.classic.Level;
-
 /**
  * JSONのキーのエイリアスを保持するクラス
  */
@@ -77,15 +73,5 @@ public class JsonKeyAlias {
     public final static String PROJECT_NAME = "projectName";
     public final static String VARIANTS = "variants";
     public final static String CONFIGURATION = "configuration";
-  }
-
-  public static class Configuration {
-
-    public final static String MUTATION_GENERATING_COUNT = "mutationGeneratingCount";
-    public final static String CROSSOVER_GENERATING_COUNT = "crossoverGeneratingCount";
-    public final static String HEAD_COUNT = "headcount";
-    public final static String MAX_GENERATION = "maxGeneration";
-    public final static String REQUIRED_SOLUTIONS_COUNT = "requiredSolutionsCount";
-    public final static String RANDOM_SEED = "randomSeed";
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/testutil/JsonKeyAlias.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/testutil/JsonKeyAlias.java
@@ -1,5 +1,9 @@
 package jp.kusumotolab.kgenprog.testutil;
 
+import java.time.Duration;
+import com.google.gson.annotations.Expose;
+import ch.qos.logback.classic.Level;
+
 /**
  * JSONのキーのエイリアスを保持するクラス
  */
@@ -72,5 +76,16 @@ public class JsonKeyAlias {
 
     public final static String PROJECT_NAME = "projectName";
     public final static String VARIANTS = "variants";
+    public final static String CONFIGURATION = "configuration";
+  }
+
+  public static class Configuration {
+
+    public final static String MUTATION_GENERATING_COUNT = "mutationGeneratingCount";
+    public final static String CROSSOVER_GENERATING_COUNT = "crossoverGeneratingCount";
+    public final static String HEAD_COUNT = "headcount";
+    public final static String MAX_GENERATION = "maxGeneration";
+    public final static String REQUIRED_SOLUTIONS_COUNT = "requiredSolutionsCount";
+    public final static String RANDOM_SEED = "randomSeed";
   }
 }


### PR DESCRIPTION
resolve #499 

## 変更点
* configのシリアライズ処理を追加(カスタムシリアライザを導入せずに、クラスをjsonにマッピングする機能を利用)

## シリアライズ対象にしたCongurationのフィールド
* ~~headCount~~
* ~~crossoverGeneratingCount~~
* ~~mutationGeneratingCount~~
* ~~maxGeneration~~
* ~~requiredSolutionsCount~~
* ~~randomSeed~~
全ての非staticフィールド
