### PR TITLE
commons.io依存の削除

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
   compile group: 'org.apache.maven', name: 'maven-core', version: '3.5.4'
 
   // https://mvnrepository.com/artifact/commons-io/commons-io
-  compile group: 'commons-io', name: 'commons-io', version: '2.6'
+  // compile group: 'commons-io', name: 'commons-io', version: '2.6'
 
   // https://mvnrepository.com/artifact/commons-lang/commons-lang
   // compile group: 'commons-lang', name: 'commons-lang', version: '2.6'

--- a/src/main/java/jp/kusumotolab/kgenprog/project/factory/BuildToolProjectFactory.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/factory/BuildToolProjectFactory.java
@@ -1,11 +1,11 @@
 package jp.kusumotolab.kgenprog.project.factory;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.stream.Collectors;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.FileFilterUtils;
 
 public abstract class BuildToolProjectFactory implements ProjectFactory {
 
@@ -16,11 +16,15 @@ public abstract class BuildToolProjectFactory implements ProjectFactory {
   }
 
   final protected Collection<Path> getConfigPath() {
-    return FileUtils
-        .listFiles(rootPath.toFile(), FileFilterUtils.nameFileFilter(getConfigFileName()), null)
-        .stream()
-        .map(File::toPath)
-        .collect(Collectors.toList());
+    try {
+      return Files.walk(rootPath)
+          .filter(p -> p.toString()
+              .endsWith(getConfigFileName()))
+          .collect(Collectors.toList());
+    } catch (IOException e) {
+      ; // do nothing
+    }
+    return Collections.emptyList();
   }
 
   abstract protected String getConfigFileName();

--- a/src/main/java/jp/kusumotolab/kgenprog/project/factory/TargetProjectFactory.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/factory/TargetProjectFactory.java
@@ -1,5 +1,6 @@
 package jp.kusumotolab.kgenprog.project.factory;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -15,10 +16,15 @@ public class TargetProjectFactory {
    * @return TargetProject
    */
   public static TargetProject create(final Path rootPath) {
-    ProjectFactory applicableFactory = instanceProjectFactories(rootPath).stream()
+    if (!Files.exists(rootPath)) {
+      throw new IllegalArgumentException("Specified project does not exist: \"" + rootPath + "\".");
+    }
+
+    final ProjectFactory applicableFactory = instanceProjectFactories(rootPath).stream()
         .filter(ProjectFactory::isApplicable)
         .findFirst()
         .orElse(new HeuristicProjectFactory(rootPath));
+
     return applicableFactory.create();
   }
 
@@ -42,7 +48,8 @@ public class TargetProjectFactory {
    * @return TargetProject
    */
   public static TargetProject create(final Path rootPath, final List<Path> pathsForProductSource,
-      final List<Path> pathsForTestSource, List<Path> pathsForClass, JUnitVersion junitVersion) {
+      final List<Path> pathsForTestSource, final List<Path> pathsForClass,
+      final JUnitVersion junitVersion) {
     return new DefaultProjectFactory(rootPath, pathsForProductSource, pathsForTestSource,
         pathsForClass, junitVersion).create();
   }


### PR DESCRIPTION
resolve #305 

### やったこと
- `apache-commons-io` 依存の部分を全て削除してnativeに
  - `commons.FileUtils`を`Files.walk`に差し替え
- final修飾子の付与漏れ修正