### PR TITLE
README のスタイル・内容を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align=center>
-    :us:English <a href="./doc/ja/README.md"> &nbsp; :jp:日本語</a>
+    :us:English &nbsp; <a href="./doc/ja/README.md"> :jp:日本語</a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <a href="https://github.com/kusumotolab/kGenProg/releases/latest" alt="release"><img src="https://img.shields.io/github/release/kusumotolab/kGenProg.svg"></a>
     <a href="https://circleci.com/gh/kusumotolab/kGenProg/tree/master" alt="CircleCI"><img src="https://circleci.com/gh/kusumotolab/kGenProg/tree/master.svg?style=shield"></a>
     <a href="https://codecov.io/gh/kusumotolab/kGenProg" alt="Codecov"><img src="https://codecov.io/gh/kusumotolab/kGenProg/branch/master/graph/badge.svg"></a>
-    <a href="https://github.com/kusumotolab/kGenProg/blob/master/LICENSE" alt="release"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+    <a href="https://github.com/kusumotolab/kGenProg/blob/master/LICENSE" alt="license"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
 </p>
 
 <p align=center>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align=center>
-    :us:English <a href="./doc/ja/README.md"> :jp:日本語</a>
+    :us:English <a href="./doc/ja/README.md"> &nbsp; :jp:日本語</a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
-:us: EN / [:jp: JA](./doc/ja/README.md)
+<h1 align="center">kGenProg</h1>
 
-[![CircleCI](https://circleci.com/gh/kusumotolab/kGenProg/tree/master.svg?style=svg)](https://circleci.com/gh/kusumotolab/kGenProg/tree/master) [![codecov](https://codecov.io/gh/kusumotolab/kGenProg/branch/master/graph/badge.svg)](https://codecov.io/gh/kusumotolab/kGenProg)
+<p align="center">
+    <strong>kGenProg is an Automated Program Repair tool written in Java for Java.</strong><br>
+    This is a reimplementation of GenProg, which automatically repairs bugs using genetic algorithm.
+</p>
 
-# kGenProg
-kGenProg is an Automated Program Repair tool written in Java for Java.
-This is a reimplementation of GenProg, which automatically repairs bugs using genetic algorithm.
+<p align=center>
+    <a href="https://github.com/kusumotolab/kGenProg/releases/latest" alt="release"><img src="https://img.shields.io/github/release/kusumotolab/kGenProg.svg"></a>
+    <a href="https://circleci.com/gh/kusumotolab/kGenProg/tree/master" alt="CircleCI"><img src="https://circleci.com/gh/kusumotolab/kGenProg/tree/master.svg?style=shield"></a>
+    <a href="https://codecov.io/gh/kusumotolab/kGenProg" alt="Codecov"><img src="https://codecov.io/gh/kusumotolab/kGenProg/branch/master/graph/badge.svg"></a>
+    <a href="https://github.com/kusumotolab/kGenProg/blob/master/LICENSE" alt="release"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+</p>
 
+<p align=center>
+    :us: English &middot; <a href="./doc/ja/README.md">:jp: 日本語</a>
+</p>
+
+---
 
 ## Requirements
 - JDK8

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align=center>
-    :us: English <a href="./doc/ja/README.md">:jp: 日本語</a>
+    :us:English <a href="./doc/ja/README.md"> :jp:日本語</a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align=center>
-    :us: English &middot; <a href="./doc/ja/README.md">:jp: 日本語</a>
+    :us: English <a href="./doc/ja/README.md">:jp: 日本語</a>
 </p>
 
 ---

--- a/doc/ja/README.md
+++ b/doc/ja/README.md
@@ -10,7 +10,7 @@
     <a href="https://github.com/kusumotolab/kGenProg/releases/latest" alt="release"><img src="https://img.shields.io/github/release/kusumotolab/kGenProg.svg"></a>
     <a href="https://circleci.com/gh/kusumotolab/kGenProg/tree/master" alt="CircleCI"><img src="https://circleci.com/gh/kusumotolab/kGenProg/tree/master.svg?style=shield"></a>
     <a href="https://codecov.io/gh/kusumotolab/kGenProg" alt="Codecov"><img src="https://codecov.io/gh/kusumotolab/kGenProg/branch/master/graph/badge.svg"></a>
-    <a href="https://github.com/kusumotolab/kGenProg/blob/master/LICENSE" alt="release"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+    <a href="https://github.com/kusumotolab/kGenProg/blob/master/LICENSE" alt="license"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
 </p>
 
 <p align=center>

--- a/doc/ja/README.md
+++ b/doc/ja/README.md
@@ -1,12 +1,23 @@
-[:us: EN](../../README.md) / :jp: JA
+<h1 align="center">kGenProg</h1>
 
-[![CircleCI](https://circleci.com/gh/kusumotolab/kGenProg/tree/master.svg?style=svg)](https://circleci.com/gh/kusumotolab/kGenProg/tree/master) [![codecov](https://codecov.io/gh/kusumotolab/kGenProg/branch/master/graph/badge.svg)](https://codecov.io/gh/kusumotolab/kGenProg)
+<p align="center">
+    <strong>kGenProg は Java プログラム向けの自動プログラム修正ツールです．</strong><br>
+    C 言語向けの自動プログラム修正ツール GenProg の Java 向け実装です．
+    遺伝的アルゴリズムを用いて修正を行います．
+</p>
 
-# kGenProg
-kGenProg は Java プログラム向けの自動プログラム修正ツールです．
-C 言語向けの自動プログラム修正ツール GenProg の Java 向け実装です．
-遺伝的アルゴリズムを用いて修正を行います．
+<p align=center>
+    <a href="https://github.com/kusumotolab/kGenProg/releases/latest" alt="release"><img src="https://img.shields.io/github/release/kusumotolab/kGenProg.svg"></a>
+    <a href="https://circleci.com/gh/kusumotolab/kGenProg/tree/master" alt="CircleCI"><img src="https://circleci.com/gh/kusumotolab/kGenProg/tree/master.svg?style=shield"></a>
+    <a href="https://codecov.io/gh/kusumotolab/kGenProg" alt="Codecov"><img src="https://codecov.io/gh/kusumotolab/kGenProg/branch/master/graph/badge.svg"></a>
+    <a href="https://github.com/kusumotolab/kGenProg/blob/master/LICENSE" alt="release"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+</p>
 
+<p align=center>
+    <a href="../../README.md">:us: English</a> &middot; :jp: 日本語
+</p>
+
+---
 
 ## 動作条件
 - JDK8

--- a/doc/ja/README.md
+++ b/doc/ja/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align=center>
-    <a href="../../README.md">:us: English</a> :jp: 日本語
+    <a href="../../README.md">:us:English</a> :jp:日本語
 </p>
 
 ---

--- a/doc/ja/README.md
+++ b/doc/ja/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align=center>
-    <a href="../../README.md">:us:English</a> :jp:日本語
+    <a href="../../README.md">:us:English</a> &nbsp; :jp:日本語
 </p>
 
 ---

--- a/doc/ja/README.md
+++ b/doc/ja/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align=center>
-    <a href="../../README.md">:us: English</a> &middot; :jp: 日本語
+    <a href="../../README.md">:us: English</a> :jp: 日本語
 </p>
 
 ---


### PR DESCRIPTION
この PR での README の見え方は以下から確認できます：

- https://github.com/kusumotolab/kGenProg/blob/update-readme/README.md

---

### 変更点

#### タイトル部分のスタイルを変更

[Bootstrap](https://github.com/twbs/bootstrap) や [IINA](https://github.com/iina/iina) などの人気プロジェクトを参考にしました

#### CircleCI のバッヂのスタイルを変更

| 旧 | 新 |
|-|-|
| <img src="https://circleci.com/gh/kusumotolab/kGenProg.svg?style=svg"> | <img src="https://circleci.com/gh/kusumotolab/kGenProg/tree/master.svg?style=shield"> |

他のバッヂとスタイルを統一するため，デフォルトから shield スタイルに変更

#### 最新リリースバージョンのバッヂを追加

<img src="https://img.shields.io/github/release/kusumotolab/kGenProg.svg">

新バージョンがリリースされればバッヂも自動的に変わります

#### ライセンスのバッヂを追加

<img src="https://img.shields.io/badge/license-MIT-blue.svg">
