### PR TITLE
バージョン解決の修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,15 +93,17 @@ jar {
     exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
   }
 
-  // copy gradle.properties to resolve version info
-  copy {
-    from 'gradle.properties'
-    into buildDir.name + '/resources/main/'
+  doFirst {
+    // copy gradle.properties to resolve version info
+    copy {
+      from 'gradle.properties'
+      into buildDir.name + '/resources/main/'
+    }
+    // annotate whether this task was executed on CI or not
+    def isCi = System.getenv('CI') ? 'true' : 'false'
+    File prop = new File(buildDir.name + '/resources/main/gradle.properties')
+    prop.append('ci = ' + isCi + '\n')
   }
-  // annotate whether this task was executed on CI or not
-  def isCi = System.getenv('CI') ? 'true' : 'false'
-  File prop = new File(buildDir.name + '/resources/main/gradle.properties')
-  prop.append('ci = ' + isCi + '\n')
 }
 
 // Define App's version


### PR DESCRIPTION
resolve #727

CIで生成したjarのバージョン解決を修正．
gradleの書式を間違えていたのが原因だと思う．`doFirst` で囲むべきだった．

たぶん直ったけど，masterにmergeする以外に確認方法がないので，やってみるしかない．