### PR TITLE
テストの類似度に基づく第二バリアント選択方法の改善

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSelectionStrategy.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSelectionStrategy.java
@@ -50,7 +50,7 @@ public interface SecondVariantSelectionStrategy {
 
       @Override
       public SecondVariantSelectionStrategy initialize(final Random random) {
-        return new SecondVariantTestSimilarityBasedSelection(random);
+        return new SecondVariantTestSimilarityBasedSelection();
       }
     };
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSelectionStrategy.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantSelectionStrategy.java
@@ -50,7 +50,7 @@ public interface SecondVariantSelectionStrategy {
 
       @Override
       public SecondVariantSelectionStrategy initialize(final Random random) {
-        return new SecondVariantTestSimilarityBasedSelection();
+        return new SecondVariantTestComplementaryBasedSelection();
       }
     };
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantTestComplementaryBasedSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantTestComplementaryBasedSelection.java
@@ -9,7 +9,7 @@ import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.project.FullyQualifiedName;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
 
-public class SecondVariantTestSimilarityBasedSelection implements SecondVariantSelectionStrategy {
+public class SecondVariantTestComplementaryBasedSelection implements SecondVariantSelectionStrategy {
 
   // 処理手順は以下の通り．
   // 1. 第一バリアントを取り除いたバリアントのリスト（secondVariantCandidates）を作成

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantTestSimilarityBasedSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantTestSimilarityBasedSelection.java
@@ -48,8 +48,8 @@ public class SecondVariantTestSimilarityBasedSelection implements SecondVariantS
 
   private Long getSuccessedNumber(final TestResults testResults,
       final Collection<FullyQualifiedName> targetFQNs) {
-    return new Long(targetFQNs.stream()
+    return targetFQNs.stream()
         .filter(fqn -> !testResults.getTestResult(fqn).failed)
-        .count());
+        .count();
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantTestSimilarityBasedSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantTestSimilarityBasedSelection.java
@@ -1,18 +1,62 @@
 package jp.kusumotolab.kgenprog.ga.crossover;
 
-import java.util.Random;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
+import jp.kusumotolab.kgenprog.project.FullyQualifiedName;
+import jp.kusumotolab.kgenprog.project.test.TestResults;
 
-public class SecondVariantTestSimilarityBasedSelection
-    extends SecondVariantSimilarityBasedSelection {
+public class SecondVariantTestSimilarityBasedSelection implements SecondVariantSelectionStrategy {
 
-  public SecondVariantTestSimilarityBasedSelection(final Random random) {
-    super(random);
+  // 第一バリアントにおける失敗テスト群と成功テスト群に分けて処理を行うため，
+  // 親クラス（SecondVariantSimilarityBasedSelection）のexecでは処理しにくい．
+  // そのため，このクラスでは独自のexecメソッドを定義してる（SecondVariantSimilarityBasedSelectionを継承していない）．
+  // 処理手順は以下の通り．
+  // 1. 第一バリアントを取り除いたバリアントのリスト（secondVariantCandidates）を作成
+  // 2. secondVariantCandidatesを，第一バリアントが成功したテストについてテストの成功数の降順でソート．
+  // 3. secondVariantCandidatesを，第一バリアントが失敗したテストについてテストの成功数の降順でソート．
+  // 4. secondVariantCandidatesの先頭の要素を返す．
+  @Override
+  public Variant exec(final List<Variant> variants, final Variant firstVariant)
+      throws CrossoverInfeasibleException {
+
+    // 第一バリアントを取り除いたバリアントのリストを作成
+    final List<Variant> secondVariantCandidates = variants.stream()
+        .filter(v -> !v.equals(firstVariant))
+        .collect(Collectors.toList());
+    if (secondVariantCandidates.isEmpty()) { // 候補リストが空の時は例外を投げる
+      throw new CrossoverInfeasibleException("no variant for second parent");
+    }
+
+    // firstVariantにおいて，失敗したテスト一覧(failedTestFQNs)と成功したテスト一覧(successedTestFQNs)を取得
+    final TestResults testResults = firstVariant.getTestResults();
+    final List<FullyQualifiedName> failedTestFQNs = testResults.getFailedTestFQNs();
+    final List<FullyQualifiedName> successedTestFQNs = testResults.getSuccessedTestFQNs();
+
+    // secondVariantCandidatesを，successedTestFQNsにおいて成功したテストが多い順にソート
+    Collections.sort(secondVariantCandidates,
+        Comparator
+            .<Variant>comparingLong(v -> getSuccessedNumber(v.getTestResults(), successedTestFQNs))
+            .reversed());
+
+
+    // secondVariantCandidatesを，failedTestFQNsにおいて成功したテストが多い順にソート
+    Collections.sort(secondVariantCandidates,
+        Comparator
+            .<Variant>comparingLong(v -> getSuccessedNumber(v.getTestResults(), failedTestFQNs))
+            .reversed());
+
+    // variantsの最初の要素を返す
+    return secondVariantCandidates.get(0);
   }
 
-  @Override
-  protected double calculateSimilarity(final Variant variant1, final Variant variant2) {
-    return SimilarityCalculator.exec(variant1, variant2, v -> v.getTestResults()
-        .getFailedTestFQNs());
+  private Long getSuccessedNumber(final TestResults testResults,
+      final Collection<FullyQualifiedName> targetFQNs) {
+    return new Long(targetFQNs.stream()
+        .filter(fqn -> !testResults.getTestResult(fqn).failed)
+        .count());
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantTestSimilarityBasedSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SecondVariantTestSimilarityBasedSelection.java
@@ -11,9 +11,6 @@ import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 public class SecondVariantTestSimilarityBasedSelection implements SecondVariantSelectionStrategy {
 
-  // 第一バリアントにおける失敗テスト群と成功テスト群に分けて処理を行うため，
-  // 親クラス（SecondVariantSimilarityBasedSelection）のexecでは処理しにくい．
-  // そのため，このクラスでは独自のexecメソッドを定義してる（SecondVariantSimilarityBasedSelectionを継承していない）．
   // 処理手順は以下の通り．
   // 1. 第一バリアントを取り除いたバリアントのリスト（secondVariantCandidates）を作成
   // 2. secondVariantCandidatesを，第一バリアントが成功したテストについてテストの成功数の降順でソート．
@@ -36,18 +33,14 @@ public class SecondVariantTestSimilarityBasedSelection implements SecondVariantS
     final List<FullyQualifiedName> failedTestFQNs = testResults.getFailedTestFQNs();
     final List<FullyQualifiedName> successedTestFQNs = testResults.getSuccessedTestFQNs();
 
-    // secondVariantCandidatesを，successedTestFQNsにおいて成功したテストが多い順にソート
-    Collections.sort(secondVariantCandidates,
-        Comparator
-            .<Variant>comparingLong(v -> getSuccessedNumber(v.getTestResults(), successedTestFQNs))
-            .reversed());
-
-
-    // secondVariantCandidatesを，failedTestFQNsにおいて成功したテストが多い順にソート
-    Collections.sort(secondVariantCandidates,
-        Comparator
-            .<Variant>comparingLong(v -> getSuccessedNumber(v.getTestResults(), failedTestFQNs))
-            .reversed());
+    // secondVariantCandidatesを，successedTestFQNsにおいて成功したテストが多い順にソートし，
+    // そのあとにfailedTestFQNsにおいて成功したテストが多い順にソート
+    final Comparator<Variant> comparator = Comparator
+        .<Variant>comparingLong(v -> getSuccessedNumber(v.getTestResults(), successedTestFQNs))
+        .reversed()
+        .thenComparingLong(v -> getSuccessedNumber(v.getTestResults(), failedTestFQNs))
+        .reversed();
+    Collections.sort(secondVariantCandidates, comparator);
 
     // variantsの最初の要素を返す
     return secondVariantCandidates.get(0);

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
@@ -2,6 +2,7 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.validation.Fitness;
@@ -14,6 +15,7 @@ import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 import jp.kusumotolab.kgenprog.project.NoneOperation;
 import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
 import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
+import jp.kusumotolab.kgenprog.project.test.TestResult;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 // 4つの疑似バリアントからなるテストデータ．
@@ -41,26 +43,137 @@ public class CrossoverTestVariants {
 
   public CrossoverTestVariants() {
 
+    final TestResult successedTestResult = Mockito.mock(TestResult.class);
+    final TestResult failedTestResult = Mockito.mock(TestResult.class);
+
+    try {
+      Class<?> c = Class.forName("jp.kusumotolab.kgenprog.project.test.TestResult");
+      Field f = c.getDeclaredField("failed");
+      f.setAccessible(true);
+      f.set(successedTestResult, false);
+      f.set(failedTestResult, true);
+    } catch (ClassNotFoundException | NoSuchFieldException | SecurityException
+        | IllegalArgumentException | IllegalAccessException e) {
+      e.printStackTrace();
+    }
+
     final TestResults testResultsA = Mockito.mock(TestResults.class);
+    when(testResultsA.getSuccessedTestFQNs())
+        .thenReturn(Arrays.asList(new TestFullyQualifiedName("Test2"),
+            new TestFullyQualifiedName("Test4"), new TestFullyQualifiedName("Test6"),
+            new TestFullyQualifiedName("Test8"), new TestFullyQualifiedName("Test10")));
     when(testResultsA.getFailedTestFQNs())
         .thenReturn(Arrays.asList(new TestFullyQualifiedName("Test1"),
             new TestFullyQualifiedName("Test3"), new TestFullyQualifiedName("Test5"),
             new TestFullyQualifiedName("Test7"), new TestFullyQualifiedName("Test9")));
+    when(testResultsA.getTestResult(new TestFullyQualifiedName("Test1")))
+        .thenReturn(failedTestResult);
+    when(testResultsA.getTestResult(new TestFullyQualifiedName("Test2")))
+        .thenReturn(successedTestResult);
+    when(testResultsA.getTestResult(new TestFullyQualifiedName("Test3")))
+        .thenReturn(failedTestResult);
+    when(testResultsA.getTestResult(new TestFullyQualifiedName("Test4")))
+        .thenReturn(successedTestResult);
+    when(testResultsA.getTestResult(new TestFullyQualifiedName("Test5")))
+        .thenReturn(failedTestResult);
+    when(testResultsA.getTestResult(new TestFullyQualifiedName("Test6")))
+        .thenReturn(successedTestResult);
+    when(testResultsA.getTestResult(new TestFullyQualifiedName("Test7")))
+        .thenReturn(failedTestResult);
+    when(testResultsA.getTestResult(new TestFullyQualifiedName("Test8")))
+        .thenReturn(successedTestResult);
+    when(testResultsA.getTestResult(new TestFullyQualifiedName("Test9")))
+        .thenReturn(failedTestResult);
+    when(testResultsA.getTestResult(new TestFullyQualifiedName("Test10")))
+        .thenReturn(successedTestResult);
+
     final TestResults testResultsB = Mockito.mock(TestResults.class);
+    when(testResultsB.getSuccessedTestFQNs())
+        .thenReturn(Arrays.asList(new TestFullyQualifiedName("Test1"),
+            new TestFullyQualifiedName("Test3"), new TestFullyQualifiedName("Test5"),
+            new TestFullyQualifiedName("Test7"), new TestFullyQualifiedName("Test9")));
     when(testResultsB.getFailedTestFQNs())
         .thenReturn(Arrays.asList(new TestFullyQualifiedName("Test2"),
             new TestFullyQualifiedName("Test4"), new TestFullyQualifiedName("Test6"),
             new TestFullyQualifiedName("Test8"), new TestFullyQualifiedName("Test10")));
+    when(testResultsB.getTestResult(new TestFullyQualifiedName("Test1")))
+        .thenReturn(successedTestResult);
+    when(testResultsB.getTestResult(new TestFullyQualifiedName("Test2")))
+        .thenReturn(failedTestResult);
+    when(testResultsB.getTestResult(new TestFullyQualifiedName("Test3")))
+        .thenReturn(successedTestResult);
+    when(testResultsB.getTestResult(new TestFullyQualifiedName("Test4")))
+        .thenReturn(failedTestResult);
+    when(testResultsB.getTestResult(new TestFullyQualifiedName("Test5")))
+        .thenReturn(successedTestResult);
+    when(testResultsB.getTestResult(new TestFullyQualifiedName("Test6")))
+        .thenReturn(failedTestResult);
+    when(testResultsB.getTestResult(new TestFullyQualifiedName("Test7")))
+        .thenReturn(successedTestResult);
+    when(testResultsB.getTestResult(new TestFullyQualifiedName("Test8")))
+        .thenReturn(failedTestResult);
+    when(testResultsB.getTestResult(new TestFullyQualifiedName("Test9")))
+        .thenReturn(successedTestResult);
+    when(testResultsB.getTestResult(new TestFullyQualifiedName("Test10")))
+        .thenReturn(failedTestResult);
+
     final TestResults testResultsC = Mockito.mock(TestResults.class);
+    when(testResultsC.getSuccessedTestFQNs()).thenReturn(
+        Arrays.asList(new TestFullyQualifiedName("Test7"), new TestFullyQualifiedName("Test8"),
+            new TestFullyQualifiedName("Test9"), new TestFullyQualifiedName("Test10")));
     when(testResultsC.getFailedTestFQNs()).thenReturn(
         Arrays.asList(new TestFullyQualifiedName("Test1"), new TestFullyQualifiedName("Test2"),
             new TestFullyQualifiedName("Test3"), new TestFullyQualifiedName("Test4"),
             new TestFullyQualifiedName("Test5"), new TestFullyQualifiedName("Test6")));
+    when(testResultsC.getTestResult(new TestFullyQualifiedName("Test1")))
+        .thenReturn(failedTestResult);
+    when(testResultsC.getTestResult(new TestFullyQualifiedName("Test2")))
+        .thenReturn(failedTestResult);
+    when(testResultsC.getTestResult(new TestFullyQualifiedName("Test3")))
+        .thenReturn(failedTestResult);
+    when(testResultsC.getTestResult(new TestFullyQualifiedName("Test4")))
+        .thenReturn(failedTestResult);
+    when(testResultsC.getTestResult(new TestFullyQualifiedName("Test5")))
+        .thenReturn(failedTestResult);
+    when(testResultsC.getTestResult(new TestFullyQualifiedName("Test6")))
+        .thenReturn(failedTestResult);
+    when(testResultsC.getTestResult(new TestFullyQualifiedName("Test7")))
+        .thenReturn(successedTestResult);
+    when(testResultsC.getTestResult(new TestFullyQualifiedName("Test8")))
+        .thenReturn(successedTestResult);
+    when(testResultsC.getTestResult(new TestFullyQualifiedName("Test9")))
+        .thenReturn(successedTestResult);
+    when(testResultsC.getTestResult(new TestFullyQualifiedName("Test10")))
+        .thenReturn(successedTestResult);
+
     final TestResults testResultsD = Mockito.mock(TestResults.class);
+    when(testResultsD.getSuccessedTestFQNs()).thenReturn(
+        Arrays.asList(new TestFullyQualifiedName("Test1"), new TestFullyQualifiedName("Test2"),
+            new TestFullyQualifiedName("Test3"), new TestFullyQualifiedName("Test4")));
     when(testResultsD.getFailedTestFQNs()).thenReturn(
         Arrays.asList(new TestFullyQualifiedName("Test5"), new TestFullyQualifiedName("Test6"),
             new TestFullyQualifiedName("Test7"), new TestFullyQualifiedName("Test8"),
             new TestFullyQualifiedName("Test9"), new TestFullyQualifiedName("Test10")));
+    when(testResultsD.getTestResult(new TestFullyQualifiedName("Test1")))
+        .thenReturn(successedTestResult);
+    when(testResultsD.getTestResult(new TestFullyQualifiedName("Test2")))
+        .thenReturn(successedTestResult);
+    when(testResultsD.getTestResult(new TestFullyQualifiedName("Test3")))
+        .thenReturn(successedTestResult);
+    when(testResultsD.getTestResult(new TestFullyQualifiedName("Test4")))
+        .thenReturn(successedTestResult);
+    when(testResultsD.getTestResult(new TestFullyQualifiedName("Test5")))
+        .thenReturn(failedTestResult);
+    when(testResultsD.getTestResult(new TestFullyQualifiedName("Test6")))
+        .thenReturn(failedTestResult);
+    when(testResultsD.getTestResult(new TestFullyQualifiedName("Test7")))
+        .thenReturn(failedTestResult);
+    when(testResultsD.getTestResult(new TestFullyQualifiedName("Test8")))
+        .thenReturn(failedTestResult);
+    when(testResultsD.getTestResult(new TestFullyQualifiedName("Test9")))
+        .thenReturn(failedTestResult);
+    when(testResultsD.getTestResult(new TestFullyQualifiedName("Test10")))
+        .thenReturn(failedTestResult);
 
     noneBase = new Base(null, new NoneOperation());
     insertBase = new Base(null, new InsertOperation(null));

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
@@ -171,7 +171,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantTestSimilarityBasedSelection(random), 1);
+        new SecondVariantTestSimilarityBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -199,7 +199,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantTestSimilarityBasedSelection(random), 1);
+        new SecondVariantTestSimilarityBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -306,7 +306,7 @@ public class RandomCrossoverTest {
     // バリアントの生成
     final Crossover crossoverET =
         new RandomCrossover(random, new FirstVariantEliteSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(random), 1);
+            new SecondVariantTestSimilarityBasedSelection(), 1);
     final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
     assertThat(variantsET).isEmpty();
 
@@ -332,7 +332,7 @@ public class RandomCrossoverTest {
     // バリアントの生成
     final Crossover crossoverRT =
         new RandomCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(random), 1);
+            new SecondVariantTestSimilarityBasedSelection(), 1);
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
@@ -171,7 +171,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantTestSimilarityBasedSelection(), 1);
+        new SecondVariantTestComplementaryBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -199,7 +199,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantTestSimilarityBasedSelection(), 1);
+        new SecondVariantTestComplementaryBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -306,7 +306,7 @@ public class RandomCrossoverTest {
     // バリアントの生成
     final Crossover crossoverET =
         new RandomCrossover(random, new FirstVariantEliteSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1);
     final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
     assertThat(variantsET).isEmpty();
 
@@ -332,7 +332,7 @@ public class RandomCrossoverTest {
     // バリアントの生成
     final Crossover crossoverRT =
         new RandomCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1);
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
@@ -174,7 +174,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -203,7 +203,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -309,7 +309,7 @@ public class SinglePointCrossoverTest {
 
     // バリアントの生成
     final Crossover crossoverET = new SinglePointCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantTestSimilarityBasedSelection(), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantTestComplementaryBasedSelection(), 1);
     final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
     assertThat(variantsET).isEmpty();
 
@@ -335,7 +335,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossoverRT =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1);
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
@@ -174,7 +174,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(random), 1);
+            new SecondVariantTestSimilarityBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -203,7 +203,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(random), 1);
+            new SecondVariantTestSimilarityBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -308,9 +308,8 @@ public class SinglePointCrossoverTest {
     assertThat(variantsEG).isEmpty();
 
     // バリアントの生成
-    final Crossover crossoverET =
-        new SinglePointCrossover(random, new FirstVariantEliteSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(random), 1);
+    final Crossover crossoverET = new SinglePointCrossover(random,
+        new FirstVariantEliteSelection(random), new SecondVariantTestSimilarityBasedSelection(), 1);
     final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
     assertThat(variantsET).isEmpty();
 
@@ -336,7 +335,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossoverRT =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(random), 1);
+            new SecondVariantTestSimilarityBasedSelection(), 1);
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -172,7 +172,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -201,7 +201,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -307,7 +307,7 @@ public class UniformCrossoverTest {
 
     // バリアントの生成
     final Crossover crossoverET = new UniformCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantTestSimilarityBasedSelection(), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantTestComplementaryBasedSelection(), 1);
     final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
     assertThat(variantsET).isEmpty();
 
@@ -333,7 +333,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossoverRT =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1);
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -172,7 +172,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(random), 1);
+            new SecondVariantTestSimilarityBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -201,7 +201,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(random), 1);
+            new SecondVariantTestSimilarityBasedSelection(), 1);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -306,9 +306,8 @@ public class UniformCrossoverTest {
     assertThat(variantsEG).isEmpty();
 
     // バリアントの生成
-    final Crossover crossoverET =
-        new UniformCrossover(random, new FirstVariantEliteSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(random), 1);
+    final Crossover crossoverET = new UniformCrossover(random,
+        new FirstVariantEliteSelection(random), new SecondVariantTestSimilarityBasedSelection(), 1);
     final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
     assertThat(variantsET).isEmpty();
 
@@ -334,7 +333,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossoverRT =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestSimilarityBasedSelection(random), 1);
+            new SecondVariantTestSimilarityBasedSelection(), 1);
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }


### PR DESCRIPTION
第一バリアントが選択されたあとに，第二バリアントをテストの類似度に基づいて選択する方法を改善した．
具体的には，
1. 第一バリアントが失敗しているテストをなるべく多く成功しているバリアントを選択
2. 第一バリアントが成功しているテストもなるべく多く成功しているバリアントを選択

を満たすようなアルゴリズムに変更した．
このアルゴリズムの変更により，SecondVariantTestSimilarityBasedSelectionには独自のexecメソッドが必要になったため，従来の親クラスであったSecondVariantSimilarityBasedSelectionの子クラスではなく，SecondVariantSelectionStrategyインターフェースを実装するように変更した．
また，テストコードも変更した．