### PR TITLE
kGenProgMainTestを例外発生の有無の確認に変更

### DIFF
--- a/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
@@ -48,8 +48,18 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(PRODUCT_NAME);
     final Path testPath = rootPath.resolve(TEST_NAME);
 
-    assertThatCode(
-        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
+    assertThatCode(() -> runKGenProgMain(rootPath, productPath, testPath)).
+        doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testCloseToZero02() {
+    final Path rootPath = Paths.get("example/CloseToZero02");
+    final Path productPath = rootPath.resolve(PRODUCT_NAME);
+    final Path testPath = rootPath.resolve(TEST_NAME);
+
+    assertThatCode(() -> runKGenProgMain(rootPath, productPath, testPath)).
+        doesNotThrowAnyException();
   }
 
   @Test
@@ -58,8 +68,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(PRODUCT_NAME);
     final Path testPath = rootPath.resolve(TEST_NAME);
 
-    assertThatCode(
-        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
+    assertThatCode(() -> runKGenProgMain(rootPath, productPath, testPath)).
+        doesNotThrowAnyException();
   }
 
   @Test
@@ -68,8 +78,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(PRODUCT_NAME);
     final Path testPath = rootPath.resolve(TEST_NAME);
 
-    assertThatCode(
-        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
+    assertThatCode(() -> runKGenProgMain(rootPath, productPath, testPath)).
+        doesNotThrowAnyException();
   }
 
   @Test
@@ -78,8 +88,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve("src/example/CountDown.java");
     final Path testPath = rootPath.resolve("src/example/CountDownTest.java");
 
-    assertThatCode(
-        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
+    assertThatCode(() -> runKGenProgMain(rootPath, productPath, testPath)).
+        doesNotThrowAnyException();
   }
 
   @Test
@@ -90,8 +100,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(productName);
     final Path testPath = rootPath.resolve(testName);
 
-    assertThatCode(
-        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
+    assertThatCode(() -> runKGenProgMain(rootPath, productPath, testPath)).
+        doesNotThrowAnyException();
   }
 
   @Test
@@ -102,7 +112,7 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(productName);
     final Path testPath = rootPath.resolve(testName);
 
-    assertThatCode(
-        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
+    assertThatCode(() -> runKGenProgMain(rootPath, productPath, testPath)).
+        doesNotThrowAnyException();
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
@@ -1,6 +1,7 @@
 package jp.kusumotolab.kgenprog;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -49,10 +50,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(PRODUCT_NAME);
     final Path testPath = rootPath.resolve(TEST_NAME);
 
-    final List<Variant> variants = runKGenProgMain(rootPath, productPath, testPath);
-
-    assertThat(variants).hasSize(1)
-        .allMatch(Variant::isCompleted);
+    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
+    assertThat(thrown).isNull();
   }
 
   @Test
@@ -61,23 +60,18 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(PRODUCT_NAME);
     final Path testPath = rootPath.resolve(TEST_NAME);
 
-    final List<Variant> variants = runKGenProgMain(rootPath, productPath, testPath);
-
-    assertThat(variants).hasSize(1)
-        .allMatch(Variant::isCompleted);
+    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
+    assertThat(thrown).isNull();
   }
 
   @Test
-  @Ignore
   public void testCloseToZero03() {
     final Path rootPath = Paths.get("example/CloseToZero03");
     final Path productPath = rootPath.resolve(PRODUCT_NAME);
     final Path testPath = rootPath.resolve(TEST_NAME);
 
-    final List<Variant> variants = runKGenProgMain(rootPath, productPath, testPath);
-
-    assertThat(variants).hasSize(1)
-        .allMatch(Variant::isCompleted);
+    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
+    assertThat(thrown).isNull();
   }
 
   @Test
@@ -86,11 +80,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(PRODUCT_NAME);
     final Path testPath = rootPath.resolve(TEST_NAME);
 
-    final List<Variant> variants = runKGenProgMain(rootPath, productPath, testPath);
-
-    assertThat(variants).hasSize(1)
-        .allMatch(Variant::isCompleted);
-
+    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
+    assertThat(thrown).isNull();
   }
 
   @Test
@@ -99,10 +90,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve("src/example/CountDown.java");
     final Path testPath = rootPath.resolve("src/example/CountDownTest.java");
 
-    final List<Variant> variants = runKGenProgMain(rootPath, productPath, testPath);
-
-    assertThat(variants).hasSize(1)
-        .allMatch(Variant::isCompleted);
+    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
+    assertThat(thrown).isNull();
   }
 
   @Test
@@ -113,10 +102,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(productName);
     final Path testPath = rootPath.resolve(testName);
 
-    final List<Variant> variants = runKGenProgMain(rootPath, productPath, testPath);
-
-    assertThat(variants).hasSize(1)
-        .allMatch(Variant::isCompleted);
+    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
+    assertThat(thrown).isNull();
   }
 
   @Test
@@ -127,9 +114,7 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(productName);
     final Path testPath = rootPath.resolve(testName);
 
-    final List<Variant> variants = runKGenProgMain(rootPath, productPath, testPath);
-
-    assertThat(variants).hasSize(1)
-        .allMatch(Variant::isCompleted);
+    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
+    assertThat(thrown).isNull();
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
@@ -1,12 +1,10 @@
 package jp.kusumotolab.kgenprog;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -50,18 +48,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(PRODUCT_NAME);
     final Path testPath = rootPath.resolve(TEST_NAME);
 
-    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
-    assertThat(thrown).isNull();
-  }
-
-  @Test
-  public void testCloseToZero02() {
-    final Path rootPath = Paths.get("example/CloseToZero02");
-    final Path productPath = rootPath.resolve(PRODUCT_NAME);
-    final Path testPath = rootPath.resolve(TEST_NAME);
-
-    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
-    assertThat(thrown).isNull();
+    assertThatCode(
+        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
   }
 
   @Test
@@ -70,8 +58,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(PRODUCT_NAME);
     final Path testPath = rootPath.resolve(TEST_NAME);
 
-    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
-    assertThat(thrown).isNull();
+    assertThatCode(
+        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
   }
 
   @Test
@@ -80,8 +68,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(PRODUCT_NAME);
     final Path testPath = rootPath.resolve(TEST_NAME);
 
-    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
-    assertThat(thrown).isNull();
+    assertThatCode(
+        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
   }
 
   @Test
@@ -90,8 +78,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve("src/example/CountDown.java");
     final Path testPath = rootPath.resolve("src/example/CountDownTest.java");
 
-    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
-    assertThat(thrown).isNull();
+    assertThatCode(
+        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
   }
 
   @Test
@@ -102,8 +90,8 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(productName);
     final Path testPath = rootPath.resolve(testName);
 
-    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
-    assertThat(thrown).isNull();
+    assertThatCode(
+        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
   }
 
   @Test
@@ -114,7 +102,7 @@ public class KGenProgMainTest {
     final Path productPath = rootPath.resolve(productName);
     final Path testPath = rootPath.resolve(testName);
 
-    final Throwable thrown = catchThrowable(() -> runKGenProgMain(rootPath, productPath, testPath));
-    assertThat(thrown).isNull();
+    assertThatCode(
+        () -> runKGenProgMain(rootPath, productPath, testPath)).doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
旧：想定した個数の解が生成されたかどうか
新：例外が発生することなくkGenProgが動作を終えるか

kGenProgのデフォルト動作が変更になることがあるため，
想定した個数の解が生成されたかどうかを確認する結合テストは制約が強すぎる．
そのため，例外が発生することなくkGenProgが動作を終えるかどうかを確認するテストに変更した．