### PR TITLE
クラスローダの委譲バグの修正

### DIFF
--- a/example/BuildSuccess23/src/example/Foo.java
+++ b/example/BuildSuccess23/src/example/Foo.java
@@ -1,0 +1,11 @@
+package example;
+
+public class Foo {
+
+  public void foo() throws ClassNotFoundException {
+    this.getClass()
+        .getClassLoader()
+        .loadClass("jp.kusumotolab.kgenprog.CUILauncher");
+  }
+
+}

--- a/example/BuildSuccess23/test/example/FooTest.java
+++ b/example/BuildSuccess23/test/example/FooTest.java
@@ -1,0 +1,25 @@
+package example;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+public class FooTest {
+
+  @Test
+  public void test01() {
+    try {
+      new Foo().foo();
+      fail();
+    } catch (ClassNotFoundException e) {
+      assertTrue(true);
+    }
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void test02() throws Exception {
+    new Foo().foo();
+    fail();
+  }
+
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/MemoryClassLoader.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/MemoryClassLoader.java
@@ -45,7 +45,7 @@ public class MemoryClassLoader extends URLClassLoader {
   }
 
   /**
-   * メモリ上からクラスを探す． メモリ上のバイト配列のクラス定義を優先で探し，それがなければurlで指定されたパス上の.classファイルからロードを行う．
+   * メモリ上からクラスを探す． まずURLClassLoaderによるファイルシステム上のクラスのロードを試み，それがなければメモリ上のクラスロードを試す．
    */
   @Override
   protected Class<?> findClass(final String name) throws ClassNotFoundException {

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/MemoryClassLoader.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/MemoryClassLoader.java
@@ -43,11 +43,6 @@ public class MemoryClassLoader extends URLClassLoader {
     return loadClass(fqn.value);
   }
 
-  @Override
-  public Class<?> loadClass(final String name) throws ClassNotFoundException {
-    return loadClass(name, false);
-  }
-
   /**
    * クラスロード． メモリ上のバイト配列のクラス定義を優先で探し，それがなければファイルシステム上の.classファイルからロードを行う．
    */

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/MemoryClassLoader.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/MemoryClassLoader.java
@@ -52,12 +52,12 @@ public class MemoryClassLoader extends URLClassLoader {
     final byte[] bytes = definitions.get(name);
     if (bytes != null) {
       try {
-        return defineClass(name.toString(), bytes, 0, bytes.length);
+        return defineClass(name, bytes, 0, bytes.length);
       } catch (final LinkageError e) {
         // クラスのロードに失敗した，可能性はバイナリが不正か，二重ロード．
 
         // 既にロードされているクラスを探してみる（二重ロードの可能性を考える）
-        final Class<?> clazz = findLoadedClass(name.toString());
+        final Class<?> clazz = findLoadedClass(name);
 
         // それでも無理ならおそらくバイナリ不正っぽい
         if (null == clazz) {
@@ -65,7 +65,7 @@ public class MemoryClassLoader extends URLClassLoader {
         }
       }
     }
-    return super.loadClass(name.toString(), resolve);
+    return super.loadClass(name, resolve);
   }
 
   @Override

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/SkippingMemoryClassLoader.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/SkippingMemoryClassLoader.java
@@ -1,0 +1,84 @@
+package jp.kusumotolab.kgenprog.project.test;
+
+import java.net.URL;
+
+/**
+ * MemoryClassLoaderの拡張．<br>
+ * クラスローダの委譲関係をあえて崩すことで，KGP本体のクラスロード（AppClassLoader）の副作用を回避する．<br>
+ * 委譲の流れは以下の通り．<br>
+ * - SkippingMemoryClassLoader<br>
+ * -> AppClassLoader (ここをスキップ)<br>
+ * -> ExtensionClassLoader (ここにダイレクトに委譲)<br>
+ * -> BootstrapClassLoader<br>
+ * 
+ * ただし例外として，JUnit関係のクラスのみ，そのロードをAppClassLoaderに委譲する．<br>
+ * KGPのテスト実行時のJUnitクラス，及び題材のテスト実行時のJUnitクラスを同一のクラスローダでロードしないと，<br>
+ * JUnitが期待通りに動作しないため．<br>
+ * 
+ * @author shinsuke
+ *
+ */
+public class SkippingMemoryClassLoader extends MemoryClassLoader {
+
+  final private ClassLoader extensionClassLoader;
+
+  public SkippingMemoryClassLoader(final URL[] urls) {
+    super(urls);
+    extensionClassLoader = findExtClassLoader(getClass().getClassLoader());
+  }
+
+  /**
+   * クラスローダの親子関係を探索して，委譲先のextensionClassLoaderを探す．
+   * 
+   * @param cl
+   * @return
+   */
+  private ClassLoader findExtClassLoader(final ClassLoader cl) {
+    if (null == cl) {
+      throw new RuntimeException("Cannot find extension class loader.");
+    }
+    if (!cl.toString()
+        .contains("$ExtClassLoader@")) {
+      return findExtClassLoader(cl.getParent());
+    }
+    return cl;
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+
+    if (name.startsWith("org.junit.Test") || name.startsWith("junit.framework")) {
+      return getParent().loadClass(name);
+    }
+
+    synchronized (getClassLoadingLock(name)) {
+      // First, check if the class has already been loaded
+      Class<?> c = findLoadedClass(name);
+
+      if (c == null) {
+        try {
+          // Second, try to load using extension class loader
+          c = extensionClassLoader.loadClass(name);
+        } catch (ClassNotFoundException e) {
+          // ignore
+        }
+      }
+      if (c == null) {
+        try {
+          // Finally, try to load from memory
+          c = findClass(name);
+        } catch (Exception e) {
+          // ignore
+        }
+      }
+      if (c == null) {
+        throw new ClassNotFoundException(name);
+      }
+      if (resolve) {
+        resolveClass(c);
+      }
+      return c;
+    }
+  }
+
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
@@ -95,9 +95,7 @@ class TestThread extends Thread {
     // set memoryClassLoader as ContextClassLoader during JUnit execution
     final List<ClassPath> classPaths = targetProject.getClassPaths();
     final URL[] classpathUrls = convertClasspathsToURLs(classPaths);
-    final MemoryClassLoader classLoader = new MemoryClassLoader(classpathUrls);
-    Thread.currentThread()
-        .setContextClassLoader(classLoader);
+    final MemoryClassLoader classLoader = new SkippingMemoryClassLoader(classpathUrls);
 
     try {
       addAllDefinitions(classLoader, productFQNs);
@@ -110,6 +108,10 @@ class TestThread extends Thread {
 
       final RunListener listener = new CoverageMeasurementListener(productFQNs, testResults);
       junitCore.addListener(listener);
+
+      Thread.currentThread()
+          .setContextClassLoader(classLoader);
+
       junitCore.run(testClasses.toArray(new Class<?>[testClasses.size()]));
 
     } catch (final ClassNotFoundException e) {

--- a/src/test/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutorTest.java
@@ -683,4 +683,23 @@ public class LocalTestExecutorTest {
     assertThat(result.getTestResult(FOO_TEST01).failed).isFalse();
     assertThat(result.getTestResult(FOO_TEST02).failed).isFalse();
   }
+
+  @Test
+  //
+  public void testExecForSkippingClassLoading() {
+    final Path rootPath = Paths.get("example/BuildSuccess23");
+
+    final TargetProject targetProject = TargetProjectFactory.create(rootPath);
+    final GeneratedSourceCode source = TestUtil.createGeneratedSourceCode(targetProject);
+
+    final Configuration config = new Configuration.Builder(targetProject).build();
+    final TestExecutor executor = new LocalTestExecutor(config);
+    final Variant variant = mock(Variant.class);
+    when(variant.getGeneratedSourceCode()).thenReturn(source);
+    final TestResults result = executor.exec(variant);
+
+    assertThat(result.getExecutedTestFQNs()).containsExactlyInAnyOrder(FOO_TEST01, FOO_TEST02);
+    assertThat(result.getTestResult(FOO_TEST01).failed).isFalse();
+    assertThat(result.getTestResult(FOO_TEST02).failed).isFalse();
+  }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/project/test/MemoryClassLoaderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/test/MemoryClassLoaderTest.java
@@ -85,7 +85,7 @@ public class MemoryClassLoaderTest {
   @Test
   public void testDynamicClassLoading02() throws Exception {
     // 動的ロード（Override側のメソッドで試す）
-    final Class<?> clazz = loader.loadClass(FOO.toString(), false);
+    final Class<?> clazz = loader.loadClass(FOO.toString());
     final Object instance = clazz.getDeclaredConstructor()
         .newInstance();
 


### PR DESCRIPTION
resolve #541

### やったこと
- バグ #541 を確認する題材 BuildSuccess23 の追加
  - `jp.kusumotolab`パッケージのクラスをロードする題材．成功する訳がない題材．
- 上記のテスト追加
- バグ #541 の修正
  - SkippingMemoryClassLoaderを作成

### SkippingMemoryClassLoader
MemoryClassLoaderの拡張クラス．クラスローダの委譲関係をあえて崩すことで，KGP本体のクラスロード（`AppClassLoader`）の副作用を回避する．委譲の流れは以下の通り．
```
 - SkippingMemoryClassLoader
 -> AppClassLoader (ここをスキップ)
 -> ExtensionClassLoader (ここにダイレクトに委譲)
 -> BootstrapClassLoader
```

ただし例外としてJUnit関係のクラスのみ，そのロードをAppClassLoaderに委譲する．KGPのテスト実行時のJUnitクラス，及び題材のテスト実行時のJUnitクラスを同一のクラスローダでロードしないと，JUnitが期待通りに動作しないため．