### PR TITLE
InsertBeforeOpetion の追加

### DIFF
--- a/doc/ja/OVERVIEW.md
+++ b/doc/ja/OVERVIEW.md
@@ -137,7 +137,8 @@ KGenProgのデフォルト値はOchiaiである．
 抽象構文木の変更操作を表すインターフェースは jp.kusumotolab.kgenprog.project.jdt.JDTOperation である．
 現在のところ，実装クラスとしては以下のものがある．
 - jp.kusumotolab.kgenprog.project.jdt.DeleteOperation：プログラム文の削除を表す操作
-- jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation：プログラム文の追加を表す操作
+- jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation：挿入対象の文の後ろにプログラム文の追加を表す操作
+- jp.kusumotolab.kgenprog.project.jdt.InsertBeforeOperation：挿入対象の文の前にプログラム文の追加を表す操作
 - jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation：プログラム文の置換を表す操作
 
 

--- a/doc/ja/OVERVIEW.md
+++ b/doc/ja/OVERVIEW.md
@@ -136,10 +136,10 @@ KGenProgのデフォルト値はOchiaiである．
 ## 抽象構文木の変更操作を表すインターフェース JDTOperation
 抽象構文木の変更操作を表すインターフェースは jp.kusumotolab.kgenprog.project.jdt.JDTOperation である．
 現在のところ，実装クラスとしては以下のものがある．
-- jp.kusumotolab.kgenprog.project.jdt.DeleteOperation：プログラム文の削除を表す操作
-- jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation：挿入対象の文の後ろにプログラム文の追加を表す操作
-- jp.kusumotolab.kgenprog.project.jdt.InsertBeforeOperation：挿入対象の文の前にプログラム文の追加を表す操作
-- jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation：プログラム文の置換を表す操作
+- jp.kusumotolab.kgenprog.project.jdt.DeleteOperation：プログラム文を削除する
+- jp.kusumotolab.kgenprog.project.jdt.InsertBeforeOperation：対象のプログラム文の前にプログラム文を挿入する
+- jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation：対象のプログラム文の後ろにプログラム文を挿入する
+- jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation：プログラム文を置換する
 
 
 

--- a/doc/ja/OVERVIEW.md
+++ b/doc/ja/OVERVIEW.md
@@ -137,7 +137,7 @@ KGenProgのデフォルト値はOchiaiである．
 抽象構文木の変更操作を表すインターフェースは jp.kusumotolab.kgenprog.project.jdt.JDTOperation である．
 現在のところ，実装クラスとしては以下のものがある．
 - jp.kusumotolab.kgenprog.project.jdt.DeleteOperation：プログラム文の削除を表す操作
-- jp.kusumotolab.kgenprog.project.jdt.InsertOperation：プログラム文の追加を表す操作
+- jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation：プログラム文の追加を表す操作
 - jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation：プログラム文の置換を表す操作
 
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/HeuristicMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/HeuristicMutation.java
@@ -8,6 +8,7 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.BreakStatement;
+import org.eclipse.jdt.core.dom.ContinueStatement;
 import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.ThrowStatement;
@@ -69,6 +70,7 @@ public class HeuristicMutation extends SimpleMutation {
 
     if (node instanceof ReturnStatement
         || node instanceof BreakStatement
+        || node instanceof ContinueStatement
         || node instanceof ThrowStatement) {
       return new InsertBeforeOperation(nodeForReuse);
     }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
@@ -20,8 +20,8 @@ import jp.kusumotolab.kgenprog.project.ASTLocation;
 import jp.kusumotolab.kgenprog.project.FullyQualifiedName;
 import jp.kusumotolab.kgenprog.project.NoneOperation;
 import jp.kusumotolab.kgenprog.project.Operation;
+import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.DeleteOperation;
-import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
 import jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation;
 
 /**
@@ -107,7 +107,7 @@ public class SimpleMutation extends Mutation {
       case 0:
         return new DeleteOperation();
       case 1:
-        return new InsertOperation(chooseNodeForReuse(location));
+        return new InsertAfterOperation(chooseNodeForReuse(location));
       case 2:
         return new ReplaceOperation(chooseNodeForReuse(location));
     }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
@@ -22,6 +22,7 @@ import jp.kusumotolab.kgenprog.project.NoneOperation;
 import jp.kusumotolab.kgenprog.project.Operation;
 import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.DeleteOperation;
+import jp.kusumotolab.kgenprog.project.jdt.InsertBeforeOperation;
 import jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation;
 
 /**
@@ -44,7 +45,8 @@ public class SimpleMutation extends Mutation {
    * @param needHistoricalElement 個体が生成される過程を記録するか否か
    */
   public SimpleMutation(final int mutationGeneratingCount, final Random random,
-      final CandidateSelection candidateSelection, final Type type, final boolean needHistoricalElement) {
+      final CandidateSelection candidateSelection, final Type type,
+      final boolean needHistoricalElement) {
     super(mutationGeneratingCount, random, candidateSelection);
     this.type = type;
     this.needHistoricalElement = needHistoricalElement;
@@ -107,7 +109,9 @@ public class SimpleMutation extends Mutation {
       case 0:
         return new DeleteOperation();
       case 1:
-        return new InsertAfterOperation(chooseNodeForReuse(location));
+        final ASTNode astNode = chooseNodeForReuse(location);
+        return random.nextBoolean() ? new InsertAfterOperation(astNode)
+            : new InsertBeforeOperation(astNode);
       case 2:
         return new ReplaceOperation(chooseNodeForReuse(location));
     }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertAfterOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertAfterOperation.java
@@ -6,11 +6,11 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import jp.kusumotolab.kgenprog.project.SourcePath;
 
-public class InsertOperation extends JDTOperation {
+public class InsertAfterOperation extends JDTOperation {
 
   private final ASTNode astNode;
 
-  public InsertOperation(final ASTNode astNode) {
+  public InsertAfterOperation(final ASTNode astNode) {
     this.astNode = astNode;
   }
 
@@ -26,7 +26,7 @@ public class InsertOperation extends JDTOperation {
 
   @Override
   public String getName(){
-    return "insert";
+    return "insert_after";
   }
 
   @Override

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertBeforeOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertBeforeOperation.java
@@ -1,0 +1,37 @@
+package jp.kusumotolab.kgenprog.project.jdt;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ChildListPropertyDescriptor;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import jp.kusumotolab.kgenprog.project.SourcePath;
+
+public class InsertBeforeOperation extends JDTOperation {
+
+  private final ASTNode astNode;
+
+  public InsertBeforeOperation(final ASTNode astNode) {
+    this.astNode = astNode;
+  }
+
+  @Override
+  protected <T extends SourcePath> void applyToASTRewrite(final GeneratedJDTAST<T> ast,
+      final JDTASTLocation location, final ASTRewrite astRewrite) {
+    final ASTNode target = location.locate(ast.getRoot());
+    final ListRewrite listRewrite = astRewrite.getListRewrite(target.getParent(),
+        (ChildListPropertyDescriptor) target.getLocationInParent());
+    final ASTNode copiedNode = ASTNode.copySubtree(astRewrite.getAST(), this.astNode);
+    listRewrite.insertBefore(copiedNode, target, null);
+  }
+
+  @Override
+  public String getName(){
+    return "insert_before";
+  }
+
+  @Override
+  public String getTargetSnippet() {
+    return astNode.toString();
+  }
+
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
@@ -47,7 +47,6 @@ public class KGenProgMainTest {
             .setMaxGeneration(100)
             .setRequiredSolutionsCount(1)
             .setNeedNotOutput(true)
-            .setRandomSeed(2) // CTZ04の修正に時間がかかるので早めに終わるよう微調整（for テスト高速化）
             .build();
 
     final FaultLocalization faultLocalization = new Ochiai();

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverSingleTestVariant.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverSingleTestVariant.java
@@ -13,7 +13,7 @@ import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 import jp.kusumotolab.kgenprog.project.NoneOperation;
 import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
-import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
+import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 // 1つの疑似バリアントからなるテストデータ．
@@ -36,7 +36,7 @@ public class CrossoverSingleTestVariant {
             new TestFullyQualifiedName("Test7"), new TestFullyQualifiedName("Test9")));
 
     noneBase = new Base(null, new NoneOperation());
-    insertBase = new Base(null, new InsertOperation(null));
+    insertBase = new Base(null, new InsertAfterOperation(null));
     final Gene geneA = new Gene(Arrays.asList(noneBase, noneBase, insertBase, insertBase));
 
     final Fitness fitnessA = new SimpleFitness(0.5d);

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CrossoverTestVariants.java
@@ -14,7 +14,7 @@ import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 import jp.kusumotolab.kgenprog.project.NoneOperation;
 import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
-import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
+import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.test.TestResult;
 import jp.kusumotolab.kgenprog.project.test.TestResults;
 
@@ -176,7 +176,7 @@ public class CrossoverTestVariants {
         .thenReturn(failedTestResult);
 
     noneBase = new Base(null, new NoneOperation());
-    insertBase = new Base(null, new InsertOperation(null));
+    insertBase = new Base(null, new InsertAfterOperation(null));
     final Gene geneA = new Gene(Arrays.asList(noneBase, noneBase, noneBase, noneBase));
     final Gene geneB = new Gene(Arrays.asList(noneBase, noneBase, noneBase, insertBase));
     final Gene geneC = new Gene(Arrays.asList(noneBase, insertBase, insertBase, insertBase));

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutationTest.java
@@ -37,8 +37,8 @@ import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 import jp.kusumotolab.kgenprog.project.SourcePath;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
+import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.GeneratedJDTAST;
-import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
 import jp.kusumotolab.kgenprog.project.jdt.JDTASTLocation;
 import jp.kusumotolab.kgenprog.testutil.TestUtil;
 
@@ -134,9 +134,9 @@ public class SimpleMutationTest {
     assertThat(targetLocation.node).isSameSourceCodeAs("return n;");
 
     final Operation operation = base.getOperation();
-    assertThat(operation).isInstanceOf(InsertOperation.class);
+    assertThat(operation).isInstanceOf(InsertAfterOperation.class);
 
-    final InsertOperation insertOperation = (InsertOperation) operation;
+    final InsertAfterOperation insertOperation = (InsertAfterOperation) operation;
     final Field field = insertOperation.getClass()
         .getDeclaredField("astNode");
     field.setAccessible(true);

--- a/src/test/java/jp/kusumotolab/kgenprog/output/BaseSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/BaseSerializerTest.java
@@ -19,9 +19,9 @@ import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
+import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.DeleteOperation;
 import jp.kusumotolab.kgenprog.project.jdt.GeneratedJDTAST;
-import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
 import jp.kusumotolab.kgenprog.project.jdt.JDTASTLocation;
 import jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation;
 import jp.kusumotolab.kgenprog.testutil.ExampleAlias.Src;
@@ -92,7 +92,7 @@ public class BaseSerializerTest {
     invocation.setName(jdtAST.newSimpleName("a"));
     final Statement insertStatement = jdtAST.newExpressionStatement(invocation);
 
-    final InsertOperation operation = new InsertOperation(insertStatement);
+    final InsertAfterOperation operation = new InsertAfterOperation(insertStatement);
     final Base base = new Base(location, operation);
     final JsonObject serializedBase = gson.toJsonTree(base)
         .getAsJsonObject();

--- a/src/test/java/jp/kusumotolab/kgenprog/output/CrossoverHistoricalElementSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/CrossoverHistoricalElementSerializerTest.java
@@ -24,7 +24,7 @@ import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.GenerationFailedSourceCode;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
-import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
+import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.JDTASTConstruction;
 import jp.kusumotolab.kgenprog.project.test.EmptyTestResults;
 import jp.kusumotolab.kgenprog.testutil.JsonKeyAlias;
@@ -75,12 +75,12 @@ public class CrossoverHistoricalElementSerializerTest {
     // 親1
     final Variant parentA = createVariant(1L, 1, new SimpleFitness(0.0d),
         new GenerationFailedSourceCode(""),
-        new MutationHistoricalElement(initialVariant, new Base(null, new InsertOperation(null))));
+        new MutationHistoricalElement(initialVariant, new Base(null, new InsertAfterOperation(null))));
 
     // 親2
     final Variant parentB = createVariant(2L, 1, new SimpleFitness(0.0d),
         new GenerationFailedSourceCode(""),
-        new MutationHistoricalElement(initialVariant, new Base(null, new InsertOperation(null))));
+        new MutationHistoricalElement(initialVariant, new Base(null, new InsertAfterOperation(null))));
 
     // 子供
     final HistoricalElement historicalElement = new CrossoverHistoricalElement(parentA, parentB, 1);

--- a/src/test/java/jp/kusumotolab/kgenprog/output/MutationHistoricalElementSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/MutationHistoricalElementSerializerTest.java
@@ -28,9 +28,9 @@ import jp.kusumotolab.kgenprog.project.Operation;
 import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
+import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.DeleteOperation;
 import jp.kusumotolab.kgenprog.project.jdt.GeneratedJDTAST;
-import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
 import jp.kusumotolab.kgenprog.project.jdt.JDTASTConstruction;
 import jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation;
 import jp.kusumotolab.kgenprog.project.test.EmptyTestResults;
@@ -93,7 +93,7 @@ public class MutationHistoricalElementSerializerTest {
 
     // 差分はいらないのでNullやNullObjectにする
     // Baseのシリアライズに関するテストはここではしないのでASTLocationはモックにする
-    final Operation operation = new InsertOperation(createASTNode(project));
+    final Operation operation = new InsertAfterOperation(createASTNode(project));
     final ASTLocation targetLocation = mockASTLocation(project);
     final Base appendBase = new Base(targetLocation, operation);
     final HistoricalElement historicalElement = new MutationHistoricalElement(initialVariant,
@@ -121,7 +121,7 @@ public class MutationHistoricalElementSerializerTest {
     final String operationName = serializedHistoricalElement.get(
         JsonKeyAlias.MutationHistoricalElement.NAME)
         .getAsString();
-    assertThat(operationName).isEqualTo("insert");
+    assertThat(operationName).isEqualTo("insert_after");
   }
 
   /**

--- a/src/test/java/jp/kusumotolab/kgenprog/output/PatchSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/PatchSerializerTest.java
@@ -28,8 +28,8 @@ import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
+import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.GeneratedJDTAST;
-import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
 import jp.kusumotolab.kgenprog.project.jdt.JDTASTConstruction;
 import jp.kusumotolab.kgenprog.project.jdt.JDTASTLocation;
 import jp.kusumotolab.kgenprog.project.test.EmptyTestResults;
@@ -95,7 +95,7 @@ public class PatchSerializerTest {
     final MethodInvocation invocation = jdtAST.newMethodInvocation();
     invocation.setName(jdtAST.newSimpleName("json"));
     final Statement insertStatement = jdtAST.newExpressionStatement(invocation);
-    final InsertOperation operation = new InsertOperation(insertStatement);
+    final InsertAfterOperation operation = new InsertAfterOperation(insertStatement);
     final Base appendBase = new Base(location, operation);
     final GeneratedSourceCode code = operation.apply(originalSourceCode, location);
     final HistoricalElement historicalElement =

--- a/src/test/java/jp/kusumotolab/kgenprog/project/PatchGeneratorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/PatchGeneratorTest.java
@@ -20,7 +20,7 @@ import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
 import jp.kusumotolab.kgenprog.project.jdt.DeleteOperation;
 import jp.kusumotolab.kgenprog.project.jdt.GeneratedJDTAST;
-import jp.kusumotolab.kgenprog.project.jdt.InsertOperation;
+import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.JDTASTLocation;
 import jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation;
 import jp.kusumotolab.kgenprog.testutil.ExampleAlias.Src;
@@ -164,7 +164,7 @@ public class PatchGeneratorTest {
     invocation.setName(jdtAST.newSimpleName("a"));
     final Statement insertStatement = jdtAST.newExpressionStatement(invocation);
 
-    final InsertOperation operation = new InsertOperation(insertStatement);
+    final InsertAfterOperation operation = new InsertAfterOperation(insertStatement);
     final GeneratedSourceCode code = operation.apply(originalSourceCode, location);
     final Variant modifiedVariant = new Variant(0, 0,
         new Gene(Arrays.asList(new Base(location, operation))), code, null, null, null, null);

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/GeneratedJDTASTTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/GeneratedJDTASTTest.java
@@ -248,7 +248,7 @@ public class GeneratedJDTASTTest {
     final MethodInvocation methodInvocation = ast.newMethodInvocation();
     methodInvocation.setName(ast.newSimpleName("a"));
     final Statement insertStatement = ast.newExpressionStatement(methodInvocation);
-    final InsertOperation operation = new InsertOperation(insertStatement);
+    final InsertAfterOperation operation = new InsertAfterOperation(insertStatement);
 
     final GeneratedJDTAST<ProductSourcePath> newJdtAst =
         (GeneratedJDTAST<ProductSourcePath>) operation.apply(generatedSourceCode, location)

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertAfterOperationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertAfterOperationTest.java
@@ -13,7 +13,7 @@ import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 import jp.kusumotolab.kgenprog.project.TestSourcePath;
 
-public class InsertOperationTest {
+public class InsertAfterOperationTest {
 
   @Test
   public void testInsertStatement() {
@@ -47,7 +47,7 @@ public class InsertOperationTest {
 
     // 挿入対象生成
     final Statement insertStatement = createInsertionTarget();
-    final InsertOperation operation = new InsertOperation(insertStatement);
+    final InsertAfterOperation operation = new InsertAfterOperation(insertStatement);
 
     final GeneratedSourceCode code = operation.apply(generatedSourceCode, location);
     final GeneratedJDTAST<ProductSourcePath> newAST =

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertBeforeOperationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertBeforeOperationTest.java
@@ -1,0 +1,96 @@
+package jp.kusumotolab.kgenprog.project.jdt;
+
+import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.file.Paths;
+import java.util.Collections;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.junit.Test;
+import org.mockito.Mockito;
+import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.project.ProductSourcePath;
+import jp.kusumotolab.kgenprog.project.TestSourcePath;
+
+public class InsertBeforeOperationTest {
+
+  @Test
+  public void testInsertStatement() {
+    final String source = new StringBuilder().append("")
+        .append("class A {")
+        .append("  public void a() {")
+        .append("    int i = 0;")
+        .append("    i = 1;")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    final ProductSourcePath sourcePath = new ProductSourcePath(Paths.get("."), Paths.get("A.java"));
+
+    final JDTASTConstruction constructor = new JDTASTConstruction();
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source);
+    @SuppressWarnings("unchecked")
+    final GeneratedJDTAST<TestSourcePath> mockAst = Mockito.mock(GeneratedJDTAST.class);
+    final GeneratedSourceCode generatedSourceCode =
+        new GeneratedSourceCode(Collections.singletonList(ast), Collections.singletonList(mockAst));
+
+    // 挿入位置のLocation生成
+    final TypeDeclaration type = (TypeDeclaration) ast.getRoot()
+        .types()
+        .get(0);
+    final MethodDeclaration method = type.getMethods()[0];
+    final Statement statement = (Statement) method.getBody()
+        .statements()
+        .get(1);
+    final JDTASTLocation location = new JDTASTLocation(sourcePath, statement, ast);
+
+    // 挿入対象生成
+    final Statement insertStatement = createInsertionTarget();
+    final InsertBeforeOperation operation = new InsertBeforeOperation(insertStatement);
+
+    final GeneratedSourceCode code = operation.apply(generatedSourceCode, location);
+    final GeneratedJDTAST<ProductSourcePath> newAST =
+        (GeneratedJDTAST<ProductSourcePath>) code.getProductAsts()
+            .get(0);
+
+    final String expected = new StringBuilder().append("")
+        .append("class A {")
+        .append("  public void a() {")
+        .append("    int i = 0;")
+        .append("    xxx();") // inserted statement
+        .append("    i = 1;")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    assertThat(newAST.getRoot()).isSameSourceCodeAs(expected);
+
+    // TestASTがそのまま受け継がれているか確認
+    assertThat(code.getTestAsts()).hasSize(1);
+    assertThat(code.getTestAsts()
+        .get(0)).isSameAs(mockAst);
+  }
+
+  private Statement createInsertionTarget() {
+    final String source = new StringBuilder().append("")
+        .append("class B {")
+        .append("  public void b() {")
+        .append("    xxx();")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    final ProductSourcePath sourcePath = new ProductSourcePath(Paths.get("."), Paths.get("B.java"));
+
+    final JDTASTConstruction constructor = new JDTASTConstruction();
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source);
+
+    final TypeDeclaration type = (TypeDeclaration) ast.getRoot()
+        .types()
+        .get(0);
+    return (Statement) type.getMethods()[0].getBody()
+        .statements()
+        .get(0);
+  }
+}


### PR DESCRIPTION
resolve #632 
#632 で議論した`InsertBeforeOperation`の追加
- `InsertOperation`を`InsertAfterOperation`にリネーム
- `InsertBeforeOperation`の追加
- `SimpleMutation`は 1/2 で After か Before かを決定
- `HeuristicMutation`は挿入する先のコードを見て，After か Before かを判定．どちらでも良い場合は 1/2 で決定