### PR TITLE
交叉対象バリアントの選択において，二つ目の親を一つ目の親と被らないように選ぶように修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverAdaptor.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverAdaptor.java
@@ -4,10 +4,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 
 public abstract class CrossoverAdaptor implements Crossover {
+
+  private static Logger log = LoggerFactory.getLogger(CrossoverAdaptor.class);
 
   private final FirstVariantSelectionStrategy firstVariantSelectionStrategy;
   private final SecondVariantSelectionStrategy secondVariantSelectionStrategy;
@@ -47,19 +51,20 @@ public abstract class CrossoverAdaptor implements Crossover {
     }
 
     final List<Variant> variants = new ArrayList<>();
-
-    // generatingCountを超えるまでバリアントを作りづづける
-    while (variants.size() < generatingCount) {
-      final List<Variant> newVariants = makeVariants(filteredVariants, variantStore);
-      if (newVariants.isEmpty()) { // 交叉によりバリアントが生成されなかった場合はループを抜ける
-        break;
+    try {
+      // generatingCountを超えるまでバリアントを作りづづける
+      while (variants.size() < generatingCount) {
+        final List<Variant> newVariants = makeVariants(filteredVariants, variantStore);
+        variants.addAll(newVariants);
       }
-      variants.addAll(newVariants);
+    } catch (final CrossoverInfeasibleException e) {
+      log.debug(e.getMessage());
     }
 
     // バリアントを作りすぎた場合はそれを除いてリターン
     return variants.subList(0, generatingCount);
   }
 
-  protected abstract List<Variant> makeVariants(List<Variant> variants, VariantStore variantStore);
+  protected abstract List<Variant> makeVariants(List<Variant> variants, VariantStore variantStore)
+      throws CrossoverInfeasibleException;
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverAdaptor.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverAdaptor.java
@@ -20,7 +20,7 @@ public abstract class CrossoverAdaptor implements Crossover {
     this.secondVariantSelectionStrategy = secondVariantSelectionStrategy;
     this.generatingCount = generatingCount;
   }
-  
+
   @Override
   public FirstVariantSelectionStrategy getFirstVariantSelectionStrategy() {
     return firstVariantSelectionStrategy;
@@ -51,6 +51,9 @@ public abstract class CrossoverAdaptor implements Crossover {
     // generatingCountを超えるまでバリアントを作りづづける
     while (variants.size() < generatingCount) {
       final List<Variant> newVariants = makeVariants(filteredVariants, variantStore);
+      if (newVariants.isEmpty()) { // 交叉によりバリアントが生成されなかった場合はループを抜ける
+        break;
+      }
       variants.addAll(newVariants);
     }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverInfeasibleException.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverInfeasibleException.java
@@ -1,0 +1,11 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+
+public class CrossoverInfeasibleException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public CrossoverInfeasibleException(final String text) {
+    super(text);
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossover.java
@@ -2,7 +2,6 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -31,12 +30,10 @@ public class RandomCrossover extends CrossoverAdaptor {
   }
 
   @Override
-  public List<Variant> makeVariants(final List<Variant> variants, final VariantStore store) {
+  public List<Variant> makeVariants(final List<Variant> variants, final VariantStore store)
+      throws CrossoverInfeasibleException {
     final Variant variantA = getFirstVariantSelectionStrategy().exec(variants);
     final Variant variantB = getSecondVariantSelectionStrategy().exec(variants, variantA);
-    if (null == variantB) { // 二つ目の親となるバリアントがない場合は空のリストを返す
-      return Collections.emptyList();
-    }
     final Gene geneA = variantA.getGene();
     final Gene geneB = variantB.getGene();
     final List<Base> basesA = geneA.getBases();

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossover.java
@@ -2,6 +2,7 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -33,6 +34,9 @@ public class RandomCrossover extends CrossoverAdaptor {
   public List<Variant> makeVariants(final List<Variant> variants, final VariantStore store) {
     final Variant variantA = getFirstVariantSelectionStrategy().exec(variants);
     final Variant variantB = getSecondVariantSelectionStrategy().exec(variants, variantA);
+    if (null == variantB) { // 二つ目の親となるバリアントがない場合は空のリストを返す
+      return Collections.emptyList();
+    }
     final Gene geneA = variantA.getGene();
     final Gene geneB = variantB.getGene();
     final List<Base> basesA = geneA.getBases();

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantEliteSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantEliteSelection.java
@@ -11,12 +11,13 @@ import jp.kusumotolab.kgenprog.ga.variant.Variant;
 public class SecondVariantEliteSelection implements SecondVariantSelectionStrategy {
 
   @Override
-  public Variant exec(final List<Variant> variants, final Variant firstVariant) {
+  public Variant exec(final List<Variant> variants, final Variant firstVariant)
+      throws CrossoverInfeasibleException {
     return variants.stream()
         .sorted(Comparator.comparing(Variant::getFitness)
             .reversed())
         .filter(v -> v != firstVariant) // TODO 本来は Variantにequalsメソッドを定義すべき？
         .findFirst()
-        .get();
+        .orElseThrow(() -> new CrossoverInfeasibleException("no variant for second parent"));
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantGeneSimilarityBasedSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantGeneSimilarityBasedSelection.java
@@ -1,9 +1,14 @@
 package jp.kusumotolab.kgenprog.ga.crossover;
 
+import java.util.Random;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public class SecondVariantGeneSimilarityBasedSelection
     extends SecondVariantSimilarityBasedSelection {
+
+  public SecondVariantGeneSimilarityBasedSelection(final Random random) {
+    super(random);
+  }
 
   @Override
   protected double calculateSimilarity(final Variant variant1, final Variant variant2) {

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantRandomSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantRandomSelection.java
@@ -1,6 +1,5 @@
 package jp.kusumotolab.kgenprog.ga.crossover;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -27,7 +26,6 @@ public class SecondVariantRandomSelection implements SecondVariantSelectionStrat
     if (secondVariantCandidates.isEmpty()) { // 候補リストが空の時はnullを返す
       return null;
     }
-    Collections.shuffle(secondVariantCandidates, random);
-    return secondVariantCandidates.get(0);
+    return secondVariantCandidates.get(random.nextInt(secondVariantCandidates.size()));
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantRandomSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantRandomSelection.java
@@ -1,7 +1,9 @@
 package jp.kusumotolab.kgenprog.ga.crossover;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public class SecondVariantRandomSelection implements SecondVariantSelectionStrategy {
@@ -12,10 +14,20 @@ public class SecondVariantRandomSelection implements SecondVariantSelectionStrat
     this.random = random;
   }
 
+  /**
+   * 一つ目の親以外のバリアントからランダムに選択
+   * 
+   */
   @Override
   public Variant exec(final List<Variant> variants, final Variant firstVariant) {
-    return variants.get(random.nextInt(variants.size()));
+
+    final List<Variant> secondVariantCandidates = variants.stream()
+        .filter(v -> !v.equals(firstVariant))
+        .collect(Collectors.toList());
+    if (secondVariantCandidates.isEmpty()) { // 候補リストが空の時はnullを返す
+      return null;
+    }
+    Collections.shuffle(secondVariantCandidates, random);
+    return secondVariantCandidates.get(0);
   }
-
-
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantRandomSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantRandomSelection.java
@@ -18,13 +18,14 @@ public class SecondVariantRandomSelection implements SecondVariantSelectionStrat
    * 
    */
   @Override
-  public Variant exec(final List<Variant> variants, final Variant firstVariant) {
+  public Variant exec(final List<Variant> variants, final Variant firstVariant)
+      throws CrossoverInfeasibleException {
 
     final List<Variant> secondVariantCandidates = variants.stream()
         .filter(v -> !v.equals(firstVariant))
         .collect(Collectors.toList());
-    if (secondVariantCandidates.isEmpty()) { // 候補リストが空の時はnullを返す
-      return null;
+    if (secondVariantCandidates.isEmpty()) { // 候補リストが空の時は例外を投げる
+      throw new CrossoverInfeasibleException("no variant for second parent");
     }
     return secondVariantCandidates.get(random.nextInt(secondVariantCandidates.size()));
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSelectionStrategy.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSelectionStrategy.java
@@ -2,15 +2,28 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 
 import java.util.List;
 import java.util.Random;
-
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
+/**
+ * 交叉の二つ目の親を選択する戦略のインターフェース． 一つ目の親として選択されたバリアントとは異なるバリアントを選択する必要がある．
+ * 
+ * @author higo
+ *
+ */
 public interface SecondVariantSelectionStrategy {
 
+  /**
+   * 交叉の二つ目の親を選択するメソッド．
+   * 
+   * @param variants 親の候補
+   * @param firstVariant 一つ目の親として選択されたバリアント
+   * @return 二つ目の親として選択されたバリアント
+   */
   Variant exec(List<Variant> variants, Variant firstVariant);
 
   public enum Strategy {
     Elite {
+
       @Override
       public SecondVariantSelectionStrategy initialize(final Random random) {
         return new SecondVariantEliteSelection();
@@ -18,6 +31,7 @@ public interface SecondVariantSelectionStrategy {
     },
 
     GeneSimilarity {
+
       @Override
       public SecondVariantSelectionStrategy initialize(final Random random) {
         return new SecondVariantGeneSimilarityBasedSelection();
@@ -25,6 +39,7 @@ public interface SecondVariantSelectionStrategy {
     },
 
     Random {
+
       @Override
       public SecondVariantSelectionStrategy initialize(final java.util.Random random) {
         return new SecondVariantRandomSelection(random);
@@ -32,6 +47,7 @@ public interface SecondVariantSelectionStrategy {
     },
 
     TestSimilarity {
+
       @Override
       public SecondVariantSelectionStrategy initialize(final Random random) {
         return new SecondVariantTestSimilarityBasedSelection();

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSelectionStrategy.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSelectionStrategy.java
@@ -19,7 +19,7 @@ public interface SecondVariantSelectionStrategy {
    * @param firstVariant 一つ目の親として選択されたバリアント
    * @return 二つ目の親として選択されたバリアント
    */
-  Variant exec(List<Variant> variants, Variant firstVariant);
+  Variant exec(List<Variant> variants, Variant firstVariant) throws CrossoverInfeasibleException;
 
   public enum Strategy {
     Elite {

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSelectionStrategy.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSelectionStrategy.java
@@ -34,7 +34,7 @@ public interface SecondVariantSelectionStrategy {
 
       @Override
       public SecondVariantSelectionStrategy initialize(final Random random) {
-        return new SecondVariantGeneSimilarityBasedSelection();
+        return new SecondVariantGeneSimilarityBasedSelection(random);
       }
     },
 
@@ -50,7 +50,7 @@ public interface SecondVariantSelectionStrategy {
 
       @Override
       public SecondVariantSelectionStrategy initialize(final Random random) {
-        return new SecondVariantTestSimilarityBasedSelection();
+        return new SecondVariantTestSimilarityBasedSelection(random);
       }
     };
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSimilarityBasedSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSimilarityBasedSelection.java
@@ -1,15 +1,36 @@
 package jp.kusumotolab.kgenprog.ga.crossover;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import java.util.stream.Collectors;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public abstract class SecondVariantSimilarityBasedSelection
     implements SecondVariantSelectionStrategy {
 
+
+  private final Random random;
+
+  protected SecondVariantSimilarityBasedSelection(final Random random) {
+    this.random = random;
+  }
+
   @Override
   public Variant exec(final List<Variant> variants, final Variant firstVariant) {
+
     double minSimilarity = 1.0d;
-    Variant secondVariant = firstVariant;
+
+    // secondVariantの初期値を，一つ目の親以外のバリアントからランダムに選択
+    final List<Variant> secondVariantCandidates = variants.stream()
+        .filter(v -> !v.equals(firstVariant))
+        .collect(Collectors.toList());
+    if (secondVariantCandidates.isEmpty()) {
+      throw new NoSuchElementException("there is no candidate for second parent for crossover");
+    }
+    Collections.shuffle(secondVariantCandidates, random);
+    Variant secondVariant = secondVariantCandidates.get(0);
 
     for (final Variant variant : variants) {
       final double similarity = calculateSimilarity(firstVariant, variant);

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSimilarityBasedSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSimilarityBasedSelection.java
@@ -2,7 +2,6 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.stream.Collectors;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
@@ -26,8 +25,8 @@ public abstract class SecondVariantSimilarityBasedSelection
     final List<Variant> secondVariantCandidates = variants.stream()
         .filter(v -> !v.equals(firstVariant))
         .collect(Collectors.toList());
-    if (secondVariantCandidates.isEmpty()) {
-      throw new NoSuchElementException("there is no candidate for second parent for crossover");
+    if (secondVariantCandidates.isEmpty()) { // 候補リストが空の時はnullを返す
+      return null;
     }
     Collections.shuffle(secondVariantCandidates, random);
     Variant secondVariant = secondVariantCandidates.get(0);

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSimilarityBasedSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSimilarityBasedSelection.java
@@ -1,6 +1,5 @@
 package jp.kusumotolab.kgenprog.ga.crossover;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -28,8 +27,8 @@ public abstract class SecondVariantSimilarityBasedSelection
     if (secondVariantCandidates.isEmpty()) { // 候補リストが空の時はnullを返す
       return null;
     }
-    Collections.shuffle(secondVariantCandidates, random);
-    Variant secondVariant = secondVariantCandidates.get(0);
+    Variant secondVariant =
+        secondVariantCandidates.get(random.nextInt(secondVariantCandidates.size()));
 
     for (final Variant variant : variants) {
       final double similarity = calculateSimilarity(firstVariant, variant);

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSimilarityBasedSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSimilarityBasedSelection.java
@@ -16,7 +16,8 @@ public abstract class SecondVariantSimilarityBasedSelection
   }
 
   @Override
-  public Variant exec(final List<Variant> variants, final Variant firstVariant) {
+  public Variant exec(final List<Variant> variants, final Variant firstVariant)
+      throws CrossoverInfeasibleException {
 
     double minSimilarity = 1.0d;
 
@@ -24,8 +25,8 @@ public abstract class SecondVariantSimilarityBasedSelection
     final List<Variant> secondVariantCandidates = variants.stream()
         .filter(v -> !v.equals(firstVariant))
         .collect(Collectors.toList());
-    if (secondVariantCandidates.isEmpty()) { // 候補リストが空の時はnullを返す
-      return null;
+    if (secondVariantCandidates.isEmpty()) { // 候補リストが空の時は例外を投げる
+      throw new CrossoverInfeasibleException("no variant for second parent");
     }
     Variant secondVariant =
         secondVariantCandidates.get(random.nextInt(secondVariantCandidates.size()));

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantTestSimilarityBasedSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantTestSimilarityBasedSelection.java
@@ -1,9 +1,14 @@
 package jp.kusumotolab.kgenprog.ga.crossover;
 
+import java.util.Random;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 
 public class SecondVariantTestSimilarityBasedSelection
     extends SecondVariantSimilarityBasedSelection {
+
+  public SecondVariantTestSimilarityBasedSelection(final Random random) {
+    super(random);
+  }
 
   @Override
   protected double calculateSimilarity(final Variant variant1, final Variant variant2) {

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossover.java
@@ -1,6 +1,7 @@
 package jp.kusumotolab.kgenprog.ga.crossover;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -28,6 +29,9 @@ public class SinglePointCrossover extends CrossoverAdaptor {
   public List<Variant> makeVariants(final List<Variant> variants, final VariantStore store) {
     final Variant variantA = getFirstVariantSelectionStrategy().exec(variants);
     final Variant variantB = getSecondVariantSelectionStrategy().exec(variants, variantA);
+    if (null == variantB) { // 二つ目の親となるバリアントがない場合は空のリストを返す
+      return Collections.emptyList();
+    }
     final Gene geneA = variantA.getGene();
     final Gene geneB = variantB.getGene();
     final List<Base> basesA = geneA.getBases();

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossover.java
@@ -1,7 +1,6 @@
 package jp.kusumotolab.kgenprog.ga.crossover;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -26,12 +25,10 @@ public class SinglePointCrossover extends CrossoverAdaptor {
   }
 
   @Override
-  public List<Variant> makeVariants(final List<Variant> variants, final VariantStore store) {
+  public List<Variant> makeVariants(final List<Variant> variants, final VariantStore store)
+      throws CrossoverInfeasibleException {
     final Variant variantA = getFirstVariantSelectionStrategy().exec(variants);
     final Variant variantB = getSecondVariantSelectionStrategy().exec(variants, variantA);
-    if (null == variantB) { // 二つ目の親となるバリアントがない場合は空のリストを返す
-      return Collections.emptyList();
-    }
     final Gene geneA = variantA.getGene();
     final Gene geneB = variantB.getGene();
     final List<Base> basesA = geneA.getBases();

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
@@ -2,6 +2,7 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import jp.kusumotolab.kgenprog.ga.variant.Base;
@@ -31,6 +32,9 @@ public class UniformCrossover extends CrossoverAdaptor {
   public List<Variant> makeVariants(final List<Variant> variants, final VariantStore store) {
     final Variant variantA = getFirstVariantSelectionStrategy().exec(variants);
     final Variant variantB = getSecondVariantSelectionStrategy().exec(variants, variantA);
+    if (null == variantB) { // 二つ目の親となるバリアントがない場合は空のリストを返す
+      return Collections.emptyList();
+    }
     final Gene geneA = variantA.getGene();
     final Gene geneB = variantB.getGene();
     final List<Base> basesA = geneA.getBases();

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
@@ -2,7 +2,6 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import jp.kusumotolab.kgenprog.ga.variant.Base;
@@ -29,12 +28,10 @@ public class UniformCrossover extends CrossoverAdaptor {
   }
 
   @Override
-  public List<Variant> makeVariants(final List<Variant> variants, final VariantStore store) {
+  public List<Variant> makeVariants(final List<Variant> variants, final VariantStore store)
+      throws CrossoverInfeasibleException {
     final Variant variantA = getFirstVariantSelectionStrategy().exec(variants);
     final Variant variantB = getSecondVariantSelectionStrategy().exec(variants, variantA);
-    if (null == variantB) { // 二つ目の親となるバリアントがない場合は空のリストを返す
-      return Collections.emptyList();
-    }
     final Gene geneA = variantA.getGene();
     final Gene geneB = variantB.getGene();
     final List<Base> basesA = geneA.getBases();

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverSingleTestVariant.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverSingleTestVariant.java
@@ -19,7 +19,7 @@ import jp.kusumotolab.kgenprog.project.test.TestResults;
 // 1つの疑似バリアントからなるテストデータ．
 //
 // 10のテストケースが存在し，奇数番目のテストを失敗する．
-// 4つのBaseを持ち，none，none，nsert，insertである．
+// 4つのBaseを持ち，none，none，insert，insertである．
 public class CrossoverSingleTestVariant {
 
   final Base noneBase;

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverSingleTestVariant.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverSingleTestVariant.java
@@ -1,0 +1,58 @@
+package jp.kusumotolab.kgenprog.ga.crossover;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import java.util.Arrays;
+import org.mockito.Mockito;
+import jp.kusumotolab.kgenprog.ga.validation.Fitness;
+import jp.kusumotolab.kgenprog.ga.validation.SimpleFitness;
+import jp.kusumotolab.kgenprog.ga.variant.Base;
+import jp.kusumotolab.kgenprog.ga.variant.Gene;
+import jp.kusumotolab.kgenprog.ga.variant.HistoricalElement;
+import jp.kusumotolab.kgenprog.ga.variant.Variant;
+import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
+import jp.kusumotolab.kgenprog.project.NoneOperation;
+import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
+import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
+import jp.kusumotolab.kgenprog.project.test.TestResults;
+
+// 1つの疑似バリアントからなるテストデータ．
+//
+// 10のテストケースが存在し，奇数番目のテストを失敗する．
+// 4つのBaseを持ち，none，none，nsert，insertである．
+public class CrossoverSingleTestVariant {
+
+  final Base noneBase;
+  final Base insertBase;
+  final Variant variant;
+  final VariantStore variantStore;
+
+  public CrossoverSingleTestVariant() {
+
+    final TestResults testResultsA = Mockito.mock(TestResults.class);
+    when(testResultsA.getFailedTestFQNs())
+        .thenReturn(Arrays.asList(new TestFullyQualifiedName("Test1"),
+            new TestFullyQualifiedName("Test3"), new TestFullyQualifiedName("Test5"),
+            new TestFullyQualifiedName("Test7"), new TestFullyQualifiedName("Test9")));
+
+    noneBase = new Base(null, new NoneOperation());
+    insertBase = new Base(null, new InsertOperation(null));
+    final Gene geneA = new Gene(Arrays.asList(noneBase, noneBase, insertBase, insertBase));
+
+    final Fitness fitnessA = new SimpleFitness(0.5d);
+
+    variant = Mockito.mock(Variant.class);
+    when(variant.getId()).thenReturn(0l);
+    when(variant.getTestResults()).thenReturn(testResultsA);
+    when(variant.getGene()).thenReturn(geneA);
+    when(variant.getFitness()).thenReturn(fitnessA);
+
+    variantStore = Mockito.mock(VariantStore.class);
+    when(variantStore.getCurrentVariants()).thenReturn(Arrays.asList(variant));
+    when(variantStore.createVariant(any(), any())).thenAnswer(invocation -> {
+      final Gene gene = invocation.getArgument(0);
+      final HistoricalElement element = invocation.getArgument(1);
+      return new Variant(0, 0, gene, null, null, null, null, element);
+    });
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
@@ -30,14 +30,14 @@ public class RandomCrossoverTest {
     // バリアントの生成
     final Crossover crossover10 =
         new RandomCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(), 10);
+            new SecondVariantGeneSimilarityBasedSelection(random), 10);
     final List<Variant> variants10 = crossover10.exec(testVariants.variantStore);
     assertThat(variants10.size()).isEqualTo(10);
 
     // バリアントの生成
     final Crossover crossover100 =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(), 100);
+            new SecondVariantGeneSimilarityBasedSelection(random), 100);
     final List<Variant> variants100 = crossover100.exec(testVariants.variantStore);
     assertThat(variants100.size()).isEqualTo(100);
   }
@@ -115,7 +115,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantGeneSimilarityBasedSelection(), 1);
+        new SecondVariantGeneSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -143,7 +143,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantGeneSimilarityBasedSelection(), 1);
+        new SecondVariantGeneSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -171,7 +171,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantTestSimilarityBasedSelection(), 1);
+        new SecondVariantTestSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -199,7 +199,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantTestSimilarityBasedSelection(), 1);
+        new SecondVariantTestSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
@@ -52,7 +52,7 @@ public class RandomCrossoverTest {
     final Random random = Mockito.mock(Random.class);
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0)
-        .thenReturn(1)
+        .thenReturn(0)
         .thenReturn(2);
 
     // バリアントの生成
@@ -82,7 +82,7 @@ public class RandomCrossoverTest {
     final Random random = Mockito.mock(Random.class);
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(1)
-        .thenReturn(2)
+        .thenReturn(1)
         .thenReturn(3);
 
     // バリアントの生成

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
@@ -269,4 +269,71 @@ public class RandomCrossoverTest {
     assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
         testVariants.insertBase, testVariants.noneBase);
   }
+
+  /**
+   * 交叉の親となりうるバリアントが1つしかない場合のテスト．交叉でバリアントが生成されないことを確認する．
+   */
+  @Test
+  public void testGeneratedVariants09() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(1);
+
+    // バリアントのモック
+    final CrossoverSingleTestVariant singleTestVariant = new CrossoverSingleTestVariant();
+
+    // バリアントの生成
+    final Crossover crossoverEE = new RandomCrossover(random,
+        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1);
+    final List<Variant> variantsEE = crossoverEE.exec(singleTestVariant.variantStore);
+    assertThat(variantsEE).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverER = new RandomCrossover(random,
+        new FirstVariantEliteSelection(random), new SecondVariantRandomSelection(random), 1);
+    final List<Variant> variantsER = crossoverER.exec(singleTestVariant.variantStore);
+    assertThat(variantsER).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverEG =
+        new RandomCrossover(random, new FirstVariantEliteSelection(random),
+            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsEG = crossoverEG.exec(singleTestVariant.variantStore);
+    assertThat(variantsEG).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverET =
+        new RandomCrossover(random, new FirstVariantEliteSelection(random),
+            new SecondVariantTestSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
+    assertThat(variantsET).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRE = new RandomCrossover(random,
+        new FirstVariantRandomSelection(random), new SecondVariantEliteSelection(), 1);
+    final List<Variant> variantsRE = crossoverRE.exec(singleTestVariant.variantStore);
+    assertThat(variantsRE).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRR = new RandomCrossover(random,
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1);
+    final List<Variant> variantsRR = crossoverRR.exec(singleTestVariant.variantStore);
+    assertThat(variantsRR).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRG =
+        new RandomCrossover(random, new FirstVariantRandomSelection(random),
+            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsRG = crossoverRG.exec(singleTestVariant.variantStore);
+    assertThat(variantsRG).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRT =
+        new RandomCrossover(random, new FirstVariantRandomSelection(random),
+            new SecondVariantTestSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
+    assertThat(variantsRT).isEmpty();
+  }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
@@ -30,14 +30,14 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover10 =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(), 10);
+            new SecondVariantGeneSimilarityBasedSelection(random), 10);
     final List<Variant> variants10 = crossover10.exec(testVariants.variantStore);
     assertThat(variants10.size()).isEqualTo(10);
 
     // バリアントの生成
     final Crossover crossover100 =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(), 100);
+            new SecondVariantGeneSimilarityBasedSelection(random), 100);
     final List<Variant> variants100 = crossover100.exec(testVariants.variantStore);
     assertThat(variants100.size()).isEqualTo(100);
   }
@@ -116,7 +116,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -145,7 +145,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -174,7 +174,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -203,7 +203,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
@@ -52,7 +52,7 @@ public class SinglePointCrossoverTest {
     final Random random = Mockito.mock(Random.class);
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0) // variantAを選ぶための0
-        .thenReturn(1) // variantBを選ぶための1
+        .thenReturn(0) // variantBを選ぶための0
         .thenReturn(0); // 交叉ポイントを1にするための0
 
     // バリアントの生成
@@ -82,7 +82,7 @@ public class SinglePointCrossoverTest {
     final Random random = Mockito.mock(Random.class);
     when(random.nextBoolean()).thenReturn(false);
     when(random.nextInt(anyInt())).thenReturn(2) // variantCを選ぶための2
-        .thenReturn(3) // variantDを選ぶための3
+        .thenReturn(2) // variantDを選ぶための2
         .thenReturn(1); // 交叉ポイントを2にするための1
 
     // バリアントの生成

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
@@ -273,4 +273,71 @@ public class SinglePointCrossoverTest {
     assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
         testVariants.noneBase, testVariants.noneBase);
   }
+
+  /**
+   * 交叉の親となりうるバリアントが1つしかない場合のテスト．交叉でバリアントが生成されないことを確認する．
+   */
+  @Test
+  public void testGeneratedVariants09() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(1);
+
+    // バリアントのモック
+    final CrossoverSingleTestVariant singleTestVariant = new CrossoverSingleTestVariant();
+
+    // バリアントの生成
+    final Crossover crossoverEE = new SinglePointCrossover(random,
+        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1);
+    final List<Variant> variantsEE = crossoverEE.exec(singleTestVariant.variantStore);
+    assertThat(variantsEE).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverER = new SinglePointCrossover(random,
+        new FirstVariantEliteSelection(random), new SecondVariantRandomSelection(random), 1);
+    final List<Variant> variantsER = crossoverER.exec(singleTestVariant.variantStore);
+    assertThat(variantsER).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverEG =
+        new SinglePointCrossover(random, new FirstVariantEliteSelection(random),
+            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsEG = crossoverEG.exec(singleTestVariant.variantStore);
+    assertThat(variantsEG).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverET =
+        new SinglePointCrossover(random, new FirstVariantEliteSelection(random),
+            new SecondVariantTestSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
+    assertThat(variantsET).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRE = new SinglePointCrossover(random,
+        new FirstVariantRandomSelection(random), new SecondVariantEliteSelection(), 1);
+    final List<Variant> variantsRE = crossoverRE.exec(singleTestVariant.variantStore);
+    assertThat(variantsRE).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRR = new SinglePointCrossover(random,
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1);
+    final List<Variant> variantsRR = crossoverRR.exec(singleTestVariant.variantStore);
+    assertThat(variantsRR).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRG =
+        new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
+            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsRG = crossoverRG.exec(singleTestVariant.variantStore);
+    assertThat(variantsRG).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRT =
+        new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
+            new SecondVariantTestSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
+    assertThat(variantsRT).isEmpty();
+  }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -52,7 +52,7 @@ public class UniformCrossoverTest {
     final Random random = Mockito.mock(Random.class);
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0) // variantAを選ぶための0
-        .thenReturn(1); // variantBを選ぶための1
+        .thenReturn(0); // variantBを選ぶための1
 
     // バリアントの生成
     final Crossover crossover = new UniformCrossover(random,
@@ -81,7 +81,7 @@ public class UniformCrossoverTest {
     final Random random = Mockito.mock(Random.class);
     when(random.nextBoolean()).thenReturn(false);
     when(random.nextInt(anyInt())).thenReturn(1) // variantBを選ぶための1
-        .thenReturn(2); // variantCを選ぶための2
+        .thenReturn(1); // variantCを選ぶための1
 
     // バリアントの生成
     final Crossover crossover = new UniformCrossover(random,

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -30,14 +30,14 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover10 =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(), 10);
+            new SecondVariantGeneSimilarityBasedSelection(random), 10);
     final List<Variant> variants10 = crossover10.exec(testVariants.variantStore);
     assertThat(variants10.size()).isEqualTo(10);
 
     // バリアントの生成
     final Crossover crossover100 =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(), 100);
+            new SecondVariantGeneSimilarityBasedSelection(random), 100);
     final List<Variant> variants100 = crossover100.exec(testVariants.variantStore);
     assertThat(variants100.size()).isEqualTo(100);
   }
@@ -114,7 +114,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -143,7 +143,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -172,7 +172,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -201,7 +201,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestSimilarityBasedSelection(random), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -243,7 +243,7 @@ public class UniformCrossoverTest {
     assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
         testVariants.noneBase, testVariants.noneBase);
   }
-  
+
   /**
    * 一つ目のバリアントを評価関数，二つ目のバリアントも評価関数で選択する一様交叉のテスト
    */

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -271,4 +271,71 @@ public class UniformCrossoverTest {
     assertThat(gene.getBases()).containsExactly(testVariants.noneBase, testVariants.noneBase,
         testVariants.noneBase, testVariants.noneBase);
   }
+
+  /**
+   * 交叉の親となりうるバリアントが1つしかない場合のテスト．交叉でバリアントが生成されないことを確認する．
+   */
+  @Test
+  public void testGeneratedVariants09() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+    when(random.nextBoolean()).thenReturn(true);
+    when(random.nextInt(anyInt())).thenReturn(1);
+
+    // バリアントのモック
+    final CrossoverSingleTestVariant singleTestVariant = new CrossoverSingleTestVariant();
+
+    // バリアントの生成
+    final Crossover crossoverEE = new UniformCrossover(random,
+        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1);
+    final List<Variant> variantsEE = crossoverEE.exec(singleTestVariant.variantStore);
+    assertThat(variantsEE).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverER = new UniformCrossover(random,
+        new FirstVariantEliteSelection(random), new SecondVariantRandomSelection(random), 1);
+    final List<Variant> variantsER = crossoverER.exec(singleTestVariant.variantStore);
+    assertThat(variantsER).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverEG =
+        new UniformCrossover(random, new FirstVariantEliteSelection(random),
+            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsEG = crossoverEG.exec(singleTestVariant.variantStore);
+    assertThat(variantsEG).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverET =
+        new UniformCrossover(random, new FirstVariantEliteSelection(random),
+            new SecondVariantTestSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
+    assertThat(variantsET).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRE = new UniformCrossover(random,
+        new FirstVariantRandomSelection(random), new SecondVariantEliteSelection(), 1);
+    final List<Variant> variantsRE = crossoverRE.exec(singleTestVariant.variantStore);
+    assertThat(variantsRE).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRR = new UniformCrossover(random,
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1);
+    final List<Variant> variantsRR = crossoverRR.exec(singleTestVariant.variantStore);
+    assertThat(variantsRR).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRG =
+        new UniformCrossover(random, new FirstVariantRandomSelection(random),
+            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsRG = crossoverRG.exec(singleTestVariant.variantStore);
+    assertThat(variantsRG).isEmpty();
+
+    // バリアントの生成
+    final Crossover crossoverRT =
+        new UniformCrossover(random, new FirstVariantRandomSelection(random),
+            new SecondVariantTestSimilarityBasedSelection(random), 1);
+    final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
+    assertThat(variantsRT).isEmpty();
+  }
 }


### PR DESCRIPTION
resolve #568 

### やったこと
- exec#SecondVariantSimilarityBasedSelectionにおいて，一つ目の親と同じバリアントを二つ目の親として返すことが内容に修正
- exec#SecondVariantRandomSelectionにおいて，一つ目の親と同じバリアントを二つ目の親として返すことが内容に修正
- 上記2メソッドにおいて，交叉対象バリアントが足りない（1つしかない）場合は，nullを返すように修正
- 各CrossoverのmakeVariantsにおいて，二つ目の親がnullとなった場合には空のリストを返すように修正
- 上記に伴い，exec#CrossoverAdaptorにおいて，交叉でバリアントが生成できなくなった場合に交叉生成ループを抜けるように修正
- 各種テストケースの追加