### PR TITLE
FLの高速化

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Ochiai.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Ochiai.java
@@ -2,8 +2,11 @@ package jp.kusumotolab.kgenprog.fl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import jp.kusumotolab.kgenprog.project.ASTLocation;
 import jp.kusumotolab.kgenprog.project.ASTLocations;
+import jp.kusumotolab.kgenprog.project.FullyQualifiedName;
 import jp.kusumotolab.kgenprog.project.GeneratedAST;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.ProductSourcePath;
@@ -31,7 +34,18 @@ public class Ochiai implements FaultLocalization {
 
     final List<Suspiciousness> suspiciousnesses = new ArrayList<>();
 
+    final Set<FullyQualifiedName> targetFQNs = testResults.getFailedTestResults()
+        .stream()
+        .flatMap(tr -> tr.getExecutedTargetFQNs()
+            .stream())
+        .collect(Collectors.toSet());
+
     for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
+
+      if (!targetFQNs.contains(ast.getPrimaryClassName())) {
+        continue;
+      }
+
       final ProductSourcePath path = ast.getSourcePath();
       final int lastLineNumber = ast.getNumberOfLines();
       final ASTLocations astLocations = ast.createLocations();

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/Coverage.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/Coverage.java
@@ -55,4 +55,10 @@ public interface Coverage {
   int getStatusesSize();
 
   String toString(final int indentDepth);
+
+  /**
+   * このカバレッジ情報で表される対象が，1つでもCOVEREDもしくはPARTLY_COVEREDな行を含むかどうか
+   * @return
+   */
+  boolean includingCovered();
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/RawCoverage.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/RawCoverage.java
@@ -102,4 +102,9 @@ public class RawCoverage implements Coverage {
     sb.append("]}");
     return sb.toString();
   }
+
+  public boolean includingCovered() {
+    return this.statuses.stream()
+        .anyMatch(s -> s == Status.COVERED || s == Status.PARTLY_COVERED);
+  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
@@ -38,8 +38,11 @@ public class TestResult {
    * @return 実行されたテストのFQN一覧
    */
   public List<FullyQualifiedName> getExecutedTargetFQNs() {
-    return this.coverages.keySet()
+    return this.coverages.entrySet()
         .stream()
+        .filter(e -> e.getValue()
+            .includingCovered())
+        .map(e -> e.getKey())
         .collect(Collectors.toList());
   }
 

--- a/src/test/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutorTest.java
@@ -109,7 +109,7 @@ public class LocalTestExecutorTest {
     when(variant.getGeneratedSourceCode()).thenReturn(source);
     final TestResults result = executor.exec(variant);
 
-    // 実行されたテストは10個のはず
+    // 実行されたテストは9個のはず
     assertThat(result.getExecutedTestFQNs()).containsExactlyInAnyOrder( //
         FOO_TEST01, FOO_TEST02, FOO_TEST03, FOO_TEST04, //
         BAR_TEST01, BAR_TEST02, BAR_TEST03, BAR_TEST04, BAR_TEST05);
@@ -126,17 +126,17 @@ public class LocalTestExecutorTest {
     assertThat(result.getTestResult(BAR_TEST05).failed).isFalse();
 
     final TestResult fooTest01result = result.getTestResult(FOO_TEST01);
-    // FooTest.test01()ではFooとBarが実行されたはず
-    assertThat(fooTest01result.getExecutedTargetFQNs()).containsExactlyInAnyOrder(FOO, BAR);
+    // FooTest.test01()ではFooが実行されたはず
+    assertThat(fooTest01result.getExecutedTargetFQNs()).containsExactlyInAnyOrder(FOO);
 
     // FooTest.test01()で実行されたFooのカバレッジはこうなるはず
     final Coverage fooTest01coverage = fooTest01result.getCoverages(FOO);
     assertThat(extractStatuses(fooTest01coverage)).containsExactly(EMPTY, COVERED, EMPTY, COVERED,
         COVERED, EMPTY, EMPTY, NOT_COVERED, EMPTY, COVERED);
 
-    // BarTest.test01()ではFooとBarが実行されたはず
+    // BarTest.test01()ではBarが実行されたはず
     final TestResult barTest01r = result.getTestResult(BAR_TEST01);
-    assertThat(barTest01r.getExecutedTargetFQNs()).containsExactlyInAnyOrder(FOO, BAR);
+    assertThat(barTest01r.getExecutedTargetFQNs()).containsExactlyInAnyOrder(BAR);
 
     // BarTest.test01()で実行されたBarのカバレッジはこうなるはず
     final Coverage barTest01rCoverage = barTest01r.getCoverages(BAR);
@@ -245,8 +245,8 @@ public class LocalTestExecutorTest {
 
     final TestResult fooTest01result = result.getTestResult(FOO_TEST01);
 
-    // FooTest.test01()ではFooとBarが実行されたはず
-    assertThat(fooTest01result.getExecutedTargetFQNs()).containsExactlyInAnyOrder(FOO, BAR);
+    // FooTest.test01()ではFooが実行されたはず
+    assertThat(fooTest01result.getExecutedTargetFQNs()).containsExactlyInAnyOrder(FOO);
 
     // FooTest.test01()で実行されたFooのカバレッジはこうなるはず
     final Coverage coverage = fooTest01result.getCoverages(FOO);


### PR DESCRIPTION
resolve #628 

FLが重たい原因は対象プロジェクトの全てのクラスの全ての行に対してFLを計算しているから．
この修正では，失敗したテストで実行したクラスのみを取得し，それらのクラスについてのみFLを計算するように変更した．