### PR TITLE
JDK9以上の環境で実行できるように

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   #   Execute `gradle test` to run unit tests on the target commit.
   run-unit-tests:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:11-jdk
     working_directory: ~/repo
     environment:
       JVM_OPTS: -Xmx3200m
@@ -58,7 +58,7 @@ jobs:
   #   Execute `gradle assemble` to generate a jar file on the target commit.
   build-artifacts:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:11-jdk
     steps:
       # ===== Initialize the environment
       - checkout

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ apply plugin: 'idea'
 apply plugin: 'jacoco'
 
 // Set compiler version
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+sourceCompatibility = '1.11'
+targetCompatibility = '1.11'
 
 // Set default encoding
 compileJava.options.encoding = 'UTF-8'


### PR DESCRIPTION
resolve #600 #659

### やったこと
- JDK9以上の環境もサポート（JDK8もOK）
  - クラスローダ探索のバグを修正
- `build.gradle` のJDK指定を8→11に変更
- CIのテスト環境も8→11に変更