### PR TITLE
jacoco APIの使い方のバグを修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/Coverage.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/Coverage.java
@@ -56,9 +56,4 @@ public interface Coverage {
 
   String toString(final int indentDepth);
 
-  /**
-   * このカバレッジ情報で表される対象が，1つでもCOVEREDもしくはPARTLY_COVEREDな行を含むかどうか
-   * @return
-   */
-  boolean includingCovered();
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/RawCoverage.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/RawCoverage.java
@@ -103,8 +103,4 @@ public class RawCoverage implements Coverage {
     return sb.toString();
   }
 
-  public boolean includingCovered() {
-    return this.statuses.stream()
-        .anyMatch(s -> s == Status.COVERED || s == Status.PARTLY_COVERED);
-  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
@@ -40,8 +40,6 @@ public class TestResult {
   public List<FullyQualifiedName> getExecutedTargetFQNs() {
     return this.coverages.entrySet()
         .stream()
-        .filter(e -> e.getValue()
-            .includingCovered())
         .map(e -> e.getKey())
         .collect(Collectors.toList());
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
@@ -13,6 +13,7 @@ import jp.kusumotolab.kgenprog.project.LineNumberRange;
 import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 import jp.kusumotolab.kgenprog.project.build.BuildResults;
 import jp.kusumotolab.kgenprog.project.build.JavaBinaryObject;
+import jp.kusumotolab.kgenprog.project.test.Coverage.Status;
 
 /**
  * 全テストの結果を表すオブジェクト．<br>
@@ -43,7 +44,7 @@ public class TestResults {
     this();
     this.buildResults = buildResults;
   }
-  
+
   /**
    * 新規TestResultの追加
    * 
@@ -145,7 +146,7 @@ public class TestResults {
    * @return
    */
   private long getNumberOfTests(final ProductSourcePath productSourcePath,
-      final ASTLocation location, final Coverage.Status status, final boolean failed) {
+      final ASTLocation location, final boolean failed) {
 
     // 翻訳1: SourcePath → [FQN]
     final Set<FullyQualifiedName> correspondingFqns = getCorrespondingFqns(productSourcePath);
@@ -161,7 +162,7 @@ public class TestResults {
     final int correspondingLineNumber = correspondingRange.start;
 
     return correspondingFqns.stream()
-        .map(fqn -> getTestFQNs(fqn, correspondingLineNumber, status, failed))
+        .map(fqn -> getTestFQNs(fqn, correspondingLineNumber, Status.COVERED, failed))
         .mapToLong(Collection::size)
         .sum();
   }
@@ -207,7 +208,7 @@ public class TestResults {
    */
   public long getNumberOfPassedTestsExecutingTheStatement(final ProductSourcePath productSourcePath,
       final ASTLocation location) {
-    return getNumberOfTests(productSourcePath, location, Coverage.Status.COVERED, false);
+    return getNumberOfTests(productSourcePath, location, false);
   }
 
   /**
@@ -219,7 +220,7 @@ public class TestResults {
    */
   public long getNumberOfFailedTestsExecutingTheStatement(final ProductSourcePath productSourcePath,
       final ASTLocation location) {
-    return getNumberOfTests(productSourcePath, location, Coverage.Status.COVERED, true);
+    return getNumberOfTests(productSourcePath, location, true);
   }
 
   /**
@@ -231,7 +232,8 @@ public class TestResults {
    */
   public long getNumberOfPassedTestsNotExecutingTheStatement(
       final ProductSourcePath productSourcePath, final ASTLocation location) {
-    return getNumberOfTests(productSourcePath, location, Coverage.Status.NOT_COVERED, false);
+    return getSuccessedTestResults().size()
+        - getNumberOfPassedTestsExecutingTheStatement(productSourcePath, location);
   }
 
   /**
@@ -243,7 +245,8 @@ public class TestResults {
    */
   public long getNumberOfFailedTestsNotExecutingTheStatement(
       final ProductSourcePath productSourcePath, final ASTLocation location) {
-    return getNumberOfTests(productSourcePath, location, Coverage.Status.NOT_COVERED, true);
+    return getFailedTestResults().size()
+        - getNumberOfFailedTestsExecutingTheStatement(productSourcePath, location);
   }
 
   /**


### PR DESCRIPTION
resolve #635

### やったこと
- FL速度低下の根本原因であったJacoco使い方のバグを修正した．
- 伴い，FLの4メトリクスの計算方法を修正
- 伴い，#633 での修正の不要になった部分を削除

#633 と併せて分散環境でのボトルネックが改善したかも．