### PR TITLE
Historical Element生成オプションの追加

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/CUILauncher.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/CUILauncher.java
@@ -42,7 +42,7 @@ public class CUILauncher {
     final RouletteStatementSelection rouletteStatementSelection =
         new RouletteStatementSelection(random);
     final Mutation mutation = new RandomMutation(config.getMutationGeneratingCount(), random,
-        rouletteStatementSelection, config.getScope(), config.needHistoricalElement());
+        rouletteStatementSelection, config.getScope(), config.getNeedHistoricalElement());
     final FirstVariantSelectionStrategy firstVariantSelectionStrategy =
         config.getFirstVariantSelectionStrategy()
             .initialize(random);
@@ -52,7 +52,7 @@ public class CUILauncher {
     final Crossover crossover = config.getCrossoverType()
         .initialize(random, firstVariantSelectionStrategy,
             secondVariantSelectionStrategy, config.getCrossoverGeneratingCount(),
-            config.needHistoricalElement());
+            config.getNeedHistoricalElement());
     final SourceCodeGeneration sourceCodeGeneration = new DefaultSourceCodeGeneration();
     final SourceCodeValidation sourceCodeValidation = new DefaultCodeValidation();
     final VariantSelection variantSelection = new DefaultVariantSelection(config.getHeadcount(),

--- a/src/main/java/jp/kusumotolab/kgenprog/CUILauncher.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/CUILauncher.java
@@ -42,7 +42,7 @@ public class CUILauncher {
     final RouletteStatementSelection rouletteStatementSelection =
         new RouletteStatementSelection(random);
     final Mutation mutation = new RandomMutation(config.getMutationGeneratingCount(), random,
-        rouletteStatementSelection, config.getScope());
+        rouletteStatementSelection, config.getScope(), config.needHistoricalElement());
     final FirstVariantSelectionStrategy firstVariantSelectionStrategy =
         config.getFirstVariantSelectionStrategy()
             .initialize(random);
@@ -51,10 +51,12 @@ public class CUILauncher {
             .initialize(random);
     final Crossover crossover = config.getCrossoverType()
         .initialize(random, firstVariantSelectionStrategy,
-            secondVariantSelectionStrategy, config.getCrossoverGeneratingCount());
+            secondVariantSelectionStrategy, config.getCrossoverGeneratingCount(),
+            config.needHistoricalElement());
     final SourceCodeGeneration sourceCodeGeneration = new DefaultSourceCodeGeneration();
     final SourceCodeValidation sourceCodeValidation = new DefaultCodeValidation();
-    final VariantSelection variantSelection = new DefaultVariantSelection(config.getHeadcount(), random);
+    final VariantSelection variantSelection = new DefaultVariantSelection(config.getHeadcount(),
+        random);
     final TestExecutor testExecutor = new LocalTestExecutor(config);
     final PatchGenerator patchGenerator = new PatchGenerator();
 

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -59,6 +59,7 @@ public class Configuration {
       FirstVariantSelectionStrategy.Strategy.Random;
   public static final SecondVariantSelectionStrategy.Strategy DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY =
       SecondVariantSelectionStrategy.Strategy.Random;
+  public static final boolean DEFAULT_NEED_HISTORICAL_ELEMENT = true;
 
   private final TargetProject targetProject;
   private final List<String> executionTests;
@@ -78,6 +79,7 @@ public class Configuration {
   private final Crossover.Type crossoverType;
   private final FirstVariantSelectionStrategy.Strategy firstVariantSelectionStrategy;
   private final SecondVariantSelectionStrategy.Strategy secondVariantSelectionStrategy;
+  private final boolean needHistoricalElement;
   // endregion
 
   // region Constructor
@@ -101,6 +103,7 @@ public class Configuration {
     crossoverType = builder.crossoverType;
     firstVariantSelectionStrategy = builder.firstVariantSelectionStrategy;
     secondVariantSelectionStrategy = builder.secondVariantSelectionStrategy;
+    needHistoricalElement = builder.needHistoricalElement;
   }
 
   // endregion
@@ -183,6 +186,10 @@ public class Configuration {
 
   public SecondVariantSelectionStrategy.Strategy getSecondVariantSelectionStrategy() {
     return secondVariantSelectionStrategy;
+  }
+
+  public boolean needHistoricalElement() {
+    return needHistoricalElement;
   }
 
   @Override
@@ -314,6 +321,10 @@ public class Configuration {
     private SecondVariantSelectionStrategy.Strategy secondVariantSelectionStrategy =
         DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY;
 
+    @Option(name = "--no-historical-element", usage = "Do not generate historical element.", hidden = true)
+    @com.electronwill.nightconfig.core.conversion.Path("no-historical-element")
+    @PreserveNotNull
+    private boolean needHistoricalElement = DEFAULT_NEED_HISTORICAL_ELEMENT;
     // endregion
 
     // region Constructors
@@ -497,6 +508,11 @@ public class Configuration {
     public Builder setSecondVariantSelectionStrategy
         (final SecondVariantSelectionStrategy.Strategy secondVariantSelectionStrategy) {
       this.secondVariantSelectionStrategy = secondVariantSelectionStrategy;
+      return this;
+    }
+
+    public Builder setNeedHistoricalElement(final boolean needHistoricalElement) {
+      this.needHistoricalElement = needHistoricalElement;
       return this;
     }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -188,7 +188,7 @@ public class Configuration {
     return secondVariantSelectionStrategy;
   }
 
-  public boolean needHistoricalElement() {
+  public boolean getNeedHistoricalElement() {
     return needHistoricalElement;
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import jp.kusumotolab.kgenprog.fl.FaultLocalization;

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import jp.kusumotolab.kgenprog.fl.FaultLocalization;
@@ -26,9 +27,8 @@ import jp.kusumotolab.kgenprog.project.test.TestExecutor;
  * kGenProgのメインクラス．<br>
  * このクラスのインスタンスを生成し，runメソッドを実行することで，自動プログラム修正を行う．<br>
  * コマンドラインからの実行には{@link CUILauncher}}クラスを用いる．<br>
- * 
- * @author higo
  *
+ * @author higo
  */
 public class KGenProgMain {
 
@@ -47,7 +47,7 @@ public class KGenProgMain {
 
   /**
    * コンストラクタ．自動プログラム修正に必要な全ての情報を渡す必要あり．
-   * 
+   *
    * @param config 設定情報
    * @param faultLocalization 自動バグ限局を行うインスタンス
    * @param mutation 変異を行うインスタンス
@@ -79,7 +79,7 @@ public class KGenProgMain {
   /**
    * 自動プログラム修正を実行する．<br>
    * 得られた解（全てのテストケースを通過するプログラム）を返す．<br>
-   * 
+   *
    * @return 得られた解（全てのテストケースを通過するプログラム）
    */
   public List<Variant> run() {

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/Crossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/Crossover.java
@@ -2,22 +2,22 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 
 import java.util.List;
 import java.util.Random;
+
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 
 /**
  * 交叉を表すインターフェース．<br>
  * 交叉アルゴリズムを実装するクラスはこのインターフェースを実装しなければならない．<br>
- * 
- * @author higo
  *
+ * @author higo
  */
 public interface Crossover {
 
   /**
    * 交叉処理を行うメソッド．<br>
    * 交叉対象の個体群を含んだVariantStoreを引数として与える必要あり．<br>
-   * 
+   *
    * @param variantStore 交叉対象の個体群
    * @return 交叉により生成された個体群
    */
@@ -25,127 +25,127 @@ public interface Crossover {
 
   /**
    * 1つ目の親を返す．
-   * 
+   *
    * @return 1つ目の親
    */
   FirstVariantSelectionStrategy getFirstVariantSelectionStrategy();
 
   /**
    * 2つ目の親を返す．
-   * 
+   *
    * @return 2つ目の親
    */
   SecondVariantSelectionStrategy getSecondVariantSelectionStrategy();
 
   /**
    * kGenProgが基本実装として持つ交叉種別を表す列挙型．
-   * 
+   * <p>
    * TODO ここに定義すべきではないものな気がするので将来移動させる予定．
-   * 
-   * @author higo
    *
+   * @author higo
    */
   enum Type {
 
     /**
      * ランダム交叉を表す型．
-     * 
+     *
      * @see jp.kusumotolab.kgenprog.ga.crossover.RandomCrossover
      */
     Random {
-
       /**
        * 交叉を行うインスタンスを生成するメソッド．
-       * 
-       * @see Crossover.Type#initialize(Random, FirstVariantSelectionStrategy,
-       *      SecondVariantSelectionStrategy, int)
-       * 
+       *
+       * @see Crossover.Type#initialize(java.util.Random, FirstVariantSelectionStrategy,
+       *      SecondVariantSelectionStrategy, int, boolean)
+       *
        * @param random 交叉処理の内部でランダム処理を行うためのシード
        * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
        * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
        * @param generatingCount 一世代の交叉処理で生成する個体の数
+       * @param needHistoricalElement
        * @return 交叉を行うインスタンス
        */
       @Override
       public Crossover initialize(final Random random,
           final FirstVariantSelectionStrategy firstVariantSelectionStrategy,
           final SecondVariantSelectionStrategy secondVariantSelectionStrategy,
-          final int generatingCount) {
+          final int generatingCount, boolean needHistoricalElement) {
         return new RandomCrossover(random, firstVariantSelectionStrategy,
-            secondVariantSelectionStrategy, generatingCount);
+            secondVariantSelectionStrategy, generatingCount, needHistoricalElement);
       }
     },
 
     /**
      * 一点交叉を表す型．
-     * 
+     *
      * @see jp.kusumotolab.kgenprog.ga.crossover.SinglePointCrossover
      */
     SinglePoint {
-
       /**
        * 交叉を行うインスタンスを生成するメソッド．
-       * 
-       * @see Crossover.Type#initialize(Random, FirstVariantSelectionStrategy,
-       *      SecondVariantSelectionStrategy, int)
-       * 
+       *
+       * @see Crossover.Type#initialize(java.util.Random, FirstVariantSelectionStrategy,
+       *      SecondVariantSelectionStrategy, int, boolean)
+       *
        * @param random 交叉処理の内部でランダム処理を行うためのシード
        * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
        * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
        * @param generatingCount 一世代の交叉処理で生成する個体の数
+       * @param needHistoricalElement
        * @return 交叉を行うインスタンス
        */
       @Override
       public Crossover initialize(final Random random,
           final FirstVariantSelectionStrategy firstVariantSelectionStrategy,
           final SecondVariantSelectionStrategy secondVariantSelectionStrategy,
-          final int generatingCount) {
+          final int generatingCount, boolean needHistoricalElement) {
         return new SinglePointCrossover(random, firstVariantSelectionStrategy,
-            secondVariantSelectionStrategy, generatingCount);
+            secondVariantSelectionStrategy, generatingCount, needHistoricalElement);
       }
     },
 
     /**
      * 一様交叉を表す型．
-     * 
+     *
      * @see jp.kusumotolab.kgenprog.ga.crossover.UniformCrossover
      */
     Uniform {
-
       /**
        * 交叉を行うインスタンスを生成するメソッド．
-       * 
-       * @see Crossover.Type#initialize(Random, FirstVariantSelectionStrategy,
-       *      SecondVariantSelectionStrategy, int)
-       * 
+       *
+       * @see Crossover.Type#initialize(java.util.Random, FirstVariantSelectionStrategy,
+       *      SecondVariantSelectionStrategy, int, boolean)
+       *
        * @param random 交叉処理の内部でランダム処理を行うためのシード
        * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
        * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
        * @param generatingCount 一世代の交叉処理で生成する個体の数
+       * @param needHistoricalElement
        * @return 交叉を行うインスタンス
        */
       @Override
       public Crossover initialize(final Random random,
           final FirstVariantSelectionStrategy firstVariantSelectionStrategy,
           final SecondVariantSelectionStrategy secondVariantSelectionStrategy,
-          final int generatingCount) {
+          final int generatingCount, boolean needHistoricalElement) {
         return new UniformCrossover(random, firstVariantSelectionStrategy,
-            secondVariantSelectionStrategy, generatingCount);
+            secondVariantSelectionStrategy, generatingCount, needHistoricalElement);
       }
     };
 
     /**
      * 交叉を行うインスタンスを生成するための抽象メソッド．
-     * 
+     *
      * @param random 交叉処理の内部でランダム処理を行うためのシード
      * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
      * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
      * @param generatingCount 一世代の交叉処理で生成する個体の数
+     * @param needHistoricalElement
      * @return 交叉を行うインスタンス
      */
     public abstract Crossover initialize(final Random random,
         final FirstVariantSelectionStrategy firstVariantSelectionStrategy,
         final SecondVariantSelectionStrategy secondVariantSelectionStrategy,
-        final int generatingCount);
+        final int generatingCount, final boolean needHistoricalElement);
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/Crossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/Crossover.java
@@ -55,7 +55,7 @@ public interface Crossover {
       /**
        * 交叉を行うインスタンスを生成するメソッド．
        *
-       * @see Crossover.Type#initialize(java.util.Random, FirstVariantSelectionStrategy,
+       * @see Crossover.Type#initialize(Random, FirstVariantSelectionStrategy,
        *      SecondVariantSelectionStrategy, int, boolean)
        *
        * @param random 交叉処理の内部でランダム処理を行うためのシード

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/Crossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/Crossover.java
@@ -2,7 +2,6 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 
 import java.util.List;
 import java.util.Random;
-
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 
@@ -62,7 +61,7 @@ public interface Crossover {
        * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
        * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
        * @param generatingCount 一世代の交叉処理で生成する個体の数
-       * @param needHistoricalElement
+       * @param needHistoricalElement 個体が生成される過程を記録するか否か
        * @return 交叉を行うインスタンス
        */
       @Override
@@ -91,7 +90,7 @@ public interface Crossover {
        * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
        * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
        * @param generatingCount 一世代の交叉処理で生成する個体の数
-       * @param needHistoricalElement
+       * @param needHistoricalElement 個体が生成される過程を記録するか否か
        * @return 交叉を行うインスタンス
        */
       @Override
@@ -120,7 +119,7 @@ public interface Crossover {
        * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
        * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
        * @param generatingCount 一世代の交叉処理で生成する個体の数
-       * @param needHistoricalElement
+       * @param needHistoricalElement 個体が生成される過程を記録するか否か
        * @return 交叉を行うインスタンス
        */
       @Override
@@ -140,7 +139,7 @@ public interface Crossover {
      * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
      * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
      * @param generatingCount 一世代の交叉処理で生成する個体の数
-     * @param needHistoricalElement
+     * @param needHistoricalElement 個体が生成される過程を記録するか否か
      * @return 交叉を行うインスタンス
      */
     public abstract Crossover initialize(final Random random,

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/Crossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/Crossover.java
@@ -39,7 +39,7 @@ public interface Crossover {
 
   /**
    * kGenProgが基本実装として持つ交叉種別を表す列挙型．
-   * <p>
+   *
    * TODO ここに定義すべきではないものな気がするので将来移動させる予定．
    *
    * @author higo
@@ -84,7 +84,7 @@ public interface Crossover {
       /**
        * 交叉を行うインスタンスを生成するメソッド．
        *
-       * @see Crossover.Type#initialize(java.util.Random, FirstVariantSelectionStrategy,
+       * @see Crossover.Type#initialize(Random, FirstVariantSelectionStrategy,
        *      SecondVariantSelectionStrategy, int, boolean)
        *
        * @param random 交叉処理の内部でランダム処理を行うためのシード
@@ -113,7 +113,7 @@ public interface Crossover {
       /**
        * 交叉を行うインスタンスを生成するメソッド．
        *
-       * @see Crossover.Type#initialize(java.util.Random, FirstVariantSelectionStrategy,
+       * @see Crossover.Type#initialize(Random, FirstVariantSelectionStrategy,
        *      SecondVariantSelectionStrategy, int, boolean)
        *
        * @param random 交叉処理の内部でランダム処理を行うためのシード

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossover.java
@@ -30,7 +30,7 @@ public class RandomCrossover extends CrossoverAdaptor {
    * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
    * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
    * @param generatingCount 一世代の交叉処理で生成する個体の数
-   * @param needHistoricalElement
+   * @param needHistoricalElement 個体が生成される過程を記録するか否か
    * @return 交叉を行うインスタンス
    */
   public RandomCrossover(final Random random,

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossover.java
@@ -15,29 +15,31 @@ import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 
 /**
  * ランダム交叉を行うクラス．
- * 
- * @author higo
  *
+ * @author higo
  */
 public class RandomCrossover extends CrossoverAdaptor {
 
   private final Random random;
+  private final boolean needHistoricalElement;
 
   /**
    * コンストラクタ．ランダム交叉に必要な情報を全て引数として渡す必要あり．
-   * 
+   *
    * @param random 交叉処理の内部でランダム処理を行うためのシード
    * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
    * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
    * @param generatingCount 一世代の交叉処理で生成する個体の数
+   * @param needHistoricalElement
    * @return 交叉を行うインスタンス
    */
   public RandomCrossover(final Random random,
       final FirstVariantSelectionStrategy firstVariantSelectionStrategy,
       final SecondVariantSelectionStrategy secondVariantSelectionStrategy,
-      final int generatingCount) {
+      final int generatingCount, final boolean needHistoricalElement) {
     super(firstVariantSelectionStrategy, secondVariantSelectionStrategy, generatingCount);
     this.random = random;
+    this.needHistoricalElement = needHistoricalElement;
   }
 
   @Override
@@ -51,7 +53,12 @@ public class RandomCrossover extends CrossoverAdaptor {
     final List<Base> basesB = geneB.getBases();
 
     final Gene newGene = makeGene(basesA, basesB);
-    final HistoricalElement newElement = new RandomCrossoverHistoricalElement(variantA, variantB);
+    final HistoricalElement newElement;
+    if (needHistoricalElement) {
+      newElement = new RandomCrossoverHistoricalElement(variantA, variantB);
+    } else {
+      newElement = null;
+    }
     return Arrays.asList(store.createVariant(newGene, newElement));
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossover.java
@@ -14,29 +14,31 @@ import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 
 /**
  * 一点交叉を行うクラス．
- * 
- * @author higo
  *
+ * @author higo
  */
 public class SinglePointCrossover extends CrossoverAdaptor {
 
   private final Random random;
+  private final boolean needHistoricalElement;
 
   /**
    * コンストラクタ．一点交叉に必要な情報を全て引数として渡す必要あり．
-   * 
+   *
    * @param random 交叉処理の内部でランダム処理を行うためのシード値
    * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
    * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
    * @param generatingCount 一世代の交叉処理で生成する個体の数
+   * @param needHistoricalElement
    * @return 交叉を行うインスタンス
    */
   public SinglePointCrossover(final Random random,
       final FirstVariantSelectionStrategy firstVariantSelectionStrategy,
       final SecondVariantSelectionStrategy secondVariantSelectionStrategy,
-      final int generatingCount) {
+      final int generatingCount, final boolean needHistoricalElement) {
     super(firstVariantSelectionStrategy, secondVariantSelectionStrategy, generatingCount);
     this.random = random;
+    this.needHistoricalElement = needHistoricalElement;
   }
 
   @Override
@@ -52,8 +54,15 @@ public class SinglePointCrossover extends CrossoverAdaptor {
     final int index = getPointAtRandom(basesA.size(), basesB.size());
     final Gene newGeneA = makeGene(basesA.subList(0, index), basesB.subList(index, basesB.size()));
     final Gene newGeneB = makeGene(basesB.subList(0, index), basesA.subList(index, basesA.size()));
-    final HistoricalElement elementA = new CrossoverHistoricalElement(variantA, variantB, index);
-    final HistoricalElement elementB = new CrossoverHistoricalElement(variantB, variantA, index);
+    final HistoricalElement elementA;
+    final HistoricalElement elementB;
+    if (needHistoricalElement) {
+      elementA = new CrossoverHistoricalElement(variantA, variantB, index);
+      elementB = new CrossoverHistoricalElement(variantB, variantA, index);
+    } else {
+      elementA = null;
+      elementB = null;
+    }
     return Arrays.asList(store.createVariant(newGeneA, elementA),
         store.createVariant(newGeneB, elementB));
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossover.java
@@ -29,7 +29,7 @@ public class SinglePointCrossover extends CrossoverAdaptor {
    * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
    * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
    * @param generatingCount 一世代の交叉処理で生成する個体の数
-   * @param needHistoricalElement
+   * @param needHistoricalElement 個体が生成される過程を記録するか否か
    * @return 交叉を行うインスタンス
    */
   public SinglePointCrossover(final Random random,

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
@@ -15,27 +15,29 @@ import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
  * 一様交叉を行うクラス．
  *
  * @author higo
- * 
  */
 public class UniformCrossover extends CrossoverAdaptor {
 
   private final Random random;
+  private final boolean needHistoricalElement;
 
   /**
    * コンストラクタ．一様交叉に必要な情報を全て引数として渡す必要あり．
-   * 
+   *
    * @param random 交叉処理の内部でランダム処理を行うためのシード値
    * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
    * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
    * @param generatingCount 一世代の交叉処理で生成する個体の数
+   * @param needHistoricalElement
    * @return 交叉を行うインスタンス
    */
   public UniformCrossover(final Random random,
       final FirstVariantSelectionStrategy firstVariantSelectionStrategy,
       final SecondVariantSelectionStrategy secondVariantSelectionStrategy,
-      final int generatingCount) {
+      final int generatingCount, final boolean needHistoricalElement) {
     super(firstVariantSelectionStrategy, secondVariantSelectionStrategy, generatingCount);
     this.random = random;
+    this.needHistoricalElement = needHistoricalElement;
   }
 
   @Override
@@ -49,7 +51,12 @@ public class UniformCrossover extends CrossoverAdaptor {
     final List<Base> basesB = geneB.getBases();
 
     final Gene newGene = makeGene(basesA, basesB);
-    final HistoricalElement newElement = new UniformCrossoverHistoricalElement(variantA, variantB);
+    final HistoricalElement newElement;
+    if (needHistoricalElement) {
+      newElement = new UniformCrossoverHistoricalElement(variantA, variantB);
+    } else {
+      newElement = null;
+    }
     return Arrays.asList(store.createVariant(newGene, newElement));
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossover.java
@@ -28,7 +28,7 @@ public class UniformCrossover extends CrossoverAdaptor {
    * @param firstVariantSelectionStrategy 1つ目の親を選ぶためのアルゴリズム
    * @param secondVariantSelectionStrategy 2つ目の親を選ぶためのアルゴリズム
    * @param generatingCount 一世代の交叉処理で生成する個体の数
-   * @param needHistoricalElement
+   * @param needHistoricalElement 個体が生成される過程を記録するか否か
    * @return 交叉を行うインスタンス
    */
   public UniformCrossover(final Random random,

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutation.java
@@ -32,6 +32,8 @@ import jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation;
  */
 public class RandomMutation extends Mutation {
 
+  private final boolean needHistoricalElement;
+
   /**
    * コンストラクタ
    *
@@ -39,11 +41,13 @@ public class RandomMutation extends Mutation {
    * @param random 乱数生成器
    * @param candidateSelection 再利用する候補を選択するオブジェクト
    * @param type 選択する候補のスコープ
+   * @param needHistoricalElement
    */
   public RandomMutation(final int mutationGeneratingCount, final Random random,
       final CandidateSelection candidateSelection,
-      final Type type) {
+      final Type type, final boolean needHistoricalElement) {
     super(mutationGeneratingCount, random, candidateSelection, type);
+    this.needHistoricalElement = needHistoricalElement;
   }
 
   /**
@@ -81,7 +85,12 @@ public class RandomMutation extends Mutation {
       final Suspiciousness suspiciousness = roulette.exec();
       final Base base = makeBase(suspiciousness);
       final Gene gene = makeGene(variant.getGene(), base);
-      final HistoricalElement element = new MutationHistoricalElement(variant, base);
+      final HistoricalElement element;
+      if (needHistoricalElement) {
+        element = new MutationHistoricalElement(variant, base);
+      } else {
+        element = null;
+      }
       generatedVariants.add(variantStore.createVariant(gene, element));
     }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutation.java
@@ -41,7 +41,7 @@ public class RandomMutation extends Mutation {
    * @param random 乱数生成器
    * @param candidateSelection 再利用する候補を選択するオブジェクト
    * @param type 選択する候補のスコープ
-   * @param needHistoricalElement
+   * @param needHistoricalElement 個体が生成される過程を記録するか否か
    */
   public RandomMutation(final int mutationGeneratingCount, final Random random,
       final CandidateSelection candidateSelection,

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/variant/VariantStore.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/variant/VariantStore.java
@@ -44,7 +44,7 @@ public class VariantStore {
     generation = new OrdinalNumber(0);
     initialVariant = createInitialVariant();
     currentVariants = Collections.singletonList(initialVariant);
-    if (config.needHistoricalElement()) {
+    if (config.getNeedHistoricalElement()) {
       allVariants = new LinkedList<>();
       allVariants.add(initialVariant);
     } else {
@@ -155,7 +155,7 @@ public class VariantStore {
    */
   public void addGeneratedVariant(final Variant variant) {
 
-    if (config.needHistoricalElement()) {
+    if (config.getNeedHistoricalElement()) {
       allVariants.add(variant);
     }
     if (variant.isCompleted()) {
@@ -186,7 +186,7 @@ public class VariantStore {
     final GeneratedSourceCode sourceCode =
         strategies.execASTConstruction(config.getTargetProject());
     final HistoricalElement newElement;
-    if (config.needHistoricalElement()) {
+    if (config.getNeedHistoricalElement()) {
       newElement = new OriginalHistoricalElement();
     } else {
       newElement = null;

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/variant/VariantStore.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/variant/VariantStore.java
@@ -44,8 +44,12 @@ public class VariantStore {
     generation = new OrdinalNumber(0);
     initialVariant = createInitialVariant();
     currentVariants = Collections.singletonList(initialVariant);
-    allVariants = new LinkedList<>();
-    allVariants.add(initialVariant);
+    if (config.needHistoricalElement()) {
+      allVariants = new LinkedList<>();
+      allVariants.add(initialVariant);
+    } else {
+      allVariants = null;
+    }
     generatedVariants = new ArrayList<>();
     foundSolutions = new ArrayList<>();
 
@@ -151,7 +155,9 @@ public class VariantStore {
    */
   public void addGeneratedVariant(final Variant variant) {
 
-    allVariants.add(variant);
+    if (config.needHistoricalElement()) {
+      allVariants.add(variant);
+    }
     if (variant.isCompleted()) {
       foundSolutions.add(variant);
     } else {
@@ -179,8 +185,13 @@ public class VariantStore {
   private Variant createInitialVariant() {
     final GeneratedSourceCode sourceCode =
         strategies.execASTConstruction(config.getTargetProject());
-    return createVariant(new Gene(Collections.emptyList()), sourceCode,
-        new OriginalHistoricalElement());
+    final HistoricalElement newElement;
+    if (config.needHistoricalElement()) {
+      newElement = new OriginalHistoricalElement();
+    } else {
+      newElement = null;
+    }
+    return createVariant(new Gene(Collections.emptyList()), sourceCode, newElement);
   }
 
   private Variant createVariant(final Gene gene, final GeneratedSourceCode sourceCode,

--- a/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
@@ -1,7 +1,6 @@
 package jp.kusumotolab.kgenprog;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;

--- a/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
@@ -7,7 +7,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-
 import org.junit.Test;
 import jp.kusumotolab.kgenprog.fl.FaultLocalization;
 import jp.kusumotolab.kgenprog.fl.Ochiai;

--- a/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
@@ -1,11 +1,13 @@
 package jp.kusumotolab.kgenprog;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+
 import org.junit.Test;
 import jp.kusumotolab.kgenprog.fl.FaultLocalization;
 import jp.kusumotolab.kgenprog.fl.Ochiai;
@@ -54,10 +56,10 @@ public class KGenProgMainTest {
     final Random random = new Random(config.getRandomSeed());
     final CandidateSelection statementSelection = new RouletteStatementSelection(random);
     final Mutation mutation = new RandomMutation(config.getMutationGeneratingCount(), random,
-        statementSelection, config.getScope());
+        statementSelection, config.getScope(), true);
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantRandomSelection(random), config.getCrossoverGeneratingCount());
+            new SecondVariantRandomSelection(random), config.getCrossoverGeneratingCount(), true);
     final SourceCodeGeneration sourceCodeGeneration = new DefaultSourceCodeGeneration();
     final SourceCodeValidation sourceCodeValidation = new DefaultCodeValidation();
     final VariantSelection variantSelection =

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
@@ -338,4 +338,24 @@ public class RandomCrossoverTest {
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }
+
+  /**
+   * HistoricalElementを必要としない場合のテスト
+   */
+  @Test
+  public void testNeedNotHistoricalElement() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+
+    // バリアントの生成
+    final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
+        new SecondVariantRandomSelection(random), 1, false);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // HistoricalElementはnullのはず
+    assertThat(variant.getHistoricalElement()).isNull();
+  }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
@@ -3,8 +3,10 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
+
 import java.util.List;
 import java.util.Random;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.variant.Gene;
@@ -30,14 +32,14 @@ public class RandomCrossoverTest {
     // バリアントの生成
     final Crossover crossover10 =
         new RandomCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 10);
+            new SecondVariantGeneSimilarityBasedSelection(random), 10, true);
     final List<Variant> variants10 = crossover10.exec(testVariants.variantStore);
     assertThat(variants10.size()).isEqualTo(10);
 
     // バリアントの生成
     final Crossover crossover100 =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 100);
+            new SecondVariantGeneSimilarityBasedSelection(random), 100, true);
     final List<Variant> variants100 = crossover100.exec(testVariants.variantStore);
     assertThat(variants100.size()).isEqualTo(100);
   }
@@ -57,7 +59,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantRandomSelection(random), 1);
+        new SecondVariantRandomSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -87,7 +89,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantRandomSelection(random), 1);
+        new SecondVariantRandomSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -115,7 +117,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantGeneSimilarityBasedSelection(random), 1);
+        new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -143,7 +145,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantGeneSimilarityBasedSelection(random), 1);
+        new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -171,7 +173,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantTestComplementaryBasedSelection(), 1);
+        new SecondVariantTestComplementaryBasedSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -199,7 +201,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantRandomSelection(random),
-        new SecondVariantTestComplementaryBasedSelection(), 1);
+        new SecondVariantTestComplementaryBasedSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -227,7 +229,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantEliteSelection(random),
-        new SecondVariantEliteSelection(), 1);
+        new SecondVariantEliteSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -255,7 +257,7 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new RandomCrossover(random, new FirstVariantEliteSelection(random),
-        new SecondVariantEliteSelection(), 1);
+        new SecondVariantEliteSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -286,53 +288,53 @@ public class RandomCrossoverTest {
 
     // バリアントの生成
     final Crossover crossoverEE = new RandomCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1, true);
     final List<Variant> variantsEE = crossoverEE.exec(singleTestVariant.variantStore);
     assertThat(variantsEE).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverER = new RandomCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantRandomSelection(random), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantRandomSelection(random), 1, true);
     final List<Variant> variantsER = crossoverER.exec(singleTestVariant.variantStore);
     assertThat(variantsER).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverEG =
         new RandomCrossover(random, new FirstVariantEliteSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final List<Variant> variantsEG = crossoverEG.exec(singleTestVariant.variantStore);
     assertThat(variantsEG).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverET =
         new RandomCrossover(random, new FirstVariantEliteSelection(random),
-            new SecondVariantTestComplementaryBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1, true);
     final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
     assertThat(variantsET).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRE = new RandomCrossover(random,
-        new FirstVariantRandomSelection(random), new SecondVariantEliteSelection(), 1);
+        new FirstVariantRandomSelection(random), new SecondVariantEliteSelection(), 1, true);
     final List<Variant> variantsRE = crossoverRE.exec(singleTestVariant.variantStore);
     assertThat(variantsRE).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRR = new RandomCrossover(random,
-        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1);
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1, true);
     final List<Variant> variantsRR = crossoverRR.exec(singleTestVariant.variantStore);
     assertThat(variantsRR).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRG =
         new RandomCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final List<Variant> variantsRG = crossoverRG.exec(singleTestVariant.variantStore);
     assertThat(variantsRG).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRT =
         new RandomCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestComplementaryBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1, true);
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
@@ -3,10 +3,8 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
-
 import java.util.List;
 import java.util.Random;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.variant.Gene;

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
@@ -3,10 +3,8 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
-
 import java.util.List;
 import java.util.Random;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.variant.Gene;

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
@@ -342,4 +342,25 @@ public class SinglePointCrossoverTest {
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }
+
+  /**
+   * HistoricalElementを必要としない場合のテスト.
+   */
+  @Test
+  public void testNeedNotHistoricalElement() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+
+    // バリアントの生成
+    final Crossover crossover = new SinglePointCrossover(random,
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1,
+        false);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // HistoricalElementはnullのはず
+    assertThat(variant.getHistoricalElement()).isNull();
+  }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
@@ -3,8 +3,10 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
+
 import java.util.List;
 import java.util.Random;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.variant.Gene;
@@ -30,14 +32,14 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover10 =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 10);
+            new SecondVariantGeneSimilarityBasedSelection(random), 10, true);
     final List<Variant> variants10 = crossover10.exec(testVariants.variantStore);
     assertThat(variants10.size()).isEqualTo(10);
 
     // バリアントの生成
     final Crossover crossover100 =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 100);
+            new SecondVariantGeneSimilarityBasedSelection(random), 100, true);
     final List<Variant> variants100 = crossover100.exec(testVariants.variantStore);
     assertThat(variants100.size()).isEqualTo(100);
   }
@@ -57,7 +59,7 @@ public class SinglePointCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new SinglePointCrossover(random,
-        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1);
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -87,7 +89,7 @@ public class SinglePointCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new SinglePointCrossover(random,
-        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1);
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -116,7 +118,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -145,7 +147,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -174,7 +176,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestComplementaryBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -203,7 +205,7 @@ public class SinglePointCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestComplementaryBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -231,7 +233,7 @@ public class SinglePointCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new SinglePointCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -259,7 +261,7 @@ public class SinglePointCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new SinglePointCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -290,52 +292,53 @@ public class SinglePointCrossoverTest {
 
     // バリアントの生成
     final Crossover crossoverEE = new SinglePointCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1, true);
     final List<Variant> variantsEE = crossoverEE.exec(singleTestVariant.variantStore);
     assertThat(variantsEE).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverER = new SinglePointCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantRandomSelection(random), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantRandomSelection(random), 1, true);
     final List<Variant> variantsER = crossoverER.exec(singleTestVariant.variantStore);
     assertThat(variantsER).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverEG =
         new SinglePointCrossover(random, new FirstVariantEliteSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final List<Variant> variantsEG = crossoverEG.exec(singleTestVariant.variantStore);
     assertThat(variantsEG).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverET = new SinglePointCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantTestComplementaryBasedSelection(), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantTestComplementaryBasedSelection(),
+        1, true);
     final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
     assertThat(variantsET).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRE = new SinglePointCrossover(random,
-        new FirstVariantRandomSelection(random), new SecondVariantEliteSelection(), 1);
+        new FirstVariantRandomSelection(random), new SecondVariantEliteSelection(), 1, true);
     final List<Variant> variantsRE = crossoverRE.exec(singleTestVariant.variantStore);
     assertThat(variantsRE).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRR = new SinglePointCrossover(random,
-        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1);
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1, true);
     final List<Variant> variantsRR = crossoverRR.exec(singleTestVariant.variantStore);
     assertThat(variantsRR).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRG =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final List<Variant> variantsRG = crossoverRG.exec(singleTestVariant.variantStore);
     assertThat(variantsRG).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRT =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestComplementaryBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1, true);
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -340,4 +340,25 @@ public class UniformCrossoverTest {
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }
+
+  /**
+   * HistoricalElementを必要としない場合のテスト
+   */
+  @Test
+  public void testNeedNotHistoricalElement() {
+
+    // 生成するバリアントを制御するための疑似乱数
+    final Random random = Mockito.mock(Random.class);
+
+    // バリアントの生成
+    final Crossover crossover = new UniformCrossover(random,
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1,
+        false);
+    final CrossoverTestVariants testVariants = new CrossoverTestVariants();
+    final List<Variant> variants = crossover.exec(testVariants.variantStore);
+    final Variant variant = variants.get(0);
+
+    // HistoricalElementはnullのはず
+    assertThat(variant.getHistoricalElement()).isNull();
+  }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -3,10 +3,8 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
-
 import java.util.List;
 import java.util.Random;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.variant.Gene;

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -3,8 +3,10 @@ package jp.kusumotolab.kgenprog.ga.crossover;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
+
 import java.util.List;
 import java.util.Random;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 import jp.kusumotolab.kgenprog.ga.variant.Gene;
@@ -30,14 +32,14 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover10 =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 10);
+            new SecondVariantGeneSimilarityBasedSelection(random), 10, true);
     final List<Variant> variants10 = crossover10.exec(testVariants.variantStore);
     assertThat(variants10.size()).isEqualTo(10);
 
     // バリアントの生成
     final Crossover crossover100 =
         new SinglePointCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 100);
+            new SecondVariantGeneSimilarityBasedSelection(random), 100, true);
     final List<Variant> variants100 = crossover100.exec(testVariants.variantStore);
     assertThat(variants100.size()).isEqualTo(100);
   }
@@ -56,7 +58,7 @@ public class UniformCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new UniformCrossover(random,
-        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1);
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -85,7 +87,7 @@ public class UniformCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new UniformCrossover(random,
-        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1);
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -114,7 +116,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -143,7 +145,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -172,7 +174,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestComplementaryBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -201,7 +203,7 @@ public class UniformCrossoverTest {
     // バリアントの生成
     final Crossover crossover =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestComplementaryBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -229,7 +231,7 @@ public class UniformCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new UniformCrossover(random, new FirstVariantEliteSelection(random),
-        new SecondVariantEliteSelection(), 1);
+        new SecondVariantEliteSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -257,7 +259,7 @@ public class UniformCrossoverTest {
 
     // バリアントの生成
     final Crossover crossover = new UniformCrossover(random, new FirstVariantEliteSelection(random),
-        new SecondVariantEliteSelection(), 1);
+        new SecondVariantEliteSelection(), 1, true);
     final CrossoverTestVariants testVariants = new CrossoverTestVariants();
     final List<Variant> variants = crossover.exec(testVariants.variantStore);
     final Variant variant = variants.get(0);
@@ -288,52 +290,53 @@ public class UniformCrossoverTest {
 
     // バリアントの生成
     final Crossover crossoverEE = new UniformCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantEliteSelection(), 1, true);
     final List<Variant> variantsEE = crossoverEE.exec(singleTestVariant.variantStore);
     assertThat(variantsEE).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverER = new UniformCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantRandomSelection(random), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantRandomSelection(random), 1, true);
     final List<Variant> variantsER = crossoverER.exec(singleTestVariant.variantStore);
     assertThat(variantsER).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverEG =
         new UniformCrossover(random, new FirstVariantEliteSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final List<Variant> variantsEG = crossoverEG.exec(singleTestVariant.variantStore);
     assertThat(variantsEG).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverET = new UniformCrossover(random,
-        new FirstVariantEliteSelection(random), new SecondVariantTestComplementaryBasedSelection(), 1);
+        new FirstVariantEliteSelection(random), new SecondVariantTestComplementaryBasedSelection(),
+        1, true);
     final List<Variant> variantsET = crossoverET.exec(singleTestVariant.variantStore);
     assertThat(variantsET).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRE = new UniformCrossover(random,
-        new FirstVariantRandomSelection(random), new SecondVariantEliteSelection(), 1);
+        new FirstVariantRandomSelection(random), new SecondVariantEliteSelection(), 1, true);
     final List<Variant> variantsRE = crossoverRE.exec(singleTestVariant.variantStore);
     assertThat(variantsRE).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRR = new UniformCrossover(random,
-        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1);
+        new FirstVariantRandomSelection(random), new SecondVariantRandomSelection(random), 1, true);
     final List<Variant> variantsRR = crossoverRR.exec(singleTestVariant.variantStore);
     assertThat(variantsRR).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRG =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantGeneSimilarityBasedSelection(random), 1);
+            new SecondVariantGeneSimilarityBasedSelection(random), 1, true);
     final List<Variant> variantsRG = crossoverRG.exec(singleTestVariant.variantStore);
     assertThat(variantsRG).isEmpty();
 
     // バリアントの生成
     final Crossover crossoverRT =
         new UniformCrossover(random, new FirstVariantRandomSelection(random),
-            new SecondVariantTestComplementaryBasedSelection(), 1);
+            new SecondVariantTestComplementaryBasedSelection(), 1, true);
     final List<Variant> variantsRT = crossoverRT.exec(singleTestVariant.variantStore);
     assertThat(variantsRT).isEmpty();
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutationTest.java
@@ -96,7 +96,8 @@ public class RandomMutationTest {
     final List<Suspiciousness> suspiciousnesses = initialVariant.getSuspiciousnesses();
 
     final VariantStore variantStore = createVariantStore(initialVariant);
-    final RandomMutation randomMutation = createRandomMutation(generatedSourceCode, new Random(0));
+    final RandomMutation randomMutation = createRandomMutation(generatedSourceCode, new Random(0),
+        true);
     final List<Variant> variantList = randomMutation.exec(variantStore);
 
     final Map<String, List<Base>> map = variantList.stream()
@@ -171,6 +172,22 @@ public class RandomMutationTest {
     assertThat(appendedBase).isEqualTo(base);
   }
 
+  @Test
+  public void testNeedNotHistoricalElement() {
+    final GeneratedSourceCode generatedSourceCode = createGeneratedSourceCode();
+
+    final Variant initialVariant = createInitialVariant(generatedSourceCode);
+    final VariantStore variantStore = createVariantStore(initialVariant);
+
+    final RandomMutation randomMutation = createRandomMutation(generatedSourceCode, new Random(0),
+        false);
+    final List<Variant> variantList = randomMutation.exec(variantStore);
+
+    final Variant variant = variantList.get(0);
+
+    assertThat(variant.getHistoricalElement()).isNull();
+  }
+
 
   private GeneratedSourceCode createGeneratedSourceCode() {
     final Path basePath = Paths.get("example/BuildSuccess01");
@@ -180,14 +197,14 @@ public class RandomMutationTest {
 
   private RandomMutation createRandomMutation(final GeneratedSourceCode sourceCode) {
     final Random random = new MockRandom(0);
-    return createRandomMutation(sourceCode, random);
+    return createRandomMutation(sourceCode, random, true);
   }
 
   private RandomMutation createRandomMutation(final GeneratedSourceCode sourceCode,
-      final Random random) {
+      final Random random, final boolean needHistoricalElement) {
     final CandidateSelection statementSelection = new RouletteStatementSelection(random);
     final RandomMutation randomMutation = new RandomMutation(15, random, statementSelection,
-        Type.PROJECT, true);
+        Type.PROJECT, needHistoricalElement);
     randomMutation.setCandidates(sourceCode.getProductAsts());
     return randomMutation;
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -14,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
+
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Statement;
@@ -185,7 +187,7 @@ public class RandomMutationTest {
       final Random random) {
     final CandidateSelection statementSelection = new RouletteStatementSelection(random);
     final RandomMutation randomMutation = new RandomMutation(15, random, statementSelection,
-        Type.PROJECT);
+        Type.PROJECT, true);
     randomMutation.setCandidates(sourceCode.getProductAsts());
     return randomMutation;
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/RandomMutationTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
-
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Statement;

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/variant/VariantStoreTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/variant/VariantStoreTest.java
@@ -32,7 +32,7 @@ public class VariantStoreTest {
   @Test
   public void testCreateVariant() {
     final Path basePath = Paths.get("example/BuildSuccess01");
-    final Configuration config = createMockConfiguration(basePath);
+    final Configuration config = createMockConfiguration(basePath, true);
 
     final List<Suspiciousness> faultLocalizationResult = new ArrayList<>();
     final GeneratedSourceCode sourceCodeGenerationResult =
@@ -78,7 +78,7 @@ public class VariantStoreTest {
   @Test
   public void testGetGenerationNumber() {
     final Path basePath = Paths.get("example/BuildSuccess01");
-    final Configuration config = createMockConfiguration(basePath);
+    final Configuration config = createMockConfiguration(basePath, true);
     final Strategies strategies = createMockStrategies(config);
 
     final VariantStore variantStore = new VariantStore(config, strategies);
@@ -101,7 +101,7 @@ public class VariantStoreTest {
   @Test
   public void testGetGeneratedVariants() {
     final Path basePath = Paths.get("example/BuildSuccess01");
-    final Configuration config = createMockConfiguration(basePath);
+    final Configuration config = createMockConfiguration(basePath, true);
     final Strategies strategies = createMockStrategies(config);
 
     final VariantStore variantStore = new VariantStore(config, strategies);
@@ -134,7 +134,7 @@ public class VariantStoreTest {
   @Test
   public void testGetFoundSolutions() {
     final Path basePath = Paths.get("example/BuildSuccess01");
-    final Configuration config = createMockConfiguration(basePath);
+    final Configuration config = createMockConfiguration(basePath, true);
     final Strategies strategies = createMockStrategies(config);
 
     final VariantStore variantStore = new VariantStore(config, strategies);
@@ -155,19 +155,38 @@ public class VariantStoreTest {
     assertThat(variantStore.getFoundSolutions(5)).containsExactly(success1, success2, success3);
   }
 
+  @Test
+  public void testNeedNotHistoricalElement() {
+    final Path basePath = Paths.get("example/BuildSuccess01");
+    final Configuration config = createMockConfiguration(basePath, false);
+    final Strategies strategies = createMockStrategies(config);
+
+    final VariantStore variantStore = new VariantStore(config, strategies);
+
+    final Variant success1 = createMockVariant(true);
+    final Variant fail1 = createMockVariant(false);
+
+    variantStore.addGeneratedVariant(success1);
+    variantStore.addGeneratedVariant(fail1);
+
+    assertThat(variantStore.getAllVariants()).isNull();
+  }
+
   private Variant createMockVariant(final boolean isCompleted) {
     final Variant variant = mock(Variant.class);
     when(variant.isCompleted()).thenReturn(isCompleted);
     return variant;
   }
 
-  private Configuration createMockConfiguration(final Path basePath) {
+  private Configuration createMockConfiguration(final Path basePath,
+      final boolean needHistoricalElement) {
     final TargetProject project = TargetProjectFactory.create(basePath);
     final Configuration config = mock(Configuration.class);
 
     when(config.getTargetProject()).thenReturn(project);
     when(config.getTimeLimitSeconds())
         .thenReturn(Configuration.DEFAULT_TEST_TIME_LIMIT.getSeconds());
+    when(config.getNeedHistoricalElement()).thenReturn(needHistoricalElement);
 
     return config;
   }


### PR DESCRIPTION
resolve #579 

### 変更点
- `Configuration.java`でオプション`needHistoricalElement`を追加
- `needHistoricalElement == false`の場合
   - 各crossover，mutationでHistorical Elementにnullを代入
   - `VariantStore.java`で`allVariant`に生成したvariantを記録しない