### PR TITLE
多重起動の問題を解決

### DIFF
--- a/example/BuildSuccess18/src/example/FooTest.java
+++ b/example/BuildSuccess18/src/example/FooTest.java
@@ -13,10 +13,8 @@ public class FooTest {
 
   @Test
   public void test01() throws IOException {
-
-    // working-dirからの相対パスでPathを取り出す．
-    // KGPテスト実行時に別プロセス切り出しが難しいので，擬似的に題材ルートからの相対パスを用いる．
-    final Path path = Paths.get(System.getProperty("user.dir"), "tmp/out.txt");
+    // 一時ファイルへの書き込みをテストする
+    final Path path = Files.createTempFile("kgp-", Long.toString(System.nanoTime()));
 
     final List<String> contents = Arrays.asList(Double.toString(Math.random()));
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/factory/JUnitLibraryResolver.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/factory/JUnitLibraryResolver.java
@@ -3,7 +3,6 @@ package jp.kusumotolab.kgenprog.project.factory;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -21,7 +20,6 @@ public class JUnitLibraryResolver {
   private static final String JUNIT4_DIR = "junit4/";
   private static final String JUNIT3_JUNIT = "junit-3.8.2.jar";
   private static final String JUNIT4_JUNIT = "junit-4.12-kgp-custom.jar";
-  private static final String SYSTEM_TEMP_DIR = System.getProperty("java.io.tmpdir");
 
   public final static EnumMap<JUnitVersion, List<ClassPath>> libraries =
       new EnumMap<>(JUnitVersion.class);
@@ -35,7 +33,7 @@ public class JUnitLibraryResolver {
       final InputStream junit4JInputStream =
           classLoader.getResourceAsStream(JUNIT4_DIR + JUNIT4_JUNIT);
 
-      final Path systemTempPath = Paths.get(SYSTEM_TEMP_DIR);
+      final Path systemTempPath = Files.createTempDirectory("kgp-");
       final Path junit3JPath = systemTempPath.resolve(JUNIT3_JUNIT);
       final Path junit4JPath = systemTempPath.resolve(JUNIT4_JUNIT);
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/factory/JUnitLibraryResolver.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/factory/JUnitLibraryResolver.java
@@ -33,22 +33,31 @@ public class JUnitLibraryResolver {
       final InputStream junit4JInputStream =
           classLoader.getResourceAsStream(JUNIT4_DIR + JUNIT4_JUNIT);
 
-      final Path systemTempPath = Files.createTempDirectory("kgp-");
+      final Path systemTempPath = getTempDirectory();
       final Path junit3JPath = systemTempPath.resolve(JUNIT3_JUNIT);
       final Path junit4JPath = systemTempPath.resolve(JUNIT4_JUNIT);
 
       Files.copy(junit3JInputStream, junit3JPath, StandardCopyOption.REPLACE_EXISTING);
       Files.copy(junit4JInputStream, junit4JPath, StandardCopyOption.REPLACE_EXISTING);
 
-      junit3JPath.toFile()
-          .deleteOnExit();
-      junit4JPath.toFile()
-          .deleteOnExit();
-
       libraries.put(JUnitVersion.JUNIT3, Arrays.asList(new ClassPath(junit3JPath)));
       libraries.put(JUnitVersion.JUNIT4, Arrays.asList(new ClassPath(junit4JPath)));
     } catch (Exception e) {
       e.printStackTrace();
     }
+  }
+
+  // TODO 一時dirの責務をひとまずこのクラスに任せたが，巨大になるなら別クラスに切った方がよさそう．
+  private static Path tempDir;
+  public static Path getTempDirectory() {
+    try {
+      if (null == tempDir) {
+        tempDir = Files.createTempDirectory("kgp-");
+        return tempDir;
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return tempDir;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/factory/JUnitLibraryResolver.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/factory/JUnitLibraryResolver.java
@@ -53,7 +53,6 @@ public class JUnitLibraryResolver {
     try {
       if (null == tempDir) {
         tempDir = Files.createTempDirectory("kgp-");
-        return tempDir;
       }
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/test/LocalTestExecutorTest.java
@@ -19,8 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -31,6 +33,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import jp.kusumotolab.kgenprog.Configuration;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.project.ASTLocation;
@@ -477,18 +480,10 @@ public class LocalTestExecutorTest {
     final Variant variant = mock(Variant.class);
     when(variant.getGeneratedSourceCode()).thenReturn(source);
 
-    // 現在のworking-dirを擬似的に対象プロジェクトに移動する．別プロセス切り出しが難しいため
-    final String userDir = System.getProperty("user.dir");
-    System.setProperty("user.dir", rootPath.toAbsolutePath()
-        .toString());
-
     final TestResults result = executor.exec(variant);
 
     // 実行されたテストは1個のはず
     assertThat(result.getExecutedTestFQNs()).containsExactlyInAnyOrder(FOO_TEST01);
-
-    // user.dir を戻しておく（副作用回避）
-    System.setProperty("user.dir", userDir);
 
     // テストは成功するはず
     assertThat(result.getTestResult(FOO_TEST01).failed).isFalse();

--- a/src/test/java/jp/kusumotolab/kgenprog/project/test/MemoryClassLoaderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/test/MemoryClassLoaderTest.java
@@ -217,7 +217,7 @@ public class MemoryClassLoaderTest {
     final Class<?> clazz = loader.loadClass(FOO_TEST);
 
     // BCTestがロードされているはず
-    assertThat(listLoadedClasses(loader)).contains(FOO_TEST.toString());
+    assertThat(listLoadedClasses(loader)).containsOnly(FOO_TEST.toString());
 
     // テストを実行
     // * ここでBCTestのClassLoaderには上記MemoryClassLoaderが紐づく（自身をロードしたローダーが指定される）
@@ -226,7 +226,7 @@ public class MemoryClassLoaderTest {
     junitCore.run(clazz);
 
     // 上記テストの実行により，BCTestに加えBCもロードされているはず
-    assertThat(listLoadedClasses(loader)).contains(FOO_TEST.toString(), FOO.toString());
+    assertThat(listLoadedClasses(loader)).containsOnly(FOO_TEST.toString(), FOO.toString());
   }
 
   @Test(expected = ClassFormatError.class)

--- a/src/test/java/jp/kusumotolab/kgenprog/testutil/ExampleAlias.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/testutil/ExampleAlias.java
@@ -6,6 +6,7 @@ import java.nio.file.Paths;
 import jp.kusumotolab.kgenprog.project.FullyQualifiedName;
 import jp.kusumotolab.kgenprog.project.TargetFullyQualifiedName;
 import jp.kusumotolab.kgenprog.project.TestFullyQualifiedName;
+import jp.kusumotolab.kgenprog.project.factory.JUnitLibraryResolver;
 
 /**
  * example/BuildSuccess01-03に対応するクラス名等のエイリアス． <br>
@@ -79,8 +80,7 @@ public class ExampleAlias {
 
   // ライブラリへのエイリアス
   public final static class Lib {
-
-    private final static Path TEMP = Paths.get(System.getProperty("java.io.tmpdir"));
+    private final static Path TEMP = JUnitLibraryResolver.getTempDirectory();
     public final static Path JUNIT = TEMP.resolve("junit-4.12-kgp-custom.jar");
     public final static Path HAMCREST = TEMP.resolve("hamcrest-core-1.3.jar");
   }


### PR DESCRIPTION
resolve #722

### やったこと
- 多重起動の妨げとなっていた一時 `junit.jar` の扱いを改善．
具体的には，プロセスごとに別一時dirを使うように変更．

ついでに以下の改善．
- テストに含まれる一時ファイルの扱いを改善（LocalTestExecutorTest.java ）
- assertがあまいテストを厳格に（MemoryClassLoaderTest.java）