### PR TITLE
Mutationで選択する個体の重みを変更

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutation.java
@@ -43,7 +43,7 @@ public class RandomMutation extends Mutation {
     final Roulette<Variant> variantRoulette = new Roulette<>(currentVariants, e -> {
       final Fitness fitness = e.getFitness();
       final double value = fitness.getValue();
-      return Double.isNaN(value) ? 0 : value + 1;
+      return Double.isNaN(value) ? 0 : value;
     }, random);
 
     for (int i = 0; i < mutationGeneratingCount; i++) {


### PR DESCRIPTION
resolve #374 
今まではビルドに失敗したものも選択できるよう、重みに1を足していたが、それを削除。
これにより、ビルドに失敗した個体はMutationの対象にはならなくなる。