### PR TITLE
Build Failedを除外するように

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/selection/DefaultVariantSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/selection/DefaultVariantSelection.java
@@ -42,6 +42,7 @@ public class DefaultVariantSelection implements VariantSelection {
     final List<Variant> list = variants.stream()
         .sorted(Comparator.comparing(Variant::getFitness)
             .reversed())
+        .filter(Variant::isBuildSucceeded)
         .limit(maxVariantsPerGeneration)
         .collect(Collectors.toList());
     return list;

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/DefaultVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/DefaultVariantSelectionTest.java
@@ -186,8 +186,7 @@ public class DefaultVariantSelectionTest {
    */
   private Variant createVariant(final Fitness fitness, final int id,
       final TestResults testResults) {
-    final Variant variant = new Variant(id, 0, null, null, testResults, fitness, null, null);
-    return variant;
+    return new Variant(id, 0, null, null, testResults, fitness, null, null);
   }
 
   /**
@@ -201,8 +200,7 @@ public class DefaultVariantSelectionTest {
   private void setupLists(final List<Variant> current, final List<Variant> generated, final int num,
       final Function<Integer, TestResults> testResultsCreator) {
     for (int i = 0; i < num; i++) {
-      final double divider = num;
-      final double value = (1.0d * (i + (i % 2))) / divider;
+      final double value = (1.0d * (i + (i % 2))) / (double) num;
       final SimpleFitness fitness = new SimpleFitness(value);
       current.add(createVariant(fitness, i, testResultsCreator.apply(i)));
       generated.add(createVariant(fitness, i + num, testResultsCreator.apply(i)));


### PR DESCRIPTION
resolve #570 

## 変更点
* DefaultVariantSelection の exec でビルド失敗しているものはフィルタリングで除外するようにした
* 上記に伴い，DefaultVariantSelectionTest にテストを追加
* 上記に伴い，同クラスの既存のテストの書き方を変更