### PR TITLE
EmptyBuildResultsとEmptyTestResultsのシングルトンを止めた

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/variant/VariantStore.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/variant/VariantStore.java
@@ -200,7 +200,7 @@ public class VariantStore {
 
     final Single<TestResults> resultsSingle =
         sourceCode.shouldBeTested() ? strategies.execAsyncTestExecutor(variantSingle)
-            .cache() : Single.just(EmptyTestResults.instance);
+            .cache() : Single.just(new EmptyTestResults());
     variant.setTestResultsSingle(resultsSingle);
 
     final Single<Fitness> fitnessSingle = Single

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/variant/VariantStore.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/variant/VariantStore.java
@@ -200,7 +200,7 @@ public class VariantStore {
 
     final Single<TestResults> resultsSingle =
         sourceCode.shouldBeTested() ? strategies.execAsyncTestExecutor(variantSingle)
-            .cache() : Single.just(new EmptyTestResults());
+            .cache() : Single.just(new EmptyTestResults("build failed or reproduced."));
     variant.setTestResultsSingle(resultsSingle);
 
     final Single<Fitness> fitnessSingle = Single

--- a/src/main/java/jp/kusumotolab/kgenprog/project/build/EmptyBuildResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/build/EmptyBuildResults.java
@@ -9,12 +9,7 @@ package jp.kusumotolab.kgenprog.project.build;
  */
 public class EmptyBuildResults extends BuildResults {
 
-  /**
-   * シングルトン
-   */
-  public static final EmptyBuildResults instance = new EmptyBuildResults();
-
-  private EmptyBuildResults() {
+  public EmptyBuildResults() {
     super(null, null, null, true);
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/build/EmptyBuildResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/build/EmptyBuildResults.java
@@ -1,5 +1,8 @@
 package jp.kusumotolab.kgenprog.project.build;
 
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaFileObject;
+
 /**
  * ビルド失敗時を表すBuildResultsオブジェクト．<br>
  * いわゆるNullオブジェクト．
@@ -9,8 +12,13 @@ package jp.kusumotolab.kgenprog.project.build;
  */
 public class EmptyBuildResults extends BuildResults {
 
+  @Deprecated
   public EmptyBuildResults() {
     super(null, null, null, true);
   }
 
+  public EmptyBuildResults(final DiagnosticCollector<JavaFileObject> diagnostics,
+      final String buildProgressText) {
+    super(null, diagnostics, buildProgressText, true);
+  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/build/ProjectBuilder.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/build/ProjectBuilder.java
@@ -80,7 +80,8 @@ public class ProjectBuilder {
       final boolean successs = build(allAsts, javaSourceObjects, diagnostics, progress);
 
       if (!successs) {
-        return EmptyBuildResults.instance;
+        final EmptyBuildResults buildResults = new EmptyBuildResults();
+        return buildResults;
       }
     }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/build/ProjectBuilder.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/build/ProjectBuilder.java
@@ -80,8 +80,7 @@ public class ProjectBuilder {
       final boolean successs = build(allAsts, javaSourceObjects, diagnostics, progress);
 
       if (!successs) {
-        final EmptyBuildResults buildResults = new EmptyBuildResults();
-        return buildResults;
+        return new EmptyBuildResults(diagnostics, progress.toString());
       }
     }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/EmptyTestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/EmptyTestResults.java
@@ -12,15 +12,15 @@ import jp.kusumotolab.kgenprog.project.ProductSourcePath;
  */
 public class EmptyTestResults extends TestResults {
 
-  final private String reason;
+  final private String cause;
 
   @Deprecated
   public EmptyTestResults() {
     this("");
   }
 
-  public EmptyTestResults(final String reason) {
-    this.reason = reason;
+  public EmptyTestResults(final String cause) {
+    this.cause = cause;
   }
 
   /**
@@ -77,7 +77,7 @@ public class EmptyTestResults extends TestResults {
    * 
    * @return テスト結果が得られなかった理由
    */
-  public String getReason() {
-    return reason;
+  public String getCause() {
+    return cause;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/EmptyTestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/EmptyTestResults.java
@@ -12,7 +12,16 @@ import jp.kusumotolab.kgenprog.project.ProductSourcePath;
  */
 public class EmptyTestResults extends TestResults {
 
-  public EmptyTestResults() {}
+  final private String reason;
+
+  @Deprecated
+  public EmptyTestResults() {
+    this("");
+  }
+
+  public EmptyTestResults(final String reason) {
+    this.reason = reason;
+  }
 
   /**
    * {@inheritDoc}<br>
@@ -63,4 +72,12 @@ public class EmptyTestResults extends TestResults {
     return 0;
   }
 
+  /**
+   * テスト結果が得られなかった理由を返す．
+   * 
+   * @return テスト結果が得られなかった理由
+   */
+  public String getReason() {
+    return reason;
+  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/EmptyTestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/EmptyTestResults.java
@@ -12,12 +12,7 @@ import jp.kusumotolab.kgenprog.project.ProductSourcePath;
  */
 public class EmptyTestResults extends TestResults {
 
-  /**
-   * singleton
-   */
-  public static final EmptyTestResults instance = new EmptyTestResults();
-
-  private EmptyTestResults() {}
+  public EmptyTestResults() {}
 
   /**
    * {@inheritDoc}<br>

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutor.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutor.java
@@ -38,7 +38,7 @@ public class LocalTestExecutor implements TestExecutor {
   public TestResults exec(final Variant variant) {
     final GeneratedSourceCode generatedSourceCode = variant.getGeneratedSourceCode();
     if (!generatedSourceCode.isGenerationSuccess()) {
-      final EmptyTestResults testResults = new EmptyTestResults();
+      final EmptyTestResults testResults = new EmptyTestResults("build failed.");
       return testResults;
     }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutor.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutor.java
@@ -38,7 +38,8 @@ public class LocalTestExecutor implements TestExecutor {
   public TestResults exec(final Variant variant) {
     final GeneratedSourceCode generatedSourceCode = variant.getGeneratedSourceCode();
     if (!generatedSourceCode.isGenerationSuccess()) {
-      return EmptyTestResults.instance;
+      final EmptyTestResults testResults = new EmptyTestResults();
+      return testResults;
     }
 
     final BuildResults buildResults = projectBuilder.build(generatedSourceCode);

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
@@ -103,7 +103,7 @@ class TestThread extends Thread {
   public void run() {
     // ビルド失敗時は即座に諦める
     if (buildResults.isBuildFailed) {
-      testResults = EmptyTestResults.instance;
+      testResults = new EmptyTestResults();
       return;
     }
 
@@ -137,7 +137,7 @@ class TestThread extends Thread {
 
     } catch (final ClassNotFoundException e) {
       // クラスロードに失敗．FQNの指定ミスの可能性が大
-      testResults = EmptyTestResults.instance;
+      testResults = new EmptyTestResults();
       return;
     } catch (Exception e) {
       // TODO

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
@@ -103,7 +103,7 @@ class TestThread extends Thread {
   public void run() {
     // ビルド失敗時は即座に諦める
     if (buildResults.isBuildFailed) {
-      testResults = new EmptyTestResults();
+      testResults = new EmptyTestResults("build failed.");
       return;
     }
 
@@ -137,7 +137,7 @@ class TestThread extends Thread {
 
     } catch (final ClassNotFoundException e) {
       // クラスロードに失敗．FQNの指定ミスの可能性が大
-      testResults = new EmptyTestResults();
+      testResults = new EmptyTestResults("failed to load classes.");
       return;
     } catch (Exception e) {
       // TODO

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/DefaultVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/DefaultVariantSelectionTest.java
@@ -156,7 +156,7 @@ public class DefaultVariantSelectionTest {
 
     // 2個に1個はbuildFailedの個体にする
     setupLists(current, generated, 10,
-        e -> e % 2 == 0 ? new EmptyTestResults() : new TestResults());
+        e -> e % 2 == 0 ? new EmptyTestResults("build failed.") : new TestResults());
 
     final List<Variant> selectedVariants = variantSelection.exec(current, generated);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/DefaultVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/DefaultVariantSelectionTest.java
@@ -156,7 +156,7 @@ public class DefaultVariantSelectionTest {
 
     // 2個に1個はbuildFailedの個体にする
     setupLists(current, generated, 10,
-        e -> e % 2 == 0 ? EmptyTestResults.instance : new TestResults());
+        e -> e % 2 == 0 ? new EmptyTestResults() : new TestResults());
 
     final List<Variant> selectedVariants = variantSelection.exec(current, generated);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/variant/VariantStoreTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/variant/VariantStoreTest.java
@@ -164,13 +164,12 @@ public class VariantStoreTest {
     final TestResults testExecutorResult = mock(TestResults.class);
     final Strategies strategies = mock(Strategies.class);
     when(strategies.execFaultLocalization(any(), any())).thenReturn(new ArrayList<>());
-    when(strategies.execSourceCodeGeneration(any(), any())).thenReturn(
-        new GeneratedSourceCode(Collections.emptyList(), Collections.emptyList()));
+    when(strategies.execSourceCodeGeneration(any(), any()))
+        .thenReturn(new GeneratedSourceCode(Collections.emptyList(), Collections.emptyList()));
     when(strategies.execTestExecutor(any())).thenReturn(testExecutorResult);
-    when(strategies.execSourceCodeValidation(any())).thenReturn(
-        new SimpleFitness(Double.NaN));
-    when(strategies.execASTConstruction(any())).thenReturn(
-        new GeneratedSourceCode(Collections.emptyList(), Collections.emptyList()));
+    when(strategies.execSourceCodeValidation(any())).thenReturn(new SimpleFitness(Double.NaN));
+    when(strategies.execASTConstruction(any()))
+        .thenReturn(new GeneratedSourceCode(Collections.emptyList(), Collections.emptyList()));
     when(strategies.execVariantSelection(any(), any())).thenReturn(Collections.emptyList());
     when(strategies.execAsyncTestExecutor(any())).thenReturn(Single.just(testExecutorResult));
 
@@ -210,7 +209,7 @@ public class VariantStoreTest {
     when(strategies.execASTConstruction(any()))
         .then(v -> jdtastConstruction.constructAST(config.getTargetProject()));
     when(strategies.execVariantSelection(any(), any())).then(v -> v.getArgument(1));
-    when(strategies.execTestExecutor(any())).then(v -> EmptyTestResults.instance);
+    when(strategies.execTestExecutor(any())).then(v -> new EmptyTestResults());
     when(strategies.execSourceCodeValidation(any())).then(v -> new SimpleFitness(1.0d));
     when(strategies.execFaultLocalization(any(), any())).then(v -> Collections.emptyList());
     when(strategies.execAsyncTestExecutor(any())).then(v -> {

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/variant/VariantStoreTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/variant/VariantStoreTest.java
@@ -209,7 +209,7 @@ public class VariantStoreTest {
     when(strategies.execASTConstruction(any()))
         .then(v -> jdtastConstruction.constructAST(config.getTargetProject()));
     when(strategies.execVariantSelection(any(), any())).then(v -> v.getArgument(1));
-    when(strategies.execTestExecutor(any())).then(v -> new EmptyTestResults());
+    when(strategies.execTestExecutor(any())).then(v -> new EmptyTestResults("for testing."));
     when(strategies.execSourceCodeValidation(any())).then(v -> new SimpleFitness(1.0d));
     when(strategies.execFaultLocalization(any(), any())).then(v -> Collections.emptyList());
     when(strategies.execAsyncTestExecutor(any())).then(v -> {

--- a/src/test/java/jp/kusumotolab/kgenprog/output/CrossoverHistoricalElementSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/CrossoverHistoricalElementSerializerTest.java
@@ -44,19 +44,17 @@ public class CrossoverHistoricalElementSerializerTest {
         .create();
   }
 
-  private Variant createVariant(final Fitness fitness,
-      final TargetProject targetProject) {
+  private Variant createVariant(final Fitness fitness, final TargetProject targetProject) {
 
     return new Variant(0, 0, new Gene(Collections.emptyList()),
-        astConstruction.constructAST(targetProject),
-        EmptyTestResults.instance, fitness, Collections.emptyList(),
-        new OriginalHistoricalElement());
+        astConstruction.constructAST(targetProject), new EmptyTestResults(), fitness,
+        Collections.emptyList(), new OriginalHistoricalElement());
   }
 
   private Variant createVariant(final long id, final int generationNumber, final Fitness fitness,
       final GeneratedSourceCode code, final HistoricalElement historicalElement) {
     return new Variant(id, generationNumber, new Gene(Collections.emptyList()), code,
-        EmptyTestResults.instance, fitness, Collections.emptyList(), historicalElement);
+        new EmptyTestResults(), fitness, Collections.emptyList(), historicalElement);
   }
 
 
@@ -74,13 +72,13 @@ public class CrossoverHistoricalElementSerializerTest {
 
     // 親1
     final Variant parentA = createVariant(1L, 1, new SimpleFitness(0.0d),
-        new GenerationFailedSourceCode(""),
-        new MutationHistoricalElement(initialVariant, new Base(null, new InsertAfterOperation(null))));
+        new GenerationFailedSourceCode(""), new MutationHistoricalElement(initialVariant,
+            new Base(null, new InsertAfterOperation(null))));
 
     // 親2
     final Variant parentB = createVariant(2L, 1, new SimpleFitness(0.0d),
-        new GenerationFailedSourceCode(""),
-        new MutationHistoricalElement(initialVariant, new Base(null, new InsertAfterOperation(null))));
+        new GenerationFailedSourceCode(""), new MutationHistoricalElement(initialVariant,
+            new Base(null, new InsertAfterOperation(null))));
 
     // 子供
     final HistoricalElement historicalElement = new CrossoverHistoricalElement(parentA, parentB, 1);
@@ -96,17 +94,17 @@ public class CrossoverHistoricalElementSerializerTest {
         JsonKeyAlias.CrossoverHistoricalElement.CROSSOVER_POINT);
 
     // 親IDのチェック
-    final JsonArray serializedParentIds = serializedHistoricalElement.get(
-        JsonKeyAlias.CrossoverHistoricalElement.PARENT_IDS)
-        .getAsJsonArray();
+    final JsonArray serializedParentIds =
+        serializedHistoricalElement.get(JsonKeyAlias.CrossoverHistoricalElement.PARENT_IDS)
+            .getAsJsonArray();
     final String[] parentIds = gson.fromJson(serializedParentIds, String[].class);
     assertThat(parentIds).hasSize(2);
     assertThat(parentIds).containsOnly(String.valueOf(1L), String.valueOf(2L));
 
     // 操作名のチェック
-    final String operationName = serializedHistoricalElement.get(
-        JsonKeyAlias.CrossoverHistoricalElement.NAME)
-        .getAsString();
+    final String operationName =
+        serializedHistoricalElement.get(JsonKeyAlias.CrossoverHistoricalElement.NAME)
+            .getAsString();
     assertThat(operationName).isEqualTo("crossover");
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/output/CrossoverHistoricalElementSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/CrossoverHistoricalElementSerializerTest.java
@@ -47,14 +47,14 @@ public class CrossoverHistoricalElementSerializerTest {
   private Variant createVariant(final Fitness fitness, final TargetProject targetProject) {
 
     return new Variant(0, 0, new Gene(Collections.emptyList()),
-        astConstruction.constructAST(targetProject), new EmptyTestResults(), fitness,
+        astConstruction.constructAST(targetProject), new EmptyTestResults("for testing."), fitness,
         Collections.emptyList(), new OriginalHistoricalElement());
   }
 
   private Variant createVariant(final long id, final int generationNumber, final Fitness fitness,
       final GeneratedSourceCode code, final HistoricalElement historicalElement) {
     return new Variant(id, generationNumber, new Gene(Collections.emptyList()), code,
-        new EmptyTestResults(), fitness, Collections.emptyList(), historicalElement);
+        new EmptyTestResults("for testing."), fitness, Collections.emptyList(), historicalElement);
   }
 
 

--- a/src/test/java/jp/kusumotolab/kgenprog/output/ExporterTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/ExporterTest.java
@@ -74,7 +74,7 @@ public class ExporterTest {
 
     final DeleteOperation operation = new DeleteOperation();
     final GeneratedSourceCode code = operation.apply(originalSourceCode, location);
-    final TestResults testResults = EmptyTestResults.instance;
+    final TestResults testResults = new EmptyTestResults();
     final Base base = new Base(location, operation);
     final Gene gene = new Gene(Collections.singletonList(base));
     final Fitness fitness = new SimpleFitness(1.0d);
@@ -88,8 +88,7 @@ public class ExporterTest {
     final List<Path> productPaths = Collections.singletonList(rootPath.resolve(PRODUCT_NAME));
     final List<Path> testPaths = Collections.singletonList(rootPath.resolve(TEST_NAME));
 
-    return new Configuration.Builder(rootPath, productPaths, testPaths)
-        .setOutDir(outDir)
+    return new Configuration.Builder(rootPath, productPaths, testPaths).setOutDir(outDir)
         .setIsForce(isForce)
         .setTestTimeLimitSeconds(1)
         .setMaxGeneration(1)
@@ -100,8 +99,12 @@ public class ExporterTest {
   /**
    * 以下の条件下でパッチとJSONを出力するか確認する
    * <li>
-   * <ul>forceオプションが有効</ul>
-   * <ul>outDirが空でないディレクトリ</ul>
+   * <ul>
+   * forceオプションが有効
+   * </ul>
+   * <ul>
+   * outDirが空でないディレクトリ
+   * </ul>
    * </li>
    */
   @Test
@@ -150,8 +153,12 @@ public class ExporterTest {
   /**
    * 以下の条件下でパッチとJSONを出力するか確認する
    * <li>
-   * <ul>forceオプションが有効</ul>
-   * <ul>outDirが空のディレクトリ</ul>
+   * <ul>
+   * forceオプションが有効
+   * </ul>
+   * <ul>
+   * outDirが空のディレクトリ
+   * </ul>
    * </li>
    */
   @Test
@@ -190,8 +197,12 @@ public class ExporterTest {
   /**
    * 以下の条件下でパッチとJSONを出力するか確認する
    * <li>
-   * <ul>forceオプションが無効</ul>
-   * <ul>outDirが空でないディレクトリ</ul>
+   * <ul>
+   * forceオプションが無効
+   * </ul>
+   * <ul>
+   * outDirが空でないディレクトリ
+   * </ul>
    * </li>
    */
   @Test
@@ -241,8 +252,12 @@ public class ExporterTest {
   /**
    * 以下の条件下でパッチとJSONを出力するか確認する
    * <li>
-   * <ul>forceオプションが無効</ul>
-   * <ul>outDirが空のディレクトリ</ul>
+   * <ul>
+   * forceオプションが無効
+   * </ul>
+   * <ul>
+   * outDirが空のディレクトリ
+   * </ul>
    * </li>
    */
   @Test
@@ -280,8 +295,12 @@ public class ExporterTest {
   /**
    * 以下の条件下でパッチとJSONを出力するか確認する
    * <li>
-   * <ul>forceオプションが有効</ul>
-   * <ul>outDirが存在しない</ul>
+   * <ul>
+   * forceオプションが有効
+   * </ul>
+   * <ul>
+   * outDirが存在しない
+   * </ul>
    * </li>
    */
   @Test
@@ -317,8 +336,12 @@ public class ExporterTest {
   /**
    * 以下の条件下でパッチとJSONを出力するか確認する
    * <li>
-   * <ul>forceオプションが無効</ul>
-   * <ul>outDirが存在しない</ul>
+   * <ul>
+   * forceオプションが無効
+   * </ul>
+   * <ul>
+   * outDirが存在しない
+   * </ul>
    * </li>
    */
   @Test

--- a/src/test/java/jp/kusumotolab/kgenprog/output/ExporterTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/ExporterTest.java
@@ -74,7 +74,7 @@ public class ExporterTest {
 
     final DeleteOperation operation = new DeleteOperation();
     final GeneratedSourceCode code = operation.apply(originalSourceCode, location);
-    final TestResults testResults = new EmptyTestResults();
+    final TestResults testResults = new EmptyTestResults("for testing.");
     final Base base = new Base(location, operation);
     final Gene gene = new Gene(Collections.singletonList(base));
     final Fitness fitness = new SimpleFitness(1.0d);

--- a/src/test/java/jp/kusumotolab/kgenprog/output/MutationHistoricalElementSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/MutationHistoricalElementSerializerTest.java
@@ -74,7 +74,7 @@ public class MutationHistoricalElementSerializerTest {
   private Variant createVariant(final Fitness fitness, final TargetProject targetProject) {
 
     return new Variant(0, 0, new Gene(Collections.emptyList()),
-        astConstruction.constructAST(targetProject), new EmptyTestResults(), fitness,
+        astConstruction.constructAST(targetProject), new EmptyTestResults("for testing."), fitness,
         Collections.emptyList(), new OriginalHistoricalElement());
   }
 

--- a/src/test/java/jp/kusumotolab/kgenprog/output/MutationHistoricalElementSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/MutationHistoricalElementSerializerTest.java
@@ -28,9 +28,9 @@ import jp.kusumotolab.kgenprog.project.Operation;
 import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
-import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.DeleteOperation;
 import jp.kusumotolab.kgenprog.project.jdt.GeneratedJDTAST;
+import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.JDTASTConstruction;
 import jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation;
 import jp.kusumotolab.kgenprog.project.test.EmptyTestResults;
@@ -74,9 +74,8 @@ public class MutationHistoricalElementSerializerTest {
   private Variant createVariant(final Fitness fitness, final TargetProject targetProject) {
 
     return new Variant(0, 0, new Gene(Collections.emptyList()),
-        astConstruction.constructAST(targetProject),
-        EmptyTestResults.instance, fitness, Collections.emptyList(),
-        new OriginalHistoricalElement());
+        astConstruction.constructAST(targetProject), new EmptyTestResults(), fitness,
+        Collections.emptyList(), new OriginalHistoricalElement());
   }
 
   /**
@@ -96,8 +95,8 @@ public class MutationHistoricalElementSerializerTest {
     final Operation operation = new InsertAfterOperation(createASTNode(project));
     final ASTLocation targetLocation = mockASTLocation(project);
     final Base appendBase = new Base(targetLocation, operation);
-    final HistoricalElement historicalElement = new MutationHistoricalElement(initialVariant,
-        appendBase);
+    final HistoricalElement historicalElement =
+        new MutationHistoricalElement(initialVariant, appendBase);
 
     final JsonObject serializedHistoricalElement = gson.toJsonTree(historicalElement)
         .getAsJsonObject();
@@ -110,17 +109,17 @@ public class MutationHistoricalElementSerializerTest {
         JsonKeyAlias.MutationHistoricalElement.APPEND_BASE);
 
     // 親IDのチェック
-    final JsonArray serializedParentIds = serializedHistoricalElement.get(
-        JsonKeyAlias.MutationHistoricalElement.PARENT_IDS)
-        .getAsJsonArray();
+    final JsonArray serializedParentIds =
+        serializedHistoricalElement.get(JsonKeyAlias.MutationHistoricalElement.PARENT_IDS)
+            .getAsJsonArray();
     assertThat(serializedParentIds).hasSize(1);
     assertThat(serializedParentIds.get(0)
         .getAsString()).isEqualTo(String.valueOf(0L));
 
     // 操作名のチェック
-    final String operationName = serializedHistoricalElement.get(
-        JsonKeyAlias.MutationHistoricalElement.NAME)
-        .getAsString();
+    final String operationName =
+        serializedHistoricalElement.get(JsonKeyAlias.MutationHistoricalElement.NAME)
+            .getAsString();
     assertThat(operationName).isEqualTo("insert_after");
   }
 
@@ -140,8 +139,8 @@ public class MutationHistoricalElementSerializerTest {
     final Operation operation = new DeleteOperation();
     final ASTLocation targetLocation = mockASTLocation(project);
     final Base appendBase = new Base(targetLocation, operation);
-    final HistoricalElement historicalElement = new MutationHistoricalElement(initialVariant,
-        appendBase);
+    final HistoricalElement historicalElement =
+        new MutationHistoricalElement(initialVariant, appendBase);
 
     final JsonObject serializedHistoricalElement = gson.toJsonTree(historicalElement)
         .getAsJsonObject();
@@ -154,17 +153,17 @@ public class MutationHistoricalElementSerializerTest {
         JsonKeyAlias.MutationHistoricalElement.APPEND_BASE);
 
     // 親IDのチェック
-    final JsonArray serializedParentIds = serializedHistoricalElement.get(
-        JsonKeyAlias.MutationHistoricalElement.PARENT_IDS)
-        .getAsJsonArray();
+    final JsonArray serializedParentIds =
+        serializedHistoricalElement.get(JsonKeyAlias.MutationHistoricalElement.PARENT_IDS)
+            .getAsJsonArray();
     assertThat(serializedParentIds).hasSize(1);
     assertThat(serializedParentIds.get(0)
         .getAsString()).isEqualTo(String.valueOf(0L));
 
     // 操作名のチェック
-    final String operationName = serializedHistoricalElement.get(
-        JsonKeyAlias.MutationHistoricalElement.NAME)
-        .getAsString();
+    final String operationName =
+        serializedHistoricalElement.get(JsonKeyAlias.MutationHistoricalElement.NAME)
+            .getAsString();
     assertThat(operationName).isEqualTo("delete");
   }
 
@@ -186,8 +185,8 @@ public class MutationHistoricalElementSerializerTest {
     final ASTLocation targetLocation = mockASTLocation(project);
     final Base appendBase = new Base(targetLocation, operation);
 
-    final HistoricalElement historicalElement = new MutationHistoricalElement(initialVariant,
-        appendBase);
+    final HistoricalElement historicalElement =
+        new MutationHistoricalElement(initialVariant, appendBase);
 
     final JsonObject serializedHistoricalElement = gson.toJsonTree(historicalElement)
         .getAsJsonObject();
@@ -200,17 +199,17 @@ public class MutationHistoricalElementSerializerTest {
         JsonKeyAlias.MutationHistoricalElement.APPEND_BASE);
 
     // 親IDのチェック
-    final JsonArray serializedParentIds = serializedHistoricalElement.get(
-        JsonKeyAlias.MutationHistoricalElement.PARENT_IDS)
-        .getAsJsonArray();
+    final JsonArray serializedParentIds =
+        serializedHistoricalElement.get(JsonKeyAlias.MutationHistoricalElement.PARENT_IDS)
+            .getAsJsonArray();
     assertThat(serializedParentIds).hasSize(1);
     assertThat(serializedParentIds.get(0)
         .getAsString()).isEqualTo(String.valueOf(0L));
 
     // 操作名のチェック
-    final String operationName = serializedHistoricalElement.get(
-        JsonKeyAlias.MutationHistoricalElement.NAME)
-        .getAsString();
+    final String operationName =
+        serializedHistoricalElement.get(JsonKeyAlias.MutationHistoricalElement.NAME)
+            .getAsString();
     assertThat(operationName).isEqualTo("replace");
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/output/PatchSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/PatchSerializerTest.java
@@ -28,8 +28,8 @@ import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
 import jp.kusumotolab.kgenprog.project.factory.TargetProjectFactory;
-import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.GeneratedJDTAST;
+import jp.kusumotolab.kgenprog.project.jdt.InsertAfterOperation;
 import jp.kusumotolab.kgenprog.project.jdt.JDTASTConstruction;
 import jp.kusumotolab.kgenprog.project.jdt.JDTASTLocation;
 import jp.kusumotolab.kgenprog.project.test.EmptyTestResults;
@@ -52,14 +52,14 @@ public class PatchSerializerTest {
   private Variant createVariant(final Fitness fitness, final TargetProject targetProject) {
 
     return new Variant(0, 0, new Gene(Collections.emptyList()),
-        astConstruction.constructAST(targetProject), EmptyTestResults.instance, fitness,
+        astConstruction.constructAST(targetProject), new EmptyTestResults(), fitness,
         Collections.emptyList(), new OriginalHistoricalElement());
   }
 
   private Variant createVariant(final long id, final int generationNumber, final Fitness fitness,
       final GeneratedSourceCode code, final HistoricalElement historicalElement) {
     return new Variant(id, generationNumber, new Gene(Collections.emptyList()), code,
-        EmptyTestResults.instance, fitness, Collections.emptyList(), historicalElement);
+        new EmptyTestResults(), fitness, Collections.emptyList(), historicalElement);
   }
 
   /**

--- a/src/test/java/jp/kusumotolab/kgenprog/output/PatchSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/PatchSerializerTest.java
@@ -52,14 +52,14 @@ public class PatchSerializerTest {
   private Variant createVariant(final Fitness fitness, final TargetProject targetProject) {
 
     return new Variant(0, 0, new Gene(Collections.emptyList()),
-        astConstruction.constructAST(targetProject), new EmptyTestResults(), fitness,
+        astConstruction.constructAST(targetProject), new EmptyTestResults("for testing."), fitness,
         Collections.emptyList(), new OriginalHistoricalElement());
   }
 
   private Variant createVariant(final long id, final int generationNumber, final Fitness fitness,
       final GeneratedSourceCode code, final HistoricalElement historicalElement) {
     return new Variant(id, generationNumber, new Gene(Collections.emptyList()), code,
-        new EmptyTestResults(), fitness, Collections.emptyList(), historicalElement);
+        new EmptyTestResults("for testing."), fitness, Collections.emptyList(), historicalElement);
   }
 
   /**

--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantSerializerTest.java
@@ -52,7 +52,7 @@ public class VariantSerializerTest {
   private Variant createVariant(final Fitness fitness, final TargetProject targetProject) {
 
     return new Variant(0, 0, new Gene(Collections.emptyList()),
-        astConstruction.constructAST(targetProject), new EmptyTestResults(), fitness,
+        astConstruction.constructAST(targetProject), new EmptyTestResults("for testing."), fitness,
         Collections.emptyList(), new OriginalHistoricalElement());
   }
 

--- a/src/test/java/jp/kusumotolab/kgenprog/output/VariantSerializerTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/VariantSerializerTest.java
@@ -52,7 +52,7 @@ public class VariantSerializerTest {
   private Variant createVariant(final Fitness fitness, final TargetProject targetProject) {
 
     return new Variant(0, 0, new Gene(Collections.emptyList()),
-        astConstruction.constructAST(targetProject), EmptyTestResults.instance, fitness,
+        astConstruction.constructAST(targetProject), new EmptyTestResults(), fitness,
         Collections.emptyList(), new OriginalHistoricalElement());
   }
 

--- a/src/test/java/jp/kusumotolab/kgenprog/project/build/ProjectBuilderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/build/ProjectBuilderTest.java
@@ -42,6 +42,7 @@ public class ProjectBuilderTest {
 
     assertThat(buildResults).isInstanceOf(EmptyBuildResults.class);
     assertThat(buildResults.isBuildFailed).isTrue();
+    assertThat(buildResults.diagnostics.getDiagnostics()).isNotEmpty();
   }
 
   @Test


### PR DESCRIPTION
resolve #284 

やったこと．
- EmptyBuildResultsはビルドがこけた情報を保持するために，diagnosticsとbuildProgressTextに情報を格納するようにした．
- EmptyTestResultsはreasonというフィールドを作り，テスト結果が得られなかった理由をそこに格納するようにした．
