### PR TITLE
fatjar生成方法を元に戻した

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "build.gradle" }}
       # ===== Assemble jar file
-      - run: ./gradlew shadowJar
+      - run: ./gradlew assemble
       # ===== Collect and persist the built artifacts
       - run:
           name: Collect artifacts to be released

--- a/.circleci/publish-new-release.sh
+++ b/.circleci/publish-new-release.sh
@@ -18,9 +18,9 @@ go get -u github.com/tcnksm/ghr
 
 echo "Starting to publish a new release as the version: ${WANTED_VERSION} ..."
 
-# trim suffix "-all" of fat jar
-jar=$(ls ./workspace/artifacts/*.jar)
-mv $jar ${jar/-all/}
+# # trim suffix "-all" of fat jar
+# jar=$(ls ./workspace/artifacts/*.jar)
+# mv $jar ${jar/-all/}
 
 # generate change log
 CHANGELOG="## Change Log

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,6 @@ plugins {
 
     // Gradle lint
     id "nebula.lint" version "16.9.0"
-
-    // To generate fat jar
-    id "com.github.johnrengelman.shadow" version "6.0.0"
 }
 
 // Set compiler version
@@ -88,12 +85,20 @@ jar {
         attributes "Main-Class": "jp.kusumotolab.kgenprog.CUILauncher"
     }
 
+    // fatjar must include all dependencies
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    // exclude jar signatures for jar compression to avoid invalid signature
+    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
+
     doFirst {
         // copy gradle.properties to resolve version info
         copy {
             from 'gradle.properties'
             into buildDir.name + '/resources/main/'
         }
+
         // annotate whether this task was executed on CI or not
         def isCi = System.getenv('CI') ? 'true' : 'false'
         File prop = new File(buildDir.name + '/resources/main/gradle.properties')
@@ -122,9 +127,4 @@ jacocoTestReport {
             fileTree(dir: it, exclude: '**/*junit**')
         }))
     }
-}
-
-// Minimize generating fat jar
-shadowJar {
-    minimize()
 }


### PR DESCRIPTION
resolve #773
revert #771 
revert #758 の一部

shadowjarを使わずにfatjarを生成する方法に戻した．
これでjarが実行できるようになったはず．

手元での生成jar動作は確認済み．
ciでの生成は未確認だけどおそらくOK．

ついでにJUnitライブラリのロード方法を改善（tungledだけど勘弁）．