### PR TITLE
作業漏れ #543

### DIFF
--- a/example/BuildSuccess08/withFaultLocalization.toml
+++ b/example/BuildSuccess08/withFaultLocalization.toml
@@ -1,4 +1,5 @@
 root-dir = "./"
 src = ["src/"]
 test = ["test/"]
-faultLocalization = "Ample"
+fault-localization = "Ample"
+

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -29,6 +29,7 @@ import com.electronwill.nightconfig.core.file.FileConfig;
 import com.google.common.collect.ImmutableList;
 import ch.qos.logback.classic.Level;
 import jp.kusumotolab.kgenprog.fl.FaultLocalization;
+import jp.kusumotolab.kgenprog.fl.FaultLocalization.Technique;
 import jp.kusumotolab.kgenprog.ga.mutation.Scope;
 import jp.kusumotolab.kgenprog.ga.mutation.Scope.Type;
 import jp.kusumotolab.kgenprog.project.factory.JUnitLibraryResolver.JUnitVersion;
@@ -268,6 +269,7 @@ public class Configuration {
 
     @com.electronwill.nightconfig.core.conversion.Path("fault-localization")
     @PreserveNotNull
+    @Conversion(FaultLocalizationTechniqueToString.class)
     private FaultLocalization.Technique faultLocalization = DEFAULT_FAULT_LOCALIZATION;
 
     // endregion
@@ -658,8 +660,7 @@ public class Configuration {
       this.scope = scope;
     }
 
-    @Option(name = "--fault-localization", metaVar = "<name>",
-            usage = "Specifies technique of fault localization.")
+    @Option(name = "--fault-localization", usage = "Specifies technique of fault localization.")
     private void setFaultLocalizationFromCmdLineParser(final FaultLocalization.Technique faultLocalization) {
       this.faultLocalization = faultLocalization;
     }
@@ -767,6 +768,25 @@ public class Configuration {
 
       @Override
       public String convertFromField(final Type value) {
+        if (value == null) {
+          return null;
+        }
+        return value.toString();
+      }
+    }
+
+    private static class FaultLocalizationTechniqueToString implements Converter<FaultLocalization.Technique, String> {
+
+      @Override
+      public Technique convertToField(final String value) {
+        if (value == null) {
+          return null;
+        }
+        return Technique.valueOf(value);
+      }
+
+      @Override
+      public String convertFromField(final Technique value) {
         if (value == null) {
           return null;
         }


### PR DESCRIPTION
related to #543 

## やったこと
- `withFaultLocalization.toml`の記述を正しいものに
- `Configuration$FaultLocalizationTechniqueToString`の実装

---

https://github.com/kusumotolab/kGenProg/blob/88f3a83241464f120997ad89f875f7b33ae912b6/src/main/java/jp/kusumotolab/kgenprog/Configuration.java#L269-L271

ここでPathを`fault-localization`としているので，
`withFaultLocalization.toml`内でも同様に書くべきでした．

> example/BuildSuccess08/withFaultLocalization.toml
```diff
- faultLocalization = "Ample"
+ fault-localization = "Ample"
```

しかし，テストにfailしていなかったので
`Configuration.java`内にConverterが必要であるにも関わらず，気づきませんでした．
（`enum` -> `String` の変換．`Scope.Type` と同様です）

なぜテストにfailしていなかったのかはよくわからないです…．
立て続けで申し訳ありませんがレビューお願いします．