### PR TITLE
リリーススクリプトの潜在バグを修正3

### DIFF
--- a/.circleci/check-version.sh
+++ b/.circleci/check-version.sh
@@ -18,7 +18,7 @@ VERSION_REGEX='^[0-9]+(\.[0-9]+){2}$'
 if [[ ! $WANTED_VERSION =~ $VERSION_REGEX ]]; then
   echo "[ERROR] Version number $WANTED_VERSION is not valid." >&2
   echo "Please follow 3-number semantic versioning system." >&2
-  exit 1
+  exit
 fi
 
 
@@ -28,10 +28,10 @@ HTTP_STATUS=$(curl -LI "${GITHUB_TAG_URL_BASE}/${VERSION_GIT_TAG}" -o /dev/null 
 
 if [[ $HTTP_STATUS = '400' ]]; then
   echo "[ERROR] Version number $WANTED_VERSION cannot be used as a tag." >&2
-  exit 1
+  exit
 elif [[ $HTTP_STATUS = '200' ]]; then
   echo "[ERROR] This version has been already released. Abort." >&2
-  exit 1
+  exit
 fi
 
 echo $WANTED_VERSION

--- a/.circleci/generate-change-log.sh
+++ b/.circleci/generate-change-log.sh
@@ -4,10 +4,10 @@ set -eo pipefail
 
 echo 'Checking version...'
 
-VERSION_GIT_TAG="v$(./.circleci/check-version.sh)"
+VERSION=$(./.circleci/check-version.sh)
 
-if [[ $? -ne 0 ]]; then
-  exit 0 # exit as success for circleci
+if [[ $VERSION == "" ]]; then
+  exit 0 # exit as status 0 to finish circleci as success
 fi
 
 

--- a/.circleci/publish-new-release.sh
+++ b/.circleci/publish-new-release.sh
@@ -4,10 +4,10 @@ set -eo pipefail
 
 echo 'Checking version...'
 
-VERSION_GIT_TAG="v$(./.circleci/check-version.sh)"
+VERSION=$(./.circleci/check-version.sh)
 
-if [[ $? -ne 0 ]]; then
-  exit 0 # exit as success for circleci
+if [[ $VERSION == "" ]]; then
+  exit 0 # exit as status 0 to finish circleci as success
 fi
 
 
@@ -29,4 +29,4 @@ ghr \
   --commitish $CIRCLE_SHA1 \
   --name "Version $WANTED_VERSION" \
   --body "$CHANGELOG" \
-    $VERSION_GIT_TAG ./workspace/artifacts/
+    $VERSION ./workspace/artifacts/


### PR DESCRIPTION
related to #767 #768

リリーススクリプトをさらに修正．

`set pipefail` が悪さの原因．
根本的にスクリプトのエラーハンドルがいけてない．が無視．