### PR TITLE
CUILauncherにエラーメッセージを追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.10.0'
     testImplementation 'org.mockito:mockito-core:2.+'
     testImplementation 'com.google.jimfs:jimfs:1.1'
+    testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
 
     // Declare by "runtimeOnly" cuz hamcrest is necessary to execute junit-test dynamically,
     // but it doesn't seem to be loaded on compile task.

--- a/src/main/java/jp/kusumotolab/kgenprog/CUILauncher.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/CUILauncher.java
@@ -32,6 +32,8 @@ public class CUILauncher {
       final CUILauncher launcher = new CUILauncher();
       launcher.launch(config);
     } catch (final RuntimeException e) {
+      Logger log = LoggerFactory.getLogger(CUILauncher.class);
+      log.error(e.getMessage(), e);
       System.exit(1);
     }
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/CUILauncherTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/CUILauncherTest.java
@@ -1,0 +1,28 @@
+package jp.kusumotolab.kgenprog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+
+public class CUILauncherTest {
+
+  @Rule
+  public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+  @Test
+  public void testNullArgs() {
+    exit.expectSystemExitWithStatus(1);
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final PrintStream printStream = System.out;
+    System.setOut(new PrintStream(out));
+
+    final CUILauncher launcher = new CUILauncher();
+    CUILauncher.main(null);
+    assertThat(out.toString()).contains("NullPointerException");
+
+    System.setOut(printStream);
+  }
+}


### PR DESCRIPTION
resolve #774 

- RuntimeExeption時に黙って死なないようエラーメッセージを追加
- エラーメッセージが吐かれているかを確かめるテストを追加
  - null argsを与えてぬるぽを起こす