### PR TITLE
リリーススクリプトの潜在バグを修正2

### DIFF
--- a/.circleci/generate-change-log.sh
+++ b/.circleci/generate-change-log.sh
@@ -2,11 +2,12 @@
 
 set -eo pipefail
 
-WANTED_VERSION="$(./.circleci/check-version.sh)"
+echo 'Checking version...'
 
-if [[ $WANTED_VERSION = "EXISTING" ]]; then
-  echo "This version has been already released. Abort."
-  exit 0
+VERSION_GIT_TAG="v$(./.circleci/check-version.sh)"
+
+if [[ $? -ne 0 ]]; then
+  exit 0 # exit as success for circleci
 fi
 
 

--- a/.circleci/publish-new-release.sh
+++ b/.circleci/publish-new-release.sh
@@ -7,7 +7,7 @@ echo 'Checking version...'
 VERSION_GIT_TAG="v$(./.circleci/check-version.sh)"
 
 if [[ $? -ne 0 ]]; then
-  exit 1
+  exit 0 # exit as success for circleci
 fi
 
 


### PR DESCRIPTION
related to #767 

#767 でciが落ちるようになった．
リリーススクリプトをさらに修正．
ciなのでテストがムズイ．マージして試すしかない．