### PR TITLE
FSに作用するテストの改善

### DIFF
--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreExporterTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreExporterTest.java
@@ -19,10 +19,10 @@ public class VariantStoreExporterTest {
   private Path outDir;
 
   @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() {
     outDir = tempFolder.getRoot()
         .toPath();
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreExporterTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreExporterTest.java
@@ -1,7 +1,6 @@
 package jp.kusumotolab.kgenprog.output;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Before;

--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreExporterTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantStoreExporterTest.java
@@ -2,14 +2,12 @@ package jp.kusumotolab.kgenprog.output;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import jp.kusumotolab.kgenprog.Configuration;
 import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
@@ -20,21 +18,13 @@ public class VariantStoreExporterTest {
 
   private Path outDir;
 
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
   @Before
   public void setUp() throws IOException {
-    /*
-     * ./tmp/outが存在するときは./tmp/outを削除する
-     * VariantExporter.writeToFile()が出力先ディレクトリが存在しないときに
-     * 出力先ディレクトリを作成できている確認するため
-     **/
-    outDir = Paths.get("./tmp/_out-dir-for-test");
-    deleteFile(outDir);
-  }
-
-  @After
-  public void tearDown() throws IOException {
-    // 後始末
-    deleteFile(outDir);
+    outDir = tempFolder.getRoot()
+        .toPath();
   }
 
   @Test
@@ -42,8 +32,7 @@ public class VariantStoreExporterTest {
     // 適当なTargetProjectを作る
     final Path rootPath = Paths.get("example/BuildSuccess01");
     final TargetProject project = TargetProjectFactory.create(rootPath);
-    final Configuration config = new Configuration.Builder(project)
-        .setOutDir(outDir)
+    final Configuration config = new Configuration.Builder(project).setOutDir(outDir)
         .build();
 
     final VariantStore variantStore = TestUtil.createVariantStoreWithDefaultStrategies(config);
@@ -53,25 +42,9 @@ public class VariantStoreExporterTest {
     // 出力ファイルの存在をチェック
     final Path exportedJsonFile = outDir.resolve("history.json");
     assertThat(exportedJsonFile).exists();
+
+    // TODO
+    // ファイルの中身をチェック
   }
 
-  /**
-   * ディレクトリの中身ごとディレクトリを削除する
-   */
-  private void deleteFile(final Path path) throws IOException {
-    if (Files.notExists(path)) {
-      return;
-    }
-
-    if (Files.isDirectory(path)) {
-      final List<Path> subFiles = Files.list(path)
-          .collect(Collectors.toList());
-
-      for (final Path subFile : subFiles) {
-        deleteFile(subFile);
-      }
-    }
-
-    Files.delete(path);
-  }
 }


### PR DESCRIPTION
### 問題
- VariantStoreExporterTest がFSに作用しており，テスト強制停止等で予期せぬ挙動をする
- テストを実行するとtmpフォルダ作りっぱなしになる
- deleteFile()メソッドのような車輪の再発明がある

### 対処
junit.TemporaryFolder を使って一時フォルダの挙動をライブラリに任せた