### PR TITLE
release版jarの名前から-allを削除

### DIFF
--- a/.circleci/publish-new-release.sh
+++ b/.circleci/publish-new-release.sh
@@ -18,6 +18,11 @@ go get -u github.com/tcnksm/ghr
 
 echo "Starting to publish a new release as the version: ${WANTED_VERSION} ..."
 
+# trim suffix "-all" of fat jar
+jar=$(ls ./workspace/artifacts/*.jar)
+mv $jar ${jar/-all/}
+
+# generate change log
 CHANGELOG="## Change Log
 
 $(cat ./workspace/CHANGELOG.md)"


### PR DESCRIPTION
resolve #770 

`kGenProg-1.7.1-all.jar`
↓
`kGenProg-1.7.1.jar`