### PR TITLE
カバレッジ計測時にVariantStoreSerializerTest.testConfigurationSerializationがFAILしないように修正

### DIFF
--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreSerializerTest.java
@@ -143,6 +143,7 @@ public class VariantStoreSerializerTest {
     final String[] configFieldNames = Arrays.stream(clazz.getDeclaredFields())
         .map(Field::getName)
         .filter(e -> !e.startsWith("DEFAULT_"))
+        .filter(e -> !e.startsWith("$"))
         .toArray(String[]::new);
     assertThat(serializedConfiguration.keySet()).containsOnly(configFieldNames);
   }


### PR DESCRIPTION
## 変更点
$jacocoフィールドを除外するフィルターを追加

手元の環境では，テストがFAILせずにカバレッジの計測ができました．
