### PR TITLE
分散処理のための細かい修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -357,6 +357,12 @@ public class Configuration {
 
     public static Configuration buildFromCmdLineArgs(final String[] args)
         throws IllegalArgumentException {
+      final Builder builder = createFromCmdLineArgs(args);
+      return builder.build();
+    }
+
+    public static Builder createFromCmdLineArgs(final String[] args)
+        throws IllegalArgumentException {
 
       final Builder builder = new Builder();
       final CmdLineParser parser = new CmdLineParser(builder);
@@ -387,7 +393,7 @@ public class Configuration {
         throw new IllegalArgumentException(e.getMessage());
       }
 
-      return builder.build();
+      return builder;
     }
 
     public Configuration build() {

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
@@ -266,7 +266,19 @@ public class TestResults {
     return sb.toString();
   }
 
-  private Set<FullyQualifiedName> getCorrespondingFqns(final ProductSourcePath productSourcePath) {
+  /**
+   * ビルドの結果 (分散に使用)
+   * @return
+   */
+  public BuildResults getBuildResults() {
+    return buildResults;
+  }
+
+  /**
+   * Pathに対応するFQNを返す (分散に使用するため，privateにはしない)
+   * @return
+   */
+  protected Set<FullyQualifiedName> getCorrespondingFqns(final ProductSourcePath productSourcePath) {
     return buildResults.binaryStore.get(productSourcePath)
         .stream()
         .map(JavaBinaryObject::getFqn)


### PR DESCRIPTION
kGenProgの開発をしていく上で，clusterd-kGenProgで使用しているメソッドが消されるなどで，clusterd-kGenProgを実行することができなりました．
なので，clusterd-kGenProgを実行する上で必要な修正をしました

修正内容としては
- いくつかのgetterを追加
- アクセスレベルの変更
- 引数の書き換えをプログラムから行うため，builderを作成するメソッドを追加．
これで，今までは
```
config = Configuration.Builder.buildFromCmdLineArgs(args);
```
としていた場所を
```
config = Configuration.Builder.createFromCmdLineArgs(builder.kgpArgs)
            .setNeedHistoricalElement(false)
            .build();
```
とすることで書き換えができす．
これはclusterd-kGenProgを使用する際は，常にJSON出力をオフにしたいための修正です．