### PR TITLE
古い個体を優先的に残さないように改良

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/selection/DefaultVariantSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/selection/DefaultVariantSelection.java
@@ -1,5 +1,6 @@
 package jp.kusumotolab.kgenprog.ga.selection;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,6 +17,8 @@ public class DefaultVariantSelection implements VariantSelection {
 
   @Override
   public List<Variant> exec(final List<Variant> current, final List<Variant> generated) {
+    Collections.shuffle(current);
+    Collections.shuffle(generated);
     final List<Variant> list = Stream.concat(current.stream(), generated.stream())
         .sorted(Comparator.comparing(Variant::getFitness).reversed())
         .limit(maxVariantsPerGeneration)

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/selection/DefaultVariantSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/selection/DefaultVariantSelection.java
@@ -1,26 +1,28 @@
 package jp.kusumotolab.kgenprog.ga.selection;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public class DefaultVariantSelection implements VariantSelection {
 
   final private int maxVariantsPerGeneration;
 
-  public DefaultVariantSelection(int maxVariantPerGeneration) {
+  public DefaultVariantSelection(final int maxVariantPerGeneration) {
     this.maxVariantsPerGeneration = maxVariantPerGeneration;
   }
 
   @Override
   public List<Variant> exec(final List<Variant> current, final List<Variant> generated) {
-    Collections.shuffle(current);
-    Collections.shuffle(generated);
-    final List<Variant> list = Stream.concat(current.stream(), generated.stream())
-        .sorted(Comparator.comparing(Variant::getFitness).reversed())
+    final ArrayList<Variant> variants = new ArrayList<>(current);
+    variants.addAll(generated);
+    Collections.shuffle(variants);
+    final List<Variant> list = variants.stream()
+        .sorted(Comparator.comparing(Variant::getFitness)
+            .reversed())
         .limit(maxVariantsPerGeneration)
         .collect(Collectors.toList());
     return list;

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/selection/EliteAndOldVariantSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/selection/EliteAndOldVariantSelection.java
@@ -1,0 +1,25 @@
+package jp.kusumotolab.kgenprog.ga.selection;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public class EliteAndOldVariantSelection implements VariantSelection {
+
+  final private int maxVariantsPerGeneration;
+
+  public EliteAndOldVariantSelection(int maxVariantPerGeneration) {
+    this.maxVariantsPerGeneration = maxVariantPerGeneration;
+  }
+
+  @Override
+  public List<Variant> exec(final List<Variant> current, final List<Variant> generated) {
+    final List<Variant> list = Stream.concat(current.stream(), generated.stream())
+        .sorted(Comparator.comparing(Variant::getFitness).reversed())
+        .limit(maxVariantsPerGeneration)
+        .collect(Collectors.toList());
+    return list;
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/selection/EliteAndOldVariantSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/selection/EliteAndOldVariantSelection.java
@@ -10,14 +10,15 @@ public class EliteAndOldVariantSelection implements VariantSelection {
 
   final private int maxVariantsPerGeneration;
 
-  public EliteAndOldVariantSelection(int maxVariantPerGeneration) {
+  public EliteAndOldVariantSelection(final int maxVariantPerGeneration) {
     this.maxVariantsPerGeneration = maxVariantPerGeneration;
   }
 
   @Override
   public List<Variant> exec(final List<Variant> current, final List<Variant> generated) {
     final List<Variant> list = Stream.concat(current.stream(), generated.stream())
-        .sorted(Comparator.comparing(Variant::getFitness).reversed())
+        .sorted(Comparator.comparing(Variant::getFitness)
+            .reversed())
         .limit(maxVariantsPerGeneration)
         .collect(Collectors.toList());
     return list;

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/selection/DefaultVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/selection/DefaultVariantSelectionTest.java
@@ -32,7 +32,7 @@ public class DefaultVariantSelectionTest {
         .extracting(Variant::getFitness)
         .extracting(Fitness::getValue)
         .hasSize(10)
-        .contains(0.00d, 0.05d, 0.20d, 0.15d, 0.40d, 0.25d, 0.60d, 0.35d, 0.80d, 0.45d);
+        .containsExactly(0.00d, 0.05d, 0.20d, 0.15d, 0.40d, 0.25d, 0.60d, 0.35d, 0.80d, 0.45d);
 
     assertThat(selectedVariants).hasSize(variantSize)
         .extracting(Variant::getFitness)
@@ -95,8 +95,47 @@ public class DefaultVariantSelectionTest {
     }
   }
 
+  @Test
+  public void testOrderOfVariants() {
+    final int variantSize = 5;
+    final DefaultVariantSelection variantSelection = new DefaultVariantSelection(variantSize);
+    final List<Variant> current = new ArrayList<>();
+    final List<Variant> generated = new ArrayList<>();
+
+    for (int i = 0; i < 10; i++) {
+      final double divider = 10;
+      final double value = (1.0d * (i + (i % 2))) / divider;
+      final SimpleFitness fitness = new SimpleFitness(value);
+      current.add(createVariant(fitness, i));
+      generated.add(createVariant(fitness, i + 10));
+    }
+
+    final List<Variant> selectedVariants = variantSelection.exec(current, generated);
+
+    assertThat(current).hasSize(10)
+        .extracting(Variant::getFitness)
+        .extracting(Fitness::getValue)
+        .hasSize(10)
+        .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
+
+    assertThat(generated).hasSize(10)
+        .extracting(Variant::getFitness)
+        .extracting(Fitness::getValue)
+        .hasSize(10)
+        .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
+
+    assertThat(selectedVariants).hasSize(variantSize)
+        .extracting(Variant::getId)
+        .doesNotContainSequence(9L, 19L, 7L, 8L, 17L);
+  }
+
   private Variant createVariant(final Fitness fitness) {
-    final Variant variant = new Variant(0 ,0, null, null, null, fitness, null, null);
+    final Variant variant = new Variant(0, 0, null, null, null, fitness, null, null);
+    return variant;
+  }
+
+  private Variant createVariant(final Fitness fitness, final int id) {
+    final Variant variant = new Variant(id, 0, null, null, null, fitness, null, null);
     return variant;
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/selection/DefaultVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/selection/DefaultVariantSelectionTest.java
@@ -32,7 +32,7 @@ public class DefaultVariantSelectionTest {
         .extracting(Variant::getFitness)
         .extracting(Fitness::getValue)
         .hasSize(10)
-        .containsExactly(0.00d, 0.05d, 0.20d, 0.15d, 0.40d, 0.25d, 0.60d, 0.35d, 0.80d, 0.45d);
+        .contains(0.00d, 0.05d, 0.20d, 0.15d, 0.40d, 0.25d, 0.60d, 0.35d, 0.80d, 0.45d);
 
     assertThat(selectedVariants).hasSize(variantSize)
         .extracting(Variant::getFitness)

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/selection/EliteAndOldVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/selection/EliteAndOldVariantSelectionTest.java
@@ -96,8 +96,48 @@ public class EliteAndOldVariantSelectionTest {
     }
   }
 
+  @Test
+  public void testOrderOfVariants() {
+    final int variantSize = 5;
+    final EliteAndOldVariantSelection variantSelection = new EliteAndOldVariantSelection(
+        variantSize);
+    final List<Variant> current = new ArrayList<>();
+    final List<Variant> generated = new ArrayList<>();
+
+    for (int i = 0; i < 10; i++) {
+      final double divider = 10;
+      final double value = (1.0d * (i + (i % 2))) / divider;
+      final SimpleFitness fitness = new SimpleFitness(value);
+      current.add(createVariant(fitness, i));
+      generated.add(createVariant(fitness, i + 10));
+    }
+
+    final List<Variant> selectedVariants = variantSelection.exec(current, generated);
+
+    assertThat(current).hasSize(10)
+        .extracting(Variant::getFitness)
+        .extracting(Fitness::getValue)
+        .hasSize(10)
+        .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
+
+    assertThat(generated).hasSize(10)
+        .extracting(Variant::getFitness)
+        .extracting(Fitness::getValue)
+        .hasSize(10)
+        .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
+
+    assertThat(selectedVariants).hasSize(variantSize)
+        .extracting(Variant::getId)
+        .containsSequence(9L, 19L, 7L, 8L, 17L);
+  }
+
   private Variant createVariant(final Fitness fitness) {
     final Variant variant = new Variant(0, 0, null, null, null, fitness, null, null);
+    return variant;
+  }
+
+  private Variant createVariant(final Fitness fitness, final int id) {
+    final Variant variant = new Variant(id, 0, null, null, null, fitness, null, null);
     return variant;
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/selection/EliteAndOldVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/selection/EliteAndOldVariantSelectionTest.java
@@ -1,0 +1,103 @@
+package jp.kusumotolab.kgenprog.ga.selection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Test;
+import jp.kusumotolab.kgenprog.ga.validation.Fitness;
+import jp.kusumotolab.kgenprog.ga.validation.SimpleFitness;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+
+public class EliteAndOldVariantSelectionTest {
+
+  @Test
+  public void testExec() {
+    final int variantSize = 5;
+    final EliteAndOldVariantSelection variantSelection = new EliteAndOldVariantSelection(
+        variantSize);
+    final List<Variant> variants = new ArrayList<>();
+
+    for (int i = 0; i < 10; i++) {
+      final double divider = (i % 2 == 0) ? 10 : 20;
+      final double value = (double) i / divider;
+      final SimpleFitness fitness = new SimpleFitness(value);
+      variants.add(createVariant(fitness));
+    }
+    final List<Variant> selectedVariants = variantSelection.exec(Collections.emptyList(), variants);
+
+    assertThat(variants).hasSize(10)
+        .extracting(Variant::getFitness)
+        .extracting(Fitness::getValue)
+        .hasSize(10)
+        .containsExactly(0.00d, 0.05d, 0.20d, 0.15d, 0.40d, 0.25d, 0.60d, 0.35d, 0.80d, 0.45d);
+
+    assertThat(selectedVariants).hasSize(variantSize)
+        .extracting(Variant::getFitness)
+        .extracting(Fitness::getValue)
+        .hasSize(5)
+        .containsExactly(0.80d, 0.60d, 0.45d, 0.40d, 0.35d);
+  }
+
+  @Test
+  public void testExecForEmptyVariants() {
+    final EliteAndOldVariantSelection variantSelection = new EliteAndOldVariantSelection(10);
+    final List<Variant> variants1 = Collections.emptyList();
+    final List<Variant> variants2 = Collections.emptyList();
+    final List<Variant> resultVariants = variantSelection.exec(variants1, variants2);
+    assertThat(resultVariants).hasSize(0);
+  }
+
+  @Test
+  public void testExecForNan() {
+    final EliteAndOldVariantSelection variantSelection = new EliteAndOldVariantSelection(10);
+    final List<Variant> variants = new ArrayList<>();
+
+    final List<Variant> nanVariants = IntStream.range(0, 10)
+        .mapToObj(e -> new SimpleFitness(Double.NaN))
+        .map(this::createVariant)
+        .collect(Collectors.toList());
+
+    variants.addAll(nanVariants);
+
+    final List<Variant> result1 = variantSelection.exec(Collections.emptyList(), variants);
+
+    assertThat(result1).hasSize(10);
+
+    final Variant normalVariant = createVariant(new SimpleFitness(0.5d));
+    variants.add(normalVariant);
+    final List<Variant> result2 = variantSelection.exec(Collections.emptyList(), variants);
+    assertThat(result2).hasSize(10);
+    assertThat(result2.get(0)).isEqualTo(normalVariant);
+  }
+
+  @Test
+  public void testExecForNanCompare() {
+    final EliteAndOldVariantSelection variantSelection = new EliteAndOldVariantSelection(10);
+
+    final List<Variant> nanVariants = IntStream.range(0, 100)
+        .mapToObj(e -> {
+          if (e == 50) {
+            return new SimpleFitness(SimpleFitness.MAXIMUM_VALUE);
+          }
+          return new SimpleFitness(Double.NaN);
+        })
+        .map(this::createVariant)
+        .collect(Collectors.toList());
+
+    try {
+      final List<Variant> result = variantSelection.exec(Collections.emptyList(), nanVariants);
+      assertThat(result).hasSize(10);
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+
+  private Variant createVariant(final Fitness fitness) {
+    final Variant variant = new Variant(0, 0, null, null, null, fitness, null, null);
+    return variant;
+  }
+}


### PR DESCRIPTION
resolve #564
古い個体が優先的に残される問題（a.k.a. じじい-oriented問題）を解決した．

## やったこと
- `DefaultVariantSelection#exec` で真っ先にVariantをshuffleする操作を追加
　　-> 古い個体がリスト内で偏らないように
- `DefaultVariantSelectionTest#testExec` を改良
　　-> shufflingを追加したことによるもの
- `EliteAndOldVariantSelection`および`EliteAndOldVariantSelectionTest`を追加
　　-> 従来の`DefaultVariantSelection`

## 気になること
- 従来の実装（じじい-oriented）の命名問題
`EliteAndOldVariantSelection`という名前で実装したがこの名前でいいのか

https://github.com/kusumotolab/kGenProg/issues/564#issuecomment-459242821

> 現状の実装（じじい-oriented）はどう名前をつけるか？
> -> EliteAndxxxVariantSelection
> xxx: Old, Ancient, Ancestor, ...


- `{Default, EliteAndOld}VariantSelection`を実行時にswitchできるオプションは実装してないです
最近オプションが増えすぎている，追加するかどうか