### PR TITLE
Fitnessとその子クラスをリファクタリング

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -280,7 +280,7 @@ public class KGenProgMain {
 
   private double getFitnessSingularValue(final Variant variant) {
     return variant.getFitness()
-        .getSingularValue();
+        .getNormalizedValue();
   }
 
   private void logGAStopped(final OrdinalNumber generation) {

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -280,7 +280,7 @@ public class KGenProgMain {
 
   private double getFitnessValue(final Variant variant) {
     return variant.getFitness()
-        .getValue();
+        .getSingularValue();
   }
 
   private void logGAStopped(final OrdinalNumber generation) {

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -267,7 +267,7 @@ public class KGenProgMain {
   private double getAverage(final List<Variant> variants) {
     return variants.stream()
         .filter(Variant::isBuildSucceeded)
-        .mapToDouble(this::getFitnessValue)
+        .mapToDouble(this::getFitnessSingularValue)
         .average()
         .orElse(Double.NaN);
   }
@@ -275,10 +275,10 @@ public class KGenProgMain {
   private Map<Double, Long> getFrequencies(final List<Variant> variants) {
     return variants.stream()
         .filter(Variant::isBuildSucceeded)
-        .collect(Collectors.groupingBy(this::getFitnessValue, Collectors.counting()));
+        .collect(Collectors.groupingBy(this::getFitnessSingularValue, Collectors.counting()));
   }
 
-  private double getFitnessValue(final Variant variant) {
+  private double getFitnessSingularValue(final Variant variant) {
     return variant.getFitness()
         .getSingularValue();
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -267,7 +267,7 @@ public class KGenProgMain {
   private double getAverage(final List<Variant> variants) {
     return variants.stream()
         .filter(Variant::isBuildSucceeded)
-        .mapToDouble(this::getFitnessSingularValue)
+        .mapToDouble(this::getNormalizedFitnessValue)
         .average()
         .orElse(Double.NaN);
   }
@@ -275,10 +275,10 @@ public class KGenProgMain {
   private Map<Double, Long> getFrequencies(final List<Variant> variants) {
     return variants.stream()
         .filter(Variant::isBuildSucceeded)
-        .collect(Collectors.groupingBy(this::getFitnessSingularValue, Collectors.counting()));
+        .collect(Collectors.groupingBy(this::getNormalizedFitnessValue, Collectors.counting()));
   }
 
-  private double getFitnessSingularValue(final Variant variant) {
+  private double getNormalizedFitnessValue(final Variant variant) {
     return variant.getFitness()
         .getNormalizedValue();
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/Mutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/Mutation.java
@@ -63,7 +63,7 @@ public abstract class Mutation {
 
     final Roulette<Variant> variantRoulette = new Roulette<>(currentVariants, e -> {
       final Fitness fitness = e.getFitness();
-      final double value = fitness.getSingularValue();
+      final double value = fitness.getNormalizedValue();
       return Double.isNaN(value) ? 0 : value;
     }, random);
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/Mutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/Mutation.java
@@ -63,7 +63,7 @@ public abstract class Mutation {
 
     final Roulette<Variant> variantRoulette = new Roulette<>(currentVariants, e -> {
       final Fitness fitness = e.getFitness();
-      final double value = fitness.getValue();
+      final double value = fitness.getSingularValue();
       return Double.isNaN(value) ? 0 : value;
     }, random);
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/selection/HeuristicSelection.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/selection/HeuristicSelection.java
@@ -1,7 +1,6 @@
 package jp.kusumotolab.kgenprog.ga.mutation.selection;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/Fitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/Fitness.java
@@ -14,4 +14,9 @@ public interface Fitness extends Comparable<Fitness> {
    * @return その評価値が最大値かどうか
    */
   boolean isMaximum();
+
+  /**
+   * @return 評価値の文字列表現を返す．
+   */
+  String toString();
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/Fitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/Fitness.java
@@ -1,7 +1,5 @@
 package jp.kusumotolab.kgenprog.ga.validation;
 
-import static java.lang.Double.isNaN;
-
 /**
  * 個体の評価値を表現するインターフェース
  */
@@ -16,28 +14,4 @@ public interface Fitness extends Comparable<Fitness> {
    * @return その評価値が最大値かどうか
    */
   boolean isMaximum();
-
-  /**
-   * Compares two {@code Fitness} objects. Basically, this comparison is performed in the same way
-   * as the numerical comparison with the {@code double} values returned from {@link #getSingularValue()}
-   * method. However, the value {@code NaN} is regarded as less than any other value.
-   *
-   * @param anotherFitness the {@code Fitness} to be compared.
-   * @return the value {@code 0} if {@code anotherDouble} is equal to this {@code Fitness}; a value
-   * less than {@code 0} if this {@code Fitness} is less than {@code anotherFitness}; and a value
-   * greater than {@code 0} if this {@code Fitness} is greater than {@code anotherDouble}.
-   */
-  @Override
-  default int compareTo(final Fitness anotherFitness) {
-    if (isNaN(getSingularValue()) && isNaN(anotherFitness.getSingularValue())) {
-      return 0;
-    }
-    if (isNaN(getSingularValue())) {
-      return -1;
-    }
-    if (isNaN(anotherFitness.getSingularValue())) {
-      return 1;
-    }
-    return Double.compare(getSingularValue(), anotherFitness.getSingularValue());
-  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/Fitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/Fitness.java
@@ -8,9 +8,9 @@ import static java.lang.Double.isNaN;
 public interface Fitness extends Comparable<Fitness> {
 
   /**
-   * @return 個体の評価値
+   * @return 個体の評価値を単一の数値で返す．
    */
-  double getValue();
+  double getSingularValue();
 
   /**
    * @return その評価値が最大値かどうか
@@ -19,7 +19,7 @@ public interface Fitness extends Comparable<Fitness> {
 
   /**
    * Compares two {@code Fitness} objects. Basically, this comparison is performed in the same way
-   * as the numerical comparison with the {@code double} values returned from {@link #getValue()}
+   * as the numerical comparison with the {@code double} values returned from {@link #getSingularValue()}
    * method. However, the value {@code NaN} is regarded as less than any other value.
    *
    * @param anotherFitness the {@code Fitness} to be compared.
@@ -29,15 +29,15 @@ public interface Fitness extends Comparable<Fitness> {
    */
   @Override
   default int compareTo(final Fitness anotherFitness) {
-    if (isNaN(getValue()) && isNaN(anotherFitness.getValue())) {
+    if (isNaN(getSingularValue()) && isNaN(anotherFitness.getSingularValue())) {
       return 0;
     }
-    if (isNaN(getValue())) {
+    if (isNaN(getSingularValue())) {
       return -1;
     }
-    if (isNaN(anotherFitness.getValue())) {
+    if (isNaN(anotherFitness.getSingularValue())) {
       return 1;
     }
-    return Double.compare(getValue(), anotherFitness.getValue());
+    return Double.compare(getSingularValue(), anotherFitness.getSingularValue());
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/Fitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/Fitness.java
@@ -6,9 +6,13 @@ package jp.kusumotolab.kgenprog.ga.validation;
 public interface Fitness extends Comparable<Fitness> {
 
   /**
-   * @return 個体の評価値を単一の数値で返す．
+   * 個体の評価値を0〜1の範囲のdouble型で返す．
+   *
+   * The fitness value is returned as double in the range of 0 to 1.
+   *
+   * @return 個体の評価値
    */
-  double getSingularValue();
+  double getNormalizedValue();
 
   /**
    * @return その評価値が最大値かどうか

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberCodeValidation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberCodeValidation.java
@@ -58,7 +58,7 @@ public class LimitedNumberCodeValidation implements SourceCodeValidation {
     // TODO 交叉により生成された変異プログラムへの対応
     if (basesFitnessMap.containsKey(parentBases)) {
       final LimitedNumberSimpleFitness parentFitness = basesFitnessMap.get(parentBases);
-      if (successRate <= parentFitness.getSingularValue()) {
+      if (successRate <= parentFitness.getNormalizedValue()) {
         parentFitness.reduceCapacity();
       }
     }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberCodeValidation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberCodeValidation.java
@@ -58,7 +58,7 @@ public class LimitedNumberCodeValidation implements SourceCodeValidation {
     // TODO 交叉により生成された変異プログラムへの対応
     if (basesFitnessMap.containsKey(parentBases)) {
       final LimitedNumberSimpleFitness parentFitness = basesFitnessMap.get(parentBases);
-      if (successRate <= parentFitness.getValue()) {
+      if (successRate <= parentFitness.getSingularValue()) {
         parentFitness.reduceCapacity();
       }
     }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberSimpleFitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberSimpleFitness.java
@@ -38,8 +38,8 @@ public class LimitedNumberSimpleFitness extends SimpleFitness {
    * @return 評価値の文字列表現を返す
    */
   @Override
-  public String toString(){
-    return isCapacityAvailable()? super.toString():Double.toString(0d);
+  public String toString() {
+    return isCapacityAvailable() ? super.toString() : Double.toString(0d);
   }
 
   /**

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberSimpleFitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberSimpleFitness.java
@@ -19,11 +19,17 @@ public class LimitedNumberSimpleFitness extends SimpleFitness {
   }
 
   /**
-   * return 評価値，ただし，期限切れの場合は0
+   * 個体の評価値を0〜1の範囲のdouble型で返す．
+   * ただし，期限切れの場合は0になる．
+   *
+   * The fitness value is returned as double in the range of 0 to 1.
+   * In the case of expiration, 0 is returned.
+   *
+   * @return 個体の評価値
    */
   @Override
-  public double getSingularValue() {
-    return isCapacityAvailable() ? super.getSingularValue() : 0d;
+  public double getNormalizedValue() {
+    return isCapacityAvailable() ? super.getNormalizedValue() : 0d;
   }
 
   /**

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberSimpleFitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberSimpleFitness.java
@@ -22,8 +22,8 @@ public class LimitedNumberSimpleFitness extends SimpleFitness {
    * return 評価値，ただし，期限切れの場合は0
    */
   @Override
-  public double getValue() {
-    return isCapacityAvailable() ? super.getValue() : 0d;
+  public double getSingularValue() {
+    return isCapacityAvailable() ? super.getSingularValue() : 0d;
   }
 
   /**

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberSimpleFitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberSimpleFitness.java
@@ -45,7 +45,7 @@ public class LimitedNumberSimpleFitness extends SimpleFitness {
    */
   @Override
   public String toString() {
-    return isCapacityAvailable() ? super.toString() : Double.toString(0d);
+    return Double.toString(getNormalizedValue());
   }
 
   /**

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberSimpleFitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberSimpleFitness.java
@@ -35,6 +35,14 @@ public class LimitedNumberSimpleFitness extends SimpleFitness {
   }
 
   /**
+   * @return 評価値の文字列表現を返す
+   */
+  @Override
+  public String toString(){
+    return isCapacityAvailable()? super.toString():Double.toString(0d);
+  }
+
+  /**
    * @return 与えられた評価値を保持する評価の残りの回数
    */
   public int getCapacity() {

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
@@ -30,4 +30,24 @@ public class SimpleFitness implements Fitness {
   public boolean isMaximum() {
     return 0 == Double.compare(value, MAXIMUM_VALUE);
   }
+
+  @Override
+  public int compareTo(final Fitness anotherFitness) {
+
+    if (SimpleFitness.class != anotherFitness.getClass()) {
+      throw new IllegalStateException("anotherFitness must be an instance of SimpleFitness.");
+    }
+
+    final SimpleFitness anotherSimpleFitness = (SimpleFitness) anotherFitness;
+    if (Double.isNaN(value) && Double.isNaN(anotherSimpleFitness.value)) {
+      return 0;
+    }
+    if (Double.isNaN(value)) {
+      return -1;
+    }
+    if (Double.isNaN(anotherSimpleFitness.value)) {
+      return 1;
+    }
+    return Double.compare(value, anotherSimpleFitness.value);
+  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
@@ -35,7 +35,7 @@ public class SimpleFitness implements Fitness {
    * @return 評価値の文字列表現を返す
    */
   @Override
-  public String toString(){
+  public String toString() {
     return Double.toString(value);
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
@@ -31,6 +31,14 @@ public class SimpleFitness implements Fitness {
     return 0 == Double.compare(value, MAXIMUM_VALUE);
   }
 
+  /**
+   * @return 評価値の文字列表現を返す
+   */
+  @Override
+  public String toString(){
+    return Double.toString(value);
+  }
+
   @Override
   public int compareTo(final Fitness anotherFitness) {
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
@@ -16,10 +16,14 @@ public class SimpleFitness implements Fitness {
   }
 
   /**
-   * @return 評価値
+   * 個体の評価値を0〜1の範囲のdouble型で返す．
+   *
+   * The fitness value is returned as double in the range of 0 to 1.
+   *
+   * @return 個体の評価値
    */
   @Override
-  public double getSingularValue() {
+  public double getNormalizedValue() {
     return value;
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
@@ -47,7 +47,7 @@ public class SimpleFitness implements Fitness {
   public int compareTo(final Fitness anotherFitness) {
 
     if (SimpleFitness.class != anotherFitness.getClass()) {
-      throw new IllegalStateException("anotherFitness must be an instance of SimpleFitness.");
+      throw new ClassCastException("anotherFitness must be an instance of SimpleFitness.");
     }
 
     final SimpleFitness anotherSimpleFitness = (SimpleFitness) anotherFitness;

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/validation/SimpleFitness.java
@@ -19,7 +19,7 @@ public class SimpleFitness implements Fitness {
    * @return 評価値
    */
   @Override
-  public double getValue() {
+  public double getSingularValue() {
     return value;
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/output/VariantSerializer.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/VariantSerializer.java
@@ -95,8 +95,7 @@ public class VariantSerializer implements JsonSerializer<Variant> {
 
     final int generationNumber = variant.getGenerationNumber()
         .get();
-    final double fitness = variant.getFitness()
-        .getSingularValue();
+    final String fitness = variant.getFitness().toString();
     final Patch patch = patchGenerator.exec(variant);
 
     final JsonObject serializedVariant = new JsonObject();
@@ -104,7 +103,7 @@ public class VariantSerializer implements JsonSerializer<Variant> {
     serializedVariant.addProperty("id", variant.getId());
     serializedVariant.addProperty("generationNumber", generationNumber);
     serializedVariant.addProperty("selectionCount", variant.getSelectionCount());
-    serializedVariant.addProperty("fitness", !Double.isNaN(fitness) ? fitness : -1.0d);
+    serializedVariant.addProperty("fitness", fitness);
     serializedVariant.addProperty("isBuildSuccess", variant.isBuildSucceeded());
     serializedVariant.addProperty("isSyntaxValid", variant.isSyntaxValid());
     serializedVariant.add("bases", context.serialize(variant.getGene()

--- a/src/main/java/jp/kusumotolab/kgenprog/output/VariantSerializer.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/VariantSerializer.java
@@ -96,7 +96,7 @@ public class VariantSerializer implements JsonSerializer<Variant> {
     final int generationNumber = variant.getGenerationNumber()
         .get();
     final double fitness = variant.getFitness()
-        .getValue();
+        .getSingularValue();
     final Patch patch = patchGenerator.exec(variant);
 
     final JsonObject serializedVariant = new JsonObject();

--- a/src/main/java/jp/kusumotolab/kgenprog/output/VariantSerializer.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/VariantSerializer.java
@@ -95,7 +95,8 @@ public class VariantSerializer implements JsonSerializer<Variant> {
 
     final int generationNumber = variant.getGenerationNumber()
         .get();
-    final String fitness = variant.getFitness().toString();
+    final String fitness = variant.getFitness()
+        .toString();
     final Patch patch = patchGenerator.exec(variant);
 
     final JsonObject serializedVariant = new JsonObject();

--- a/src/main/java/jp/kusumotolab/kgenprog/project/factory/JUnitLibraryResolver.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/factory/JUnitLibraryResolver.java
@@ -49,6 +49,7 @@ public class JUnitLibraryResolver {
 
   // TODO 一時dirの責務をひとまずこのクラスに任せたが，巨大になるなら別クラスに切った方がよさそう．
   private static Path tempDir;
+
   public static Path getTempDirectory() {
     try {
       if (null == tempDir) {

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/DefaultVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/DefaultVariantSelectionTest.java
@@ -44,15 +44,15 @@ public class DefaultVariantSelectionTest {
 
     assertThat(variants).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getSingularValue)
+        .extracting(Fitness::toString)
         .hasSize(10)
-        .containsExactly(0.00d, 0.05d, 0.20d, 0.15d, 0.40d, 0.25d, 0.60d, 0.35d, 0.80d, 0.45d);
+        .containsExactly("0.0", "0.05", "0.2", "0.15", "0.4", "0.25", "0.6", "0.35", "0.8", "0.45");
 
     assertThat(selectedVariants).hasSize(variantSize)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getSingularValue)
+        .extracting(Fitness::toString)
         .hasSize(5)
-        .containsExactly(0.80d, 0.60d, 0.45d, 0.40d, 0.35d);
+        .containsExactly("0.8", "0.6", "0.45", "0.4", "0.35");
   }
 
   @Test
@@ -128,15 +128,15 @@ public class DefaultVariantSelectionTest {
 
     assertThat(current).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getSingularValue)
+        .extracting(Fitness::toString)
         .hasSize(10)
-        .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
+        .containsExactly("0.0", "0.2", "0.2", "0.4", "0.4", "0.6", "0.6", "0.8", "0.8", "1.0");
 
     assertThat(generated).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getSingularValue)
+        .extracting(Fitness::toString)
         .hasSize(10)
-        .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
+        .containsExactly("0.0", "0.2", "0.2", "0.4", "0.4", "0.6", "0.6", "0.8", "0.8", "1.0");
 
     assertThat(selectedVariants).hasSize(variantSize)
         .extracting(Variant::getId)

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/DefaultVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/DefaultVariantSelectionTest.java
@@ -44,13 +44,13 @@ public class DefaultVariantSelectionTest {
 
     assertThat(variants).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getValue)
+        .extracting(Fitness::getSingularValue)
         .hasSize(10)
         .containsExactly(0.00d, 0.05d, 0.20d, 0.15d, 0.40d, 0.25d, 0.60d, 0.35d, 0.80d, 0.45d);
 
     assertThat(selectedVariants).hasSize(variantSize)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getValue)
+        .extracting(Fitness::getSingularValue)
         .hasSize(5)
         .containsExactly(0.80d, 0.60d, 0.45d, 0.40d, 0.35d);
   }
@@ -128,13 +128,13 @@ public class DefaultVariantSelectionTest {
 
     assertThat(current).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getValue)
+        .extracting(Fitness::getSingularValue)
         .hasSize(10)
         .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
 
     assertThat(generated).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getValue)
+        .extracting(Fitness::getSingularValue)
         .hasSize(10)
         .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/EliteAndOldVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/EliteAndOldVariantSelectionTest.java
@@ -38,15 +38,15 @@ public class EliteAndOldVariantSelectionTest {
 
     assertThat(variants).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getSingularValue)
+        .extracting(Fitness::toString)
         .hasSize(10)
-        .containsExactly(0.00d, 0.05d, 0.20d, 0.15d, 0.40d, 0.25d, 0.60d, 0.35d, 0.80d, 0.45d);
+        .containsExactly("0.0", "0.05", "0.2", "0.15", "0.4", "0.25", "0.6", "0.35", "0.8", "0.45");
 
     assertThat(selectedVariants).hasSize(variantSize)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getSingularValue)
+        .extracting(Fitness::toString)
         .hasSize(5)
-        .containsExactly(0.80d, 0.60d, 0.45d, 0.40d, 0.35d);
+        .containsExactly("0.8", "0.6", "0.45", "0.4", "0.35");
   }
 
   /**
@@ -144,15 +144,15 @@ public class EliteAndOldVariantSelectionTest {
 
     assertThat(current).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getSingularValue)
+        .extracting(Fitness::toString)
         .hasSize(10)
-        .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
+        .containsExactly("0.0", "0.2", "0.2", "0.4", "0.4", "0.6", "0.6", "0.8", "0.8", "1.0");
 
     assertThat(generated).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getSingularValue)
+        .extracting(Fitness::toString)
         .hasSize(10)
-        .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
+        .containsExactly("0.0", "0.2", "0.2", "0.4", "0.4", "0.6", "0.6", "0.8", "0.8", "1.0");
 
     assertThat(selectedVariants).hasSize(variantSize)
         .extracting(Variant::getId)

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/EliteAndOldVariantSelectionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/selection/EliteAndOldVariantSelectionTest.java
@@ -38,13 +38,13 @@ public class EliteAndOldVariantSelectionTest {
 
     assertThat(variants).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getValue)
+        .extracting(Fitness::getSingularValue)
         .hasSize(10)
         .containsExactly(0.00d, 0.05d, 0.20d, 0.15d, 0.40d, 0.25d, 0.60d, 0.35d, 0.80d, 0.45d);
 
     assertThat(selectedVariants).hasSize(variantSize)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getValue)
+        .extracting(Fitness::getSingularValue)
         .hasSize(5)
         .containsExactly(0.80d, 0.60d, 0.45d, 0.40d, 0.35d);
   }
@@ -144,13 +144,13 @@ public class EliteAndOldVariantSelectionTest {
 
     assertThat(current).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getValue)
+        .extracting(Fitness::getSingularValue)
         .hasSize(10)
         .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
 
     assertThat(generated).hasSize(10)
         .extracting(Variant::getFitness)
-        .extracting(Fitness::getValue)
+        .extracting(Fitness::getSingularValue)
         .hasSize(10)
         .containsExactly(0.00d, 0.20d, 0.20d, 0.40d, 0.40d, 0.60d, 0.60d, 0.80d, 0.80d, 1.00d);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/validation/DefaultCodeValidationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/validation/DefaultCodeValidationTest.java
@@ -25,7 +25,7 @@ public class DefaultCodeValidationTest {
     final Fitness fitness = defaultCodeValidation.exec(input);
 
     final double expected = (double) 3 / 4; // 4 tests executed and 3 tests passed.
-    assertThat(fitness.getSingularValue()).isEqualTo(expected);
+    assertThat(fitness.toString()).isEqualTo(Double.toString(expected));
   }
 
   @Test
@@ -39,6 +39,6 @@ public class DefaultCodeValidationTest {
     final Input input = new Input(null, null, initialVariant.getTestResults());
     final Fitness fitness = defaultCodeValidation.exec(input);
 
-    assertThat(fitness.getSingularValue()).isNaN();
+    assertThat(fitness.toString()).isEqualTo(Double.toString(Double.NaN));
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/validation/DefaultCodeValidationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/validation/DefaultCodeValidationTest.java
@@ -25,7 +25,7 @@ public class DefaultCodeValidationTest {
     final Fitness fitness = defaultCodeValidation.exec(input);
 
     final double expected = (double) 3 / 4; // 4 tests executed and 3 tests passed.
-    assertThat(fitness.getValue()).isEqualTo(expected);
+    assertThat(fitness.getSingularValue()).isEqualTo(expected);
   }
 
   @Test
@@ -39,6 +39,6 @@ public class DefaultCodeValidationTest {
     final Input input = new Input(null, null, initialVariant.getTestResults());
     final Fitness fitness = defaultCodeValidation.exec(input);
 
-    assertThat(fitness.getValue()).isNaN();
+    assertThat(fitness.getSingularValue()).isNaN();
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberCodeValidationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberCodeValidationTest.java
@@ -34,7 +34,7 @@ public class LimitedNumberCodeValidationTest {
 
     // 親バリアントの評価（一回目）
     final Fitness parentFitness = validation.exec(parentInput);
-    assertThat(parentFitness.getSingularValue()).isEqualTo(0.8d);
+    assertThat(parentFitness.toString()).isEqualTo("0.8");
 
     // 子バリアントを4つ生成
     final List<Gene> childGenes = parentGene.generateNextGenerationGenes(Arrays.asList(//
@@ -53,23 +53,23 @@ public class LimitedNumberCodeValidationTest {
 
     // バカ息子0の評価後，親の評価はまだ高いはず
     final Fitness childFitness0 = validation.exec(childInputs[0]);
-    assertThat(childFitness0.getSingularValue()).isEqualTo(0.3d);
-    assertThat(parentFitness.getSingularValue()).isEqualTo(0.8d);
+    assertThat(childFitness0.toString()).isEqualTo("0.3");
+    assertThat(parentFitness.toString()).isEqualTo("0.8");
 
     // バカ息子1の評価後，親の評価はまだ高いはず
     final Fitness childFitness1 = validation.exec(childInputs[1]);
-    assertThat(childFitness1.getSingularValue()).isEqualTo(0.3d);
-    assertThat(parentFitness.getSingularValue()).isEqualTo(0.8d);
+    assertThat(childFitness1.toString()).isEqualTo("0.3");
+    assertThat(parentFitness.toString()).isEqualTo("0.8");
 
     // バカ息子2の評価後，親の評価は低くなっているはず
     final Fitness childFitness2 = validation.exec(childInputs[2]);
-    assertThat(childFitness2.getSingularValue()).isEqualTo(0.3d);
-    assertThat(parentFitness.getSingularValue()).isEqualTo(0.0d);
+    assertThat(childFitness2.toString()).isEqualTo("0.3");
+    assertThat(parentFitness.toString()).isEqualTo("0.0");
 
     // バカ息子3の評価後，親の評価は相変わらず低いはず
     final Fitness childFitness3 = validation.exec(childInputs[3]);
-    assertThat(childFitness3.getSingularValue()).isEqualTo(0.3d);
-    assertThat(parentFitness.getSingularValue()).isEqualTo(0.0d);
+    assertThat(childFitness3.toString()).isEqualTo("0.3");
+    assertThat(parentFitness.toString()).isEqualTo("0.0");
 
     // 無関係のバリアントが来ても，その評価値は0にならないはず
     final Gene anotherGene = new Gene(Arrays.asList(//
@@ -81,6 +81,6 @@ public class LimitedNumberCodeValidationTest {
     when(anotherInput.getGene()).thenReturn(anotherGene);
     when(anotherInput.getTestResults()).thenReturn(anotherTestResults);
     final Fitness anotherFitness = validation.exec(anotherInput);
-    assertThat(anotherFitness.getSingularValue()).isEqualTo(0.6d);
+    assertThat(anotherFitness.toString()).isEqualTo("0.6");
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberCodeValidationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberCodeValidationTest.java
@@ -34,7 +34,7 @@ public class LimitedNumberCodeValidationTest {
 
     // 親バリアントの評価（一回目）
     final Fitness parentFitness = validation.exec(parentInput);
-    assertThat(parentFitness.getValue()).isEqualTo(0.8d);
+    assertThat(parentFitness.getSingularValue()).isEqualTo(0.8d);
 
     // 子バリアントを4つ生成
     final List<Gene> childGenes = parentGene.generateNextGenerationGenes(Arrays.asList(//
@@ -53,23 +53,23 @@ public class LimitedNumberCodeValidationTest {
 
     // バカ息子0の評価後，親の評価はまだ高いはず
     final Fitness childFitness0 = validation.exec(childInputs[0]);
-    assertThat(childFitness0.getValue()).isEqualTo(0.3d);
-    assertThat(parentFitness.getValue()).isEqualTo(0.8d);
+    assertThat(childFitness0.getSingularValue()).isEqualTo(0.3d);
+    assertThat(parentFitness.getSingularValue()).isEqualTo(0.8d);
 
     // バカ息子1の評価後，親の評価はまだ高いはず
     final Fitness childFitness1 = validation.exec(childInputs[1]);
-    assertThat(childFitness1.getValue()).isEqualTo(0.3d);
-    assertThat(parentFitness.getValue()).isEqualTo(0.8d);
+    assertThat(childFitness1.getSingularValue()).isEqualTo(0.3d);
+    assertThat(parentFitness.getSingularValue()).isEqualTo(0.8d);
 
     // バカ息子2の評価後，親の評価は低くなっているはず
     final Fitness childFitness2 = validation.exec(childInputs[2]);
-    assertThat(childFitness2.getValue()).isEqualTo(0.3d);
-    assertThat(parentFitness.getValue()).isEqualTo(0.0d);
+    assertThat(childFitness2.getSingularValue()).isEqualTo(0.3d);
+    assertThat(parentFitness.getSingularValue()).isEqualTo(0.0d);
 
     // バカ息子3の評価後，親の評価は相変わらず低いはず
     final Fitness childFitness3 = validation.exec(childInputs[3]);
-    assertThat(childFitness3.getValue()).isEqualTo(0.3d);
-    assertThat(parentFitness.getValue()).isEqualTo(0.0d);
+    assertThat(childFitness3.getSingularValue()).isEqualTo(0.3d);
+    assertThat(parentFitness.getSingularValue()).isEqualTo(0.0d);
 
     // 無関係のバリアントが来ても，その評価値は0にならないはず
     final Gene anotherGene = new Gene(Arrays.asList(//
@@ -81,6 +81,6 @@ public class LimitedNumberCodeValidationTest {
     when(anotherInput.getGene()).thenReturn(anotherGene);
     when(anotherInput.getTestResults()).thenReturn(anotherTestResults);
     final Fitness anotherFitness = validation.exec(anotherInput);
-    assertThat(anotherFitness.getValue()).isEqualTo(0.6d);
+    assertThat(anotherFitness.getSingularValue()).isEqualTo(0.6d);
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberFitnessTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberFitnessTest.java
@@ -12,25 +12,25 @@ public class LimitedNumberFitnessTest {
     final LimitedNumberSimpleFitness fitness = new LimitedNumberSimpleFitness(1.0d, 2);
     final int capacity1 = fitness.getCapacity();
     assertThat(capacity1).isEqualTo(2);
-    assertThat(fitness.getSingularValue()).isEqualTo(1.0d);
+    assertThat(fitness.toString()).isEqualTo("1.0");
     assertThat(fitness.isMaximum()).isTrue();
 
     // capacityが2から1に減ったとき
     final int capacity2 = fitness.reduceCapacity();
     assertThat(capacity2).isEqualTo(1);
-    assertThat(fitness.getSingularValue()).isEqualTo(1.0d);
+    assertThat(fitness.toString()).isEqualTo("1.0");
     assertThat(fitness.isMaximum()).isTrue();
 
     // capacityが1から0に減ったとき
     final int capacity3 = fitness.reduceCapacity();
     assertThat(capacity3).isEqualTo(0);
-    assertThat(fitness.getSingularValue()).isEqualTo(0d);
+    assertThat(fitness.toString()).isEqualTo("0.0");
     assertThat(fitness.isMaximum()).isFalse();
 
     // capacityが0のときはこれ以上減らない
     final int capacity4 = fitness.reduceCapacity();
     assertThat(capacity4).isEqualTo(0);
-    assertThat(fitness.getSingularValue()).isEqualTo(0);
+    assertThat(fitness.toString()).isEqualTo("0.0");
     assertThat(fitness.isMaximum()).isFalse();
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberFitnessTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/validation/LimitedNumberFitnessTest.java
@@ -12,25 +12,25 @@ public class LimitedNumberFitnessTest {
     final LimitedNumberSimpleFitness fitness = new LimitedNumberSimpleFitness(1.0d, 2);
     final int capacity1 = fitness.getCapacity();
     assertThat(capacity1).isEqualTo(2);
-    assertThat(fitness.getValue()).isEqualTo(1.0d);
+    assertThat(fitness.getSingularValue()).isEqualTo(1.0d);
     assertThat(fitness.isMaximum()).isTrue();
 
     // capacityが2から1に減ったとき
     final int capacity2 = fitness.reduceCapacity();
     assertThat(capacity2).isEqualTo(1);
-    assertThat(fitness.getValue()).isEqualTo(1.0d);
+    assertThat(fitness.getSingularValue()).isEqualTo(1.0d);
     assertThat(fitness.isMaximum()).isTrue();
 
     // capacityが1から0に減ったとき
     final int capacity3 = fitness.reduceCapacity();
     assertThat(capacity3).isEqualTo(0);
-    assertThat(fitness.getValue()).isEqualTo(0d);
+    assertThat(fitness.getSingularValue()).isEqualTo(0d);
     assertThat(fitness.isMaximum()).isFalse();
 
     // capacityが0のときはこれ以上減らない
     final int capacity4 = fitness.reduceCapacity();
     assertThat(capacity4).isEqualTo(0);
-    assertThat(fitness.getValue()).isEqualTo(0);
+    assertThat(fitness.getSingularValue()).isEqualTo(0);
     assertThat(fitness.isMaximum()).isFalse();
   }
 }


### PR DESCRIPTION
resolve #748 

以下の変更を実施．
- Double型での比較を止めた．Fitnessインターフェースの子クラスは必ずcompareToメソッドを実装し，それを使って比較を行う．
- Fitnessが単一のスカラー値で必要は場合はある（例えばルーレット選択の重みを決定するため）ので，Fitness#getNormalizedValueを追加．このメソッドはプリミティブ型のdoubleを返す．