### PR TITLE
mockバグの修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/SkippingMemoryClassLoader.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/SkippingMemoryClassLoader.java
@@ -64,7 +64,7 @@ public class SkippingMemoryClassLoader extends MemoryClassLoader {
       throws ClassNotFoundException {
 
     // JUnit関係のクラスのみロードを通常の委譲関係に任す．これがないとJUnitが期待通りに動かない．
-    if (name.startsWith("org.junit.") || name.startsWith("junit.")) {
+    if (name.startsWith("org.junit.") || name.startsWith("junit.") || name.startsWith("org.hamcrest.")) {
       return getParent().loadClass(name);
     }
 


### PR DESCRIPTION
resolve #690

### やったこと
SMCL のロードスキップ条件を追加した．それだけ．
```diff
- if (name.startsWith("org.junit.") || name.startsWith("junit.")) {
+ if (name.startsWith("org.junit.") || name.startsWith("junit.") || name.startsWith("org.hamcrest.")) {
```
実はクラスロードに失敗していただけで，mock処理は普通に動くっぽい．

mockライブラリはクラスローダ上の（＝メモリ上の）クラスをランタイムで書き換えるらしい．
なので，kgpとの相性問題はそもそも発生しない．
https://stackoverflow.com/questions/2993464/how-do-java-mocking-frameworks-work

### やってないこと
真面目なテスト．手元では動作確認しているが，テスト化されていない．
テスト作成は別ISSUEを切る予定．