### PR TITLE
CIでのバージョン解決方法を修正

### DIFF
--- a/.circleci/check-version.sh
+++ b/.circleci/check-version.sh
@@ -7,7 +7,7 @@ GITHUB_TAG_URL_BASE="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJ
 
 # Analyze target version to be release
 
-WANTED_VERSION="$(./gradlew -q print printCurrentVersion)"
+WANTED_VERSION="$(cat ./workspace/current-version.txt)"
 WANTED_VERSION="$(echo $WANTED_VERSION)" # Trim whitespaces
 
 VERSION_GIT_TAG="v${WANTED_VERSION}"

--- a/.circleci/check-version.sh
+++ b/.circleci/check-version.sh
@@ -7,7 +7,7 @@ GITHUB_TAG_URL_BASE="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJ
 
 # Analyze target version to be release
 
-WANTED_VERSION="$(cat ./workspace/current-version.txt)"
+WANTED_VERSION="$(cat ./gradle.properties | grep currentVersion | cut -d'=' -f2)"
 WANTED_VERSION="$(echo $WANTED_VERSION)" # Trim whitespaces
 
 VERSION_GIT_TAG="v${WANTED_VERSION}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,12 +73,15 @@ jobs:
           key: v1-dependencies-{{ checksum "build.gradle" }}
       # ===== Assemble jar file
       - run: ./gradlew assemble
+      # ===== Save current version
+      - run: ./gradlew -q printCurrentVersion > current-version.txt
       # ===== Collect and persist the built artifacts
       - run:
           name: Collect artifacts to be released
           command: |
             mkdir -p workspace/artifacts
             cp ./build/libs/* ./workspace/artifacts/
+            cp current-version.txt ./workspace/
       - persist_to_workspace:
           root: ./workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,15 +73,12 @@ jobs:
           key: v1-dependencies-{{ checksum "build.gradle" }}
       # ===== Assemble jar file
       - run: ./gradlew assemble
-      # ===== Save current version
-      - run: ./gradlew -q printCurrentVersion > current-version.txt
       # ===== Collect and persist the built artifacts
       - run:
           name: Collect artifacts to be released
           command: |
             mkdir -p workspace/artifacts
             cp ./build/libs/* ./workspace/artifacts/
-            cp current-version.txt ./workspace/
       - persist_to_workspace:
           root: ./workspace
           paths:


### PR DESCRIPTION
PR #696 #694 によるCI failを修正．

CI failはver解決方法のミスが原因．
ver解決方法は以下3択だがCが一番マシという判断．

### A. CIタスク`build-artifacts`でverを取り出し`generate-change-log`に渡す
#694 以前の状態．
cons: 上記2つのタスク間で強い依存を持ってしまう

### B. `generate-change-log` で `gradlew` する
cons: このタスクのcontainerがnodeなのでjavaがそもそも使えない（#696 でのfailの原因）

### C. `generate-change-log` で `sed` する
```
$ cat gradle.properties | grep currentVersion | cut -d'=' -f2
1.5.4
```
cons: 正規表現
