### PR TITLE
for 文の initializer がAssignment の時の処理もれ

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/AccessibleVariableSearcher.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/AccessibleVariableSearcher.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.EnhancedForStatement;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
@@ -118,6 +119,9 @@ public class AccessibleVariableSearcher {
     final List<Variable> results = new ArrayList<>();
     final List initializers = node.initializers();
     for (final Object initializer : initializers) {
+      if (initializer instanceof Assignment) {
+        continue;
+      }
       if (!(initializer instanceof VariableDeclarationExpression)) {
         throw new RuntimeException("Not Implemented");
       }


### PR DESCRIPTION
`AccessibleVariableSearcher`で for 文の変数を探索する際，
```java
for (index = 0; index < n; index++) {
}
```
のようなもの時に例外で落ちるので，そのような場合の処理を追加