### PR TITLE
入力コードがどのテストにどう落ちるか出力する処理を追加

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -19,6 +19,8 @@ import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 import jp.kusumotolab.kgenprog.output.Exporter;
 import jp.kusumotolab.kgenprog.project.jdt.JDTASTConstruction;
 import jp.kusumotolab.kgenprog.project.test.TestExecutor;
+import jp.kusumotolab.kgenprog.project.test.TestResult;
+import jp.kusumotolab.kgenprog.project.test.TestResults;
 
 /**
  * kGenProgのメインクラス．<br>
@@ -90,6 +92,8 @@ public class KGenProgMain {
         sourceCodeGeneration, sourceCodeValidation, testExecutor, variantSelection);
     final VariantStore variantStore = new VariantStore(config, strategies);
     final Variant initialVariant = variantStore.getInitialVariant();
+
+    logInitialFailedTests(initialVariant.getTestResults());
 
     mutation.setCandidates(initialVariant.getGeneratedSourceCode()
         .getProductAsts());
@@ -164,6 +168,26 @@ public class KGenProgMain {
         .append(System.lineSeparator())
         .append(config.toString())
         .append("================================================================");
+    log.info(sb.toString());
+  }
+
+  private void logInitialFailedTests(final TestResults testResults) {
+    final StringBuilder sb = new StringBuilder();
+    final List<TestResult> successedTestResults = testResults.getSuccessedTestResults();
+    final List<TestResult> failedTestResults = testResults.getFailedTestResults();
+    sb//
+        .append("initial failed tests (")
+        .append(failedTestResults.size())
+        .append("/")
+        .append(successedTestResults.size() + failedTestResults.size())
+        .append(")")
+        .append(System.lineSeparator());
+
+    testResults.getFailedTestResults()
+        .forEach(testResult ->
+            sb//
+                .append(testResult.executedTestFQN)
+                .append(System.lineSeparator()));
     log.info(sb.toString());
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -187,6 +187,10 @@ public class KGenProgMain {
         .forEach(testResult ->
             sb//
                 .append(testResult.executedTestFQN)
+                .append(": expected ")
+                .append(testResult.getExpectedValue())
+                .append(", actual ")
+                .append(testResult.getActualValue())
                 .append(System.lineSeparator()));
     log.info(sb.toString());
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -186,18 +186,8 @@ public class KGenProgMain {
     for (TestResult testResult : testResults.getFailedTestResults()) {
       sb//
           .append(testResult.executedTestFQN)
-          .append(": ");
-      if (testResult.getExpectedValue() != null && testResult.getActualValue() != null) {
-        sb//
-            .append("expected ")
-            .append(testResult.getExpectedValue())
-            .append(", actual ")
-            .append(testResult.getActualValue());
-      } else {
-        sb//
-            .append(testResult.failedReason);
-      }
-      sb//
+          .append(": ")
+          .append(testResult.failedReason)
           .append(System.lineSeparator());
     }
     log.info(sb.toString());

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -183,15 +183,23 @@ public class KGenProgMain {
         .append(")")
         .append(System.lineSeparator());
 
-    testResults.getFailedTestResults()
-        .forEach(testResult ->
-            sb//
-                .append(testResult.executedTestFQN)
-                .append(": expected ")
-                .append(testResult.getExpectedValue())
-                .append(", actual ")
-                .append(testResult.getActualValue())
-                .append(System.lineSeparator()));
+    for (TestResult testResult : testResults.getFailedTestResults()) {
+      sb//
+          .append(testResult.executedTestFQN)
+          .append(": ");
+      if (testResult.getExpectedValue() != null && testResult.getActualValue() != null) {
+        sb//
+            .append("expected ")
+            .append(testResult.getExpectedValue())
+            .append(", actual ")
+            .append(testResult.getActualValue());
+      } else {
+        sb//
+            .append(testResult.failedReason);
+      }
+      sb//
+          .append(System.lineSeparator());
+    }
     log.info(sb.toString());
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -187,7 +187,7 @@ public class KGenProgMain {
       sb//
           .append(testResult.executedTestFQN)
           .append(": ")
-          .append(testResult.failedReason)
+          .append(testResult.getFailedReason())
           .append(System.lineSeparator());
     }
     log.info(sb.toString());

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
@@ -2,8 +2,6 @@ package jp.kusumotolab.kgenprog.project.test;
 
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import jp.kusumotolab.kgenprog.project.FullyQualifiedName;

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
@@ -86,4 +86,34 @@ public class TestResult {
     sb.append(indent + "}");
     return sb.toString();
   }
+
+  /**
+   * failedReasonをパースしテストで期待していた値を取得．
+   *
+   * @return
+   */
+  public String getExpectedValue() {
+    Pattern p = Pattern.compile(".*expected:\\<(.*)\\>.*but was:\\<(.*)\\>.*");
+    Matcher m = p.matcher(this.failedReason);
+    if (m.matches()) {
+      return m.group(1);
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * failedReasonをパースし実際に得た値を取得．
+   *
+   * @return
+   */
+  public String getActualValue() {
+    Pattern p = Pattern.compile(".*expected:\\<(.*)\\>.*but was:\\<(.*)\\>.*");
+    Matcher m = p.matcher(this.failedReason);
+    if (m.matches()) {
+      return m.group(2);
+    } else {
+      return null;
+    }
+  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
@@ -86,34 +86,4 @@ public class TestResult {
     sb.append(indent + "}");
     return sb.toString();
   }
-
-  /**
-   * failedReasonをパースしテストで期待していた値を取得．
-   *
-   * @return
-   */
-  public String getExpectedValue() {
-    Pattern p = Pattern.compile(".*expected:\\<(.*)\\>.*but was:\\<(.*)\\>.*");
-    Matcher m = p.matcher(this.failedReason);
-    if (m.matches()) {
-      return m.group(1);
-    } else {
-      return null;
-    }
-  }
-
-  /**
-   * failedReasonをパースし実際に得た値を取得．
-   *
-   * @return
-   */
-  public String getActualValue() {
-    Pattern p = Pattern.compile(".*expected:\\<(.*)\\>.*but was:\\<(.*)\\>.*");
-    Matcher m = p.matcher(this.failedReason);
-    if (m.matches()) {
-      return m.group(2);
-    } else {
-      return null;
-    }
-  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
@@ -2,6 +2,8 @@ package jp.kusumotolab.kgenprog.project.test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import jp.kusumotolab.kgenprog.project.FullyQualifiedName;
@@ -16,6 +18,7 @@ public class TestResult {
 
   final public FullyQualifiedName executedTestFQN;
   final public boolean failed;
+  final public String failedReason;
   final private Map<FullyQualifiedName, Coverage> coverages;
 
   /**
@@ -23,12 +26,14 @@ public class TestResult {
    *
    * @param executedTestFQN 実行したテストメソッドの名前
    * @param failed テストの結果
+   * @param failedReason テストに落ちた場合はその理由
    * @param coverages テスト対象それぞれの行ごとのCoverage計測結果
    */
   public TestResult(final FullyQualifiedName executedTestFQN, final boolean failed,
-      final Map<FullyQualifiedName, Coverage> coverages) {
+      final String failedReason, final Map<FullyQualifiedName, Coverage> coverages) {
     this.executedTestFQN = executedTestFQN;
     this.failed = failed;
+    this.failedReason = failedReason;
     this.coverages = coverages;
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResult.java
@@ -18,7 +18,7 @@ public class TestResult {
 
   final public FullyQualifiedName executedTestFQN;
   final public boolean failed;
-  final public String failedReason;
+  final private String failedReason;
   final private Map<FullyQualifiedName, Coverage> coverages;
 
   /**
@@ -57,6 +57,15 @@ public class TestResult {
    */
   public Coverage getCoverages(final FullyQualifiedName testFQN) {
     return this.coverages.get(testFQN);
+  }
+
+  /**
+   * failedReasonを取得
+   *
+   * @return
+   */
+  public String getFailedReason() {
+    return this.failedReason;
   }
 
   @Override

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
@@ -253,6 +253,7 @@ class TestThread extends Thread {
 
     final private TestResults testResults;
     private boolean wasFailed;
+    private String failedReason;
 
     /**
      * constructor
@@ -268,11 +269,14 @@ class TestThread extends Thread {
     public void testStarted(Description description) {
       jacocoRuntimeData.reset();
       wasFailed = false;
+      failedReason = null;
     }
 
     @Override
     public void testFailure(Failure failure) {
       wasFailed = true;
+      failedReason = failure.getException()
+          .getMessage();
     }
 
     @Override
@@ -349,7 +353,8 @@ class TestThread extends Thread {
           .map(RawCoverage::new)
           .collect(Collectors.toMap(Coverage::getExecutedTargetFQN, Functions.identity()));
 
-      final TestResult testResult = new TestResult(testMethodFQN, wasFailed, coverages);
+      final TestResult testResult = new TestResult(testMethodFQN, wasFailed, failedReason,
+          coverages);
       testResults.add(testResult);
     }
   }


### PR DESCRIPTION
resolve #741 

- `TestResult` にテストの失敗理由を保持する`failedReson`を追加
  - ↑に関連して `TestThread` の処理も追加
- ~~`TestResult` に `failedReason` をパースして expected / actual valueを取得するメソッドを追加~~
→ see https://github.com/kusumotolab/kGenProg/pull/746#issuecomment-645102518
- `kGenProgMain` に `failedReason` を利用して入力コードがどのテストにどう落ちるか出力する処理を追加

