### PR TITLE
FL実装のリファクタリング

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Ample.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Ample.java
@@ -1,59 +1,18 @@
 package jp.kusumotolab.kgenprog.fl;
 
-import java.util.ArrayList;
-import java.util.List;
-import jp.kusumotolab.kgenprog.project.ASTLocation;
-import jp.kusumotolab.kgenprog.project.ASTLocations;
-import jp.kusumotolab.kgenprog.project.GeneratedAST;
-import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
-import jp.kusumotolab.kgenprog.project.ProductSourcePath;
-import jp.kusumotolab.kgenprog.project.test.TestResults;
-
 /**
- *  FL戦略の一つ(Ample).
- *  <br>
- *  {@code value = Math.abs(ef / (ef + nf) - ep / (ep + np))}<br>
- *  {@code ef}:該当する文を実行し，通過しなかったテストの個数<br>
- *  {@code nf}:該当する文を実行せずに，通過しなかったテストの個数<br>
- *  {@code ep}:該当する文を実行し，通過したテストの個数<br>
- *  {@code np}:該当する文を実行せずに，通過したテストの個数
+ * FL戦略の一つ(Ample).<br>
+ * {@code value = Math.abs(ef / (ef + nf) - ep / (ep + np))}<br>
  */
-public class Ample implements FaultLocalization {
+public class Ample extends SpectrumBasedFaultLocalization {
 
-  /**
-   * 疑惑値を計算する.
-   * @param generatedSourceCode 自動バグ限局の対象ソースコード
-   * @param testResults テストの実行結果
-   * @return suspiciousnesses 疑惑値
-   */
   @Override
-  public List<Suspiciousness> exec(final GeneratedSourceCode generatedSourceCode,
-      final TestResults testResults) {
+  protected double formula(double ef, double nf, double ep, double np) {
+    return Math.abs(ef / (double) (ef + nf) - ep / (double) (ep + np));
+  }
 
-    final List<Suspiciousness> suspiciousnesses = new ArrayList<>();
-
-    for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
-      final ProductSourcePath path = ast.getSourcePath();
-      final int lastLineNumber = ast.getNumberOfLines();
-      final ASTLocations astLocations = ast.createLocations();
-
-      for (int line = 1; line <= lastLineNumber; line++) {
-        final List<ASTLocation> locations = astLocations.infer(line);
-        if (!locations.isEmpty()) {
-          final ASTLocation l = locations.get(locations.size() - 1);
-          final long ef = testResults.getNumberOfFailedTestsExecutingTheStatement(path, l);
-          final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
-          final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
-          final long np = testResults.getNumberOfPassedTestsNotExecutingTheStatement(path, l);
-          final double value = Math.abs(ef / (double)(ef + nf) - ep / (double)(ep + np));
-          if (0d < value) {
-            final Suspiciousness s = new Suspiciousness(l, value);
-            suspiciousnesses.add(s);
-          }
-        }
-      }
-    }
-
-    return suspiciousnesses;
+  @Override
+  protected boolean isSkippablePassedTests() {
+    return false;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Ample.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Ample.java
@@ -7,12 +7,8 @@ package jp.kusumotolab.kgenprog.fl;
 public class Ample extends SpectrumBasedFaultLocalization {
 
   @Override
-  protected double formula(double ef, double nf, double ep, double np) {
+  protected double formula(final double ef, final double nf, final double ep, final double np) {
     return Math.abs(ef / (double) (ef + nf) - ep / (double) (ep + np));
   }
 
-  @Override
-  protected boolean isSkippablePassedTests() {
-    return false;
-  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Jaccard.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Jaccard.java
@@ -7,12 +7,8 @@ package jp.kusumotolab.kgenprog.fl;
 public class Jaccard extends SpectrumBasedFaultLocalization {
 
   @Override
-  protected double formula(double ef, double nf, double ep, double np) {
+  protected double formula(final double ef, final double nf, final double ep, final double np) {
     return ef / (double) (ef + nf + ep);
   }
 
-  @Override
-  protected boolean isSkippablePassedTests() {
-    return true;
-  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Jaccard.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Jaccard.java
@@ -1,57 +1,18 @@
 package jp.kusumotolab.kgenprog.fl;
 
-import java.util.ArrayList;
-import java.util.List;
-import jp.kusumotolab.kgenprog.project.ASTLocation;
-import jp.kusumotolab.kgenprog.project.ASTLocations;
-import jp.kusumotolab.kgenprog.project.GeneratedAST;
-import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
-import jp.kusumotolab.kgenprog.project.ProductSourcePath;
-import jp.kusumotolab.kgenprog.project.test.TestResults;
-
 /**
- *  FL戦略の一つ(Jaccard).
- *  <br>
- *  {@code value = ef / (ef + nf + ep)}<br>
- *  {@code ef}:該当する文を実行し，通過しなかったテストの個数<br>
- *  {@code nf}:該当する文を実行せずに，通過しなかったテストの個数<br>
- *  {@code ep}:該当する文を実行し，通過したテストの個数
+ * FL戦略の一つ(Jaccard). <br>
+ * {@code value = ef / (ef + nf + ep)}
  */
-public class Jaccard implements FaultLocalization {
+public class Jaccard extends SpectrumBasedFaultLocalization {
 
-  /**
-   * 疑惑値を計算する.
-   * @param generatedSourceCode 自動バグ限局の対象ソースコード
-   * @param testResults テストの実行結果
-   * @return suspiciousnesses 疑惑値
-   */
   @Override
-  public List<Suspiciousness> exec(final GeneratedSourceCode generatedSourceCode,
-      final TestResults testResults) {
+  protected double formula(double ef, double nf, double ep, double np) {
+    return ef / (double) (ef + nf + ep);
+  }
 
-    final List<Suspiciousness> suspiciousnesses = new ArrayList<>();
-
-    for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
-      final ProductSourcePath path = ast.getSourcePath();
-      final int lastLineNumber = ast.getNumberOfLines();
-      final ASTLocations astLocations = ast.createLocations();
-
-      for (int line = 1; line <= lastLineNumber; line++) {
-        final List<ASTLocation> locations = astLocations.infer(line);
-        if (!locations.isEmpty()) {
-          final ASTLocation l = locations.get(locations.size() - 1);
-          final long ef = testResults.getNumberOfFailedTestsExecutingTheStatement(path, l);
-          final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
-          final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
-          final double value = ef / (double)(ef + nf + ep);
-          if (0d < value) {
-            final Suspiciousness s = new Suspiciousness(l, value);
-            suspiciousnesses.add(s);
-          }
-        }
-      }
-    }
-
-    return suspiciousnesses;
+  @Override
+  protected boolean isSkippablePassedTests() {
+    return true;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Ochiai.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Ochiai.java
@@ -7,12 +7,8 @@ package jp.kusumotolab.kgenprog.fl;
 public class Ochiai extends SpectrumBasedFaultLocalization {
 
   @Override
-  protected double formula(double ef, double nf, double ep, double np) {
+  protected double formula(final double ef, final double nf, final double ep, final double np) {
     return ef / Math.sqrt((ef + nf) * (ef + ep));
   }
 
-  @Override
-  protected boolean isSkippablePassedTests() {
-    return true;
-  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Ochiai.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Ochiai.java
@@ -1,71 +1,18 @@
 package jp.kusumotolab.kgenprog.fl;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import jp.kusumotolab.kgenprog.project.ASTLocation;
-import jp.kusumotolab.kgenprog.project.ASTLocations;
-import jp.kusumotolab.kgenprog.project.FullyQualifiedName;
-import jp.kusumotolab.kgenprog.project.GeneratedAST;
-import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
-import jp.kusumotolab.kgenprog.project.ProductSourcePath;
-import jp.kusumotolab.kgenprog.project.test.TestResults;
-
 /**
- *  FL戦略の一つ(Ochiai).
- *  <br>
- *  {@code value = ef / Math.sqrt((ef + nf) * (ef + ep))}<br>
- *  {@code ef}:該当する文を実行し，通過しなかったテストの個数<br>
- *  {@code nf}:該当する文を実行せずに，通過しなかったテストの個数<br>
- *  {@code ep}:該当する文を実行し，通過したテストの個数
+ * FL戦略の一つ(Ochiai). <br>
+ * {@code value = ef / Math.sqrt((ef + nf) * (ef + ep))}
  */
-public class Ochiai implements FaultLocalization {
+public class Ochiai extends SpectrumBasedFaultLocalization {
 
-  /**
-   * 疑惑値を計算する.
-   * @param generatedSourceCode 自動バグ限局の対象ソースコード
-   * @param testResults テストの実行結果
-   * @return suspiciousnesses 疑惑値
-   */
   @Override
-  public List<Suspiciousness> exec(final GeneratedSourceCode generatedSourceCode,
-      final TestResults testResults) {
+  protected double formula(double ef, double nf, double ep, double np) {
+    return ef / Math.sqrt((ef + nf) * (ef + ep));
+  }
 
-    final List<Suspiciousness> suspiciousnesses = new ArrayList<>();
-
-    final Set<FullyQualifiedName> targetFQNs = testResults.getFailedTestResults()
-        .stream()
-        .flatMap(tr -> tr.getExecutedTargetFQNs()
-            .stream())
-        .collect(Collectors.toSet());
-
-    for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
-
-      if (!targetFQNs.contains(ast.getPrimaryClassName())) {
-        continue;
-      }
-
-      final ProductSourcePath path = ast.getSourcePath();
-      final int lastLineNumber = ast.getNumberOfLines();
-      final ASTLocations astLocations = ast.createLocations();
-
-      for (int line = 1; line <= lastLineNumber; line++) {
-        final List<ASTLocation> locations = astLocations.infer(line);
-        if (!locations.isEmpty()) {
-          final ASTLocation l = locations.get(locations.size() - 1);
-          final long ef = testResults.getNumberOfFailedTestsExecutingTheStatement(path, l);
-          final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
-          final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
-          final double value = ef / Math.sqrt((ef + nf) * (ef + ep));
-          if (0d < value) {
-            final Suspiciousness s = new Suspiciousness(l, value);
-            suspiciousnesses.add(s);
-          }
-        }
-      }
-    }
-
-    return suspiciousnesses;
+  @Override
+  protected boolean isSkippablePassedTests() {
+    return true;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/SpectrumBasedFaultLocalization.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/SpectrumBasedFaultLocalization.java
@@ -19,6 +19,24 @@ import jp.kusumotolab.kgenprog.project.test.TestResults;
  */
 public abstract class SpectrumBasedFaultLocalization implements FaultLocalization {
 
+  private boolean skippableFormula;
+
+  public SpectrumBasedFaultLocalization() {
+    skippableFormula = isSkippableFormula();
+  }
+
+  /**
+   * 与えられた数式が以下条件を満たすかを確認する．満たす場合，計算手順をある程度省略可能．<br>
+   * 条件：ef=0 の場合に常に計算結果が 0 になる．<br>
+   * @see <a href="https://github.com/kusumotolab/kGenProg/pull/658">issue#658</a>
+   */
+  private boolean isSkippableFormula() {
+    // 3つの条件でテスト (efは常に0)
+    return formula(0, 10, 20, 30) == 0d && //
+        formula(0, 99, 300, 0) == 0d && //
+        formula(0, 33, 55, 66) == 0d;
+  }
+
   /**
    * 疑惑値を計算する.
    * 
@@ -41,8 +59,7 @@ public abstract class SpectrumBasedFaultLocalization implements FaultLocalizatio
     for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
 
       // do nothing if none of failed target fqns contain the ast
-      if (isSkippablePassedTests()
-          && !execuetdFailedTargetFQNs.contains(ast.getPrimaryClassName())) {
+      if (skippableFormula && !execuetdFailedTargetFQNs.contains(ast.getPrimaryClassName())) {
         continue;
       }
 
@@ -82,16 +99,10 @@ public abstract class SpectrumBasedFaultLocalization implements FaultLocalizatio
    * FLメトリクスの計算式<br>
    * {@code ef}:該当する文を実行した失敗テストの個数<br>
    * {@code nf}:該当する文を実行しなかった失敗テストの個数<br>
-   * {@code ep}:該当する文を実行した通過テストの個数
+   * {@code ep}:該当する文を実行した通過テストの個数<br>
    * {@code np}:該当する文を実行しなかった通過テストの個数<br>
    */
-  abstract protected double formula(double ef, double nf, double ep, double np);
-
-  /**
-   * {@link SpectrumBasedFaultLocalization#formula}の計算において，通過テストのみを対象としてよいかどうか．
-   * 高速化のためのパラメタであり不明な際はtrueでも正しく動作する．
-   * @return
-   */
-  abstract protected boolean isSkippablePassedTests();
+  abstract protected double formula(final double ef, final double nf, final double ep,
+      final double np);
 
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/SpectrumBasedFaultLocalization.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/SpectrumBasedFaultLocalization.java
@@ -1,0 +1,97 @@
+package jp.kusumotolab.kgenprog.fl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import jp.kusumotolab.kgenprog.project.ASTLocation;
+import jp.kusumotolab.kgenprog.project.ASTLocations;
+import jp.kusumotolab.kgenprog.project.FullyQualifiedName;
+import jp.kusumotolab.kgenprog.project.GeneratedAST;
+import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
+import jp.kusumotolab.kgenprog.project.ProductSourcePath;
+import jp.kusumotolab.kgenprog.project.test.TestResults;
+
+/**
+ * テスト情報に基づくFL<br>
+ * メトリクスの計算式のみを抽象化
+ */
+public abstract class SpectrumBasedFaultLocalization implements FaultLocalization {
+
+  /**
+   * 疑惑値を計算する.
+   * 
+   * @param generatedSourceCode 自動バグ限局の対象ソースコード
+   * @param testResults テストの実行結果
+   * @return suspiciousnesses 疑惑値
+   */
+  @Override
+  public List<Suspiciousness> exec(final GeneratedSourceCode generatedSourceCode,
+      final TestResults testResults) {
+
+    final List<Suspiciousness> suspiciousnesses = new ArrayList<>();
+
+    final Set<FullyQualifiedName> execuetdFailedTargetFQNs = testResults.getFailedTestResults()
+        .stream()
+        .map(tr -> tr.getExecutedTargetFQNs())
+        .flatMap(Collection::stream)
+        .collect(Collectors.toSet());
+
+    for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
+
+      // do nothing if none of failed target fqns contain the ast
+      if (isSkippablePassedTests()
+          && !execuetdFailedTargetFQNs.contains(ast.getPrimaryClassName())) {
+        continue;
+      }
+
+      final ProductSourcePath path = ast.getSourcePath();
+      final int lastLineNumber = ast.getNumberOfLines();
+      final ASTLocations astLocations = ast.createLocations();
+
+      for (int line = 1; line <= lastLineNumber; line++) {
+        final List<ASTLocation> locations = astLocations.infer(line);
+
+        // no location found
+        if (locations.isEmpty()) {
+          continue;
+        }
+
+        final ASTLocation loc = locations.get(locations.size() - 1);
+        final long ef = testResults.getNumberOfFailedTestsExecutingTheStatement(path, loc);
+        final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, loc);
+        final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, loc);
+        final long np = testResults.getNumberOfPassedTestsNotExecutingTheStatement(path, loc);
+
+        final double value = formula(ef, nf, ep, np);
+
+        // zero or nan means nothing
+        if (value <= 0 || Double.isNaN(value)) {
+          continue;
+        }
+
+        final Suspiciousness s = new Suspiciousness(loc, value);
+        suspiciousnesses.add(s);
+      }
+    }
+    return suspiciousnesses;
+  }
+
+  /**
+   * FLメトリクスの計算式<br>
+   * {@code ef}:該当する文を実行した失敗テストの個数<br>
+   * {@code nf}:該当する文を実行しなかった失敗テストの個数<br>
+   * {@code ep}:該当する文を実行した通過テストの個数
+   * {@code np}:該当する文を実行しなかった通過テストの個数<br>
+   */
+  abstract protected double formula(double ef, double nf, double ep, double np);
+
+  /**
+   * {@link SpectrumBasedFaultLocalization#formula}の計算において，通過テストのみを対象としてよいかどうか．
+   * 高速化のためのパラメタであり不明な際はtrueでも正しく動作する．
+   * @return
+   */
+  abstract protected boolean isSkippablePassedTests();
+
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Suspiciousness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Suspiciousness.java
@@ -8,7 +8,7 @@ public class Suspiciousness {
   final private ASTLocation location;
   final private double value;
 
-  public Suspiciousness(ASTLocation location, double value) {
+  public Suspiciousness(final ASTLocation location, final double value) {
     this.location = location;
     this.value = value;
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Tarantula.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Tarantula.java
@@ -7,12 +7,8 @@ package jp.kusumotolab.kgenprog.fl;
 public class Tarantula extends SpectrumBasedFaultLocalization {
 
   @Override
-  protected double formula(double ef, double nf, double ep, double np) {
+  protected double formula(final double ef, final double nf, final double ep, final double np) {
     return (ef / (double) (ef + nf)) / (ef / (double) (ef + nf) + ep / (double) (ep + np));
   }
 
-  @Override
-  protected boolean isSkippablePassedTests() {
-    return true;
-  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Tarantula.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Tarantula.java
@@ -1,59 +1,18 @@
 package jp.kusumotolab.kgenprog.fl;
 
-import java.util.ArrayList;
-import java.util.List;
-import jp.kusumotolab.kgenprog.project.ASTLocation;
-import jp.kusumotolab.kgenprog.project.ASTLocations;
-import jp.kusumotolab.kgenprog.project.GeneratedAST;
-import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
-import jp.kusumotolab.kgenprog.project.ProductSourcePath;
-import jp.kusumotolab.kgenprog.project.test.TestResults;
-
 /**
- *  FL戦略の一つ(Tarantula).
- *  <br>
- *  {@code value = (ef / (ef + nf)) / (ef / (ef + nf) + ep / (ep + np))}<br>
- *  {@code ef}:該当する文を実行し，通過しなかったテストの個数<br>
- *  {@code nf}:該当する文を実行せずに，通過しなかったテストの個数<br>
- *  {@code ep}:該当する文を実行し，通過したテストの個数<br>
- *  {@code np}:該当する文を実行せずに，通過したテストの個数
+ * FL戦略の一つ(Tarantula).<br>
+ * {@code value = (ef / (ef + nf)) / (ef / (ef + nf) + ep / (ep + np))}
  */
-public class Tarantula implements FaultLocalization {
+public class Tarantula extends SpectrumBasedFaultLocalization {
 
-  /**
-   * 疑惑値を計算する.
-   * @param generatedSourceCode 自動バグ限局の対象ソースコード
-   * @param testResults テストの実行結果
-   * @return suspiciousnesses 疑惑値
-   */
   @Override
-  public List<Suspiciousness> exec(final GeneratedSourceCode generatedSourceCode,
-      final TestResults testResults) {
+  protected double formula(double ef, double nf, double ep, double np) {
+    return (ef / (double) (ef + nf)) / (ef / (double) (ef + nf) + ep / (double) (ep + np));
+  }
 
-    final List<Suspiciousness> suspiciousnesses = new ArrayList<>();
-
-    for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
-      final ProductSourcePath path = ast.getSourcePath();
-      final int lastLineNumber = ast.getNumberOfLines();
-      final ASTLocations astLocations = ast.createLocations();
-
-      for (int line = 1; line <= lastLineNumber; line++) {
-        final List<ASTLocation> locations = astLocations.infer(line);
-        if (!locations.isEmpty()) {
-          final ASTLocation l = locations.get(locations.size() - 1);
-          final long ef = testResults.getNumberOfFailedTestsExecutingTheStatement(path, l);
-          final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
-          final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
-          final long np = testResults.getNumberOfPassedTestsNotExecutingTheStatement(path, l);
-          final double value = (ef / (double)(ef + nf)) / (ef / (double)(ef + nf) + ep / (double)(ep + np));
-          if (0d < value) {
-            final Suspiciousness s = new Suspiciousness(l, value);
-            suspiciousnesses.add(s);
-          }
-        }
-      }
-    }
-
-    return suspiciousnesses;
+  @Override
+  protected boolean isSkippablePassedTests() {
+    return true;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Zoltar.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Zoltar.java
@@ -7,12 +7,8 @@ package jp.kusumotolab.kgenprog.fl;
 public class Zoltar extends SpectrumBasedFaultLocalization {
 
   @Override
-  protected double formula(double ef, double nf, double ep, double np) {
+  protected double formula(final double ef, final double nf, final double ep, final double np) {
     return ef / (ef + nf + ep + 10000d * nf * ep / ef);
   }
 
-  @Override
-  protected boolean isSkippablePassedTests() {
-    return true;
-  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/fl/Zoltar.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/fl/Zoltar.java
@@ -1,57 +1,18 @@
 package jp.kusumotolab.kgenprog.fl;
 
-import java.util.ArrayList;
-import java.util.List;
-import jp.kusumotolab.kgenprog.project.ASTLocation;
-import jp.kusumotolab.kgenprog.project.ASTLocations;
-import jp.kusumotolab.kgenprog.project.GeneratedAST;
-import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
-import jp.kusumotolab.kgenprog.project.ProductSourcePath;
-import jp.kusumotolab.kgenprog.project.test.TestResults;
-
 /**
- *  FL戦略の一つ(Zoltar).
- *  <br>
- *  {@code value = ef / (ef + nf + ep + 10000 * nf * ep / ef)}<br>
- *  {@code ef}:該当する文を実行し，通過しなかったテストの個数<br>
- *  {@code nf}:該当する文を実行せずに，通過しなかったテストの個数<br>
- *  {@code ep}:該当する文を実行し，通過したテストの個数
+ * FL戦略の一つ(Zoltar). <br>
+ * {@code value = ef / (ef + nf + ep + 10000 * nf * ep / ef)}
  */
-public class Zoltar implements FaultLocalization {
+public class Zoltar extends SpectrumBasedFaultLocalization {
 
-  /**
-   * 疑惑値を計算する.
-   * @param generatedSourceCode 自動バグ限局の対象ソースコード
-   * @param testResults テストの実行結果
-   * @return suspiciousnesses 疑惑値
-   */
   @Override
-  public List<Suspiciousness> exec(final GeneratedSourceCode generatedSourceCode,
-      final TestResults testResults) {
+  protected double formula(double ef, double nf, double ep, double np) {
+    return ef / (ef + nf + ep + 10000d * nf * ep / ef);
+  }
 
-    final List<Suspiciousness> suspiciousnesses = new ArrayList<>();
-
-    for (final GeneratedAST<ProductSourcePath> ast : generatedSourceCode.getProductAsts()) {
-      final ProductSourcePath path = ast.getSourcePath();
-      final int lastLineNumber = ast.getNumberOfLines();
-      final ASTLocations astLocations = ast.createLocations();
-
-      for (int line = 1; line <= lastLineNumber; line++) {
-        final List<ASTLocation> locations = astLocations.infer(line);
-        if (!locations.isEmpty()) {
-          final ASTLocation l = locations.get(locations.size() - 1);
-          final long ef = testResults.getNumberOfFailedTestsExecutingTheStatement(path, l);
-          final long nf = testResults.getNumberOfFailedTestsNotExecutingTheStatement(path, l);
-          final long ep = testResults.getNumberOfPassedTestsExecutingTheStatement(path, l);
-          final double value = ef / (ef + nf + ep + 10000d * nf * ep / ef);
-          if (0d < value) {
-            final Suspiciousness s = new Suspiciousness(l, value);
-            suspiciousnesses.add(s);
-          }
-        }
-      }
-    }
-
-    return suspiciousnesses;
+  @Override
+  protected boolean isSkippablePassedTests() {
+    return true;
   }
 }


### PR DESCRIPTION
resolve #657 

### やったこと
- FL周りをリファクタリング．
  - Spectrum-Based FL固有の処理を共通化し，抽象化された数式のみを実装する形に変更．
- 簡単な高速化の工夫も追加．