### PR TITLE
JDTOperationのエラーログを削除

### DIFF
--- a/example/CloseToZero01/kgenprog.toml
+++ b/example/CloseToZero01/kgenprog.toml
@@ -27,7 +27,7 @@ test = ["src/example/CloseToZeroTest.java"]
 
 # Selects the log level to be shown at least.
 # Acceptable values are "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", or "ALL"
-log-level = "TRACE"
+log-level = "INFO"
 
 # Specifies how many variants are generated in a generation by a mutation.
 #mutation-generating-count = <num>

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTOperation.java
@@ -31,6 +31,8 @@ public abstract class JDTOperation implements Operation {
           .collect(Collectors.toList());
       return new GeneratedSourceCode(newASTs, generatedSourceCode.getTestAsts());
     } catch (final Exception e) {
+      log.debug("Opperation failed: {}", e.getMessage());
+      log.trace("Trace:", e);
       return createGenerationFailedSourceCode(e);
     }
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTOperation.java
@@ -31,8 +31,6 @@ public abstract class JDTOperation implements Operation {
           .collect(Collectors.toList());
       return new GeneratedSourceCode(newASTs, generatedSourceCode.getTestAsts());
     } catch (final Exception e) {
-      log.debug("Opperation failed: {}", e.getMessage());
-      log.trace("Trace:", e);
       return createGenerationFailedSourceCode(e);
     }
   }


### PR DESCRIPTION
ref #410 

# 再現
以下のコマンドを叩くと、実行途中にエラーログが流れる
`kgp.jar --config example/CloseToZero01/kgenprog.toml --required-solutions 5`

# 修正内容
エラーログを削除