### PR TITLE
tomlを使わずに実行した時に落ちる問題を解決

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/SourcePath.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/SourcePath.java
@@ -14,7 +14,7 @@ public abstract class SourcePath {
 
   /**
    * SourcePathを生成する
-   * 
+   *
    * @param rootPath プロジェクトルートへのパス {@link TargetProject#rootPath}
    * @param path ルートからの相対パス
    */
@@ -47,13 +47,15 @@ public abstract class SourcePath {
 
   /**
    * 相対パスに変換する
-   * 
+   *
    * @param base 基準となるパス
    * @param target 対象パス
    * @return 相対パス
    */
   public static Path relativize(final Path base, final Path target) {
-    return base.toAbsolutePath()
-        .relativize(target.toAbsolutePath());
+    return base.normalize()
+        .toAbsolutePath()
+        .relativize(target.normalize()
+            .toAbsolutePath());
   }
 }


### PR DESCRIPTION
resolve #573 
`Path`を`relativize`する時に`normalize`していないことが原因