### PR TITLE
出力メッセージの調整

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -254,7 +254,7 @@ public class KGenProgMain {
     final Map.Entry<Double, Long> max =
         Collections.max(frequencies.entrySet(), Map.Entry.comparingByKey());
     final DecimalFormat df = createDecimalFormat();
-    return df.format(max.getKey()) + "(" + max.getValue() + ")"; // ここのmax.getKey()
+    return df.format(max.getKey()) + "(" + max.getValue() + ")";
   }
 
   private String getMinText(final List<Variant> variants) {
@@ -265,7 +265,7 @@ public class KGenProgMain {
     final Map.Entry<Double, Long> min =
         Collections.min(frequencies.entrySet(), Map.Entry.comparingByKey());
     final DecimalFormat df = createDecimalFormat();
-    return df.format(min.getKey()) + "(" + min.getValue() + ")"; // ここのmin.getKey()
+    return df.format(min.getKey()) + "(" + min.getValue() + ")";
   }
 
   private double getAverage(final List<Variant> variants) {
@@ -273,7 +273,6 @@ public class KGenProgMain {
         .filter(Variant::isBuildSucceeded)
         .mapToDouble(this::getNormalizedFitnessValue)
         .average()
-        // ここの.average() NaNの時フォーマッタ大丈夫か？
         .orElse(Double.NaN);
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -288,7 +288,7 @@ public class KGenProgMain {
         .getNormalizedValue();
   }
 
-  private DecimalFormat createDecimalFormat(){
+  private DecimalFormat createDecimalFormat() {
     return new DecimalFormat("#.###");
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -121,21 +121,18 @@ public class KGenProgMain {
       // しきい値以上の completedVariants が生成された場合は，GA を抜ける
       if (areEnoughCompletedVariants(variantStore.getFoundSolutions())) {
         exitStatus = ExitStatus.SUCCESS;
-        log.info("GA stopped.");
         break;
       }
 
       // 制限時間に達した場合には GA を抜ける
       if (stopwatch.isTimeout()) {
-        exitStatus = ExitStatus.FAIL_TIME;
-        log.info("GA stopped.");
+        exitStatus = ExitStatus.FAILURE_TIME_LIMIT;
         break;
       }
 
       // 最大世代数に到達した場合には GA を抜ける
       if (reachedMaxGeneration(variantStore.getGenerationNumber())) {
-        exitStatus = ExitStatus.FAIL_GEN;
-        log.info("GA stopped.");
+        exitStatus = ExitStatus.FAILURE_MAXIMUM_GENERATION;
         break;
       }
 
@@ -143,6 +140,7 @@ public class KGenProgMain {
       variantStore.proceedNextGeneration();
     }
 
+    log.info("GA stopped.");
     // 出力処理を行う
     exporters.exportAll(variantStore);
 
@@ -295,7 +293,7 @@ public class KGenProgMain {
       final ExitStatus exitStatus) {
     final StringBuilder sb = new StringBuilder();
     sb//
-        .append("Overall")
+        .append("Summary")
         .append(System.lineSeparator())
         .append("Reached generation = ")
         .append(generation.intValue())
@@ -309,7 +307,8 @@ public class KGenProgMain {
   }
 
   private enum ExitStatus {
-    SUCCESS("SUCCESS"), FAIL_GEN("FAIL(maximum generation)"), FAIL_TIME("FAIL(time limit)");
+    SUCCESS("SUCCESS"), FAILURE_MAXIMUM_GENERATION(
+        "FAILURE (maximum generation)"), FAILURE_TIME_LIMIT("FAILURE (time limit)");
     private final String code;
 
     ExitStatus(String code) {

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -1,5 +1,6 @@
 package jp.kusumotolab.kgenprog;
 
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -206,6 +207,7 @@ public class KGenProgMain {
     variants.addAll(variantsByMutation);
     variants.addAll(variantsByCrossover);
     final StringBuilder sb = new StringBuilder();
+    final DecimalFormat df = createDecimalFormat();
     sb//
         .append(System.lineSeparator())
         .append("----------------------------------------------------------------")
@@ -229,7 +231,7 @@ public class KGenProgMain {
         .append(", min ")
         .append(getMinText(variants))
         .append(", ave ")
-        .append(getAverage(variants))
+        .append(df.format(getAverage(variants)))
         .append(System.lineSeparator())
         .append("----------------------------------------------------------------")
         .append(System.lineSeparator());
@@ -249,7 +251,8 @@ public class KGenProgMain {
     }
     final Map.Entry<Double, Long> max =
         Collections.max(frequencies.entrySet(), Map.Entry.comparingByKey());
-    return max.getKey() + "(" + max.getValue() + ")";
+    final DecimalFormat df = createDecimalFormat();
+    return df.format(max.getKey()) + "(" + max.getValue() + ")"; // ここのmax.getKey()
   }
 
   private String getMinText(final List<Variant> variants) {
@@ -259,7 +262,8 @@ public class KGenProgMain {
     }
     final Map.Entry<Double, Long> min =
         Collections.min(frequencies.entrySet(), Map.Entry.comparingByKey());
-    return min.getKey() + "(" + min.getValue() + ")";
+    final DecimalFormat df = createDecimalFormat();
+    return df.format(min.getKey()) + "(" + min.getValue() + ")"; // ここのmin.getKey()
   }
 
   private double getAverage(final List<Variant> variants) {
@@ -267,6 +271,7 @@ public class KGenProgMain {
         .filter(Variant::isBuildSucceeded)
         .mapToDouble(this::getNormalizedFitnessValue)
         .average()
+        // ここの.average() NaNの時フォーマッタ大丈夫か？
         .orElse(Double.NaN);
   }
 
@@ -279,6 +284,10 @@ public class KGenProgMain {
   private double getNormalizedFitnessValue(final Variant variant) {
     return variant.getFitness()
         .getNormalizedValue();
+  }
+
+  private DecimalFormat createDecimalFormat(){
+    return new DecimalFormat("#.###");
   }
 
   private void logGAStopped(final OrdinalNumber generation) {

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/variant/VariantStore.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/variant/VariantStore.java
@@ -36,6 +36,9 @@ public class VariantStore {
   private final AtomicLong variantCounter;
   private final Function<HistoricalElement, HistoricalElement> elementReplacer;
   private final Consumer<Variant> variantRecorder;
+  private int variantCount;
+  private int syntaxValidVariantCount;
+  private int buildSuccessVariantCount;
 
   /**
    * @param config 設定
@@ -57,6 +60,9 @@ public class VariantStore {
     foundSolutions = new ArrayList<>();
     // 最後に次の世代番号に進めておく
     generation.incrementAndGet();
+    variantCount = 0;
+    syntaxValidVariantCount = 0;
+    buildSuccessVariantCount = 0;
   }
 
   /**
@@ -127,6 +133,27 @@ public class VariantStore {
   public List<Variant> getFoundSolutions(final int maxNumber) {
     final int length = Math.min(maxNumber, foundSolutions.size());
     return foundSolutions.subList(0, length);
+  }
+
+  /**
+   * @return 今まで生成した個体数
+   */
+  public int getVariantCount() {
+    return variantCount;
+  }
+
+  /**
+   * @return 今まで生成した個体のうち、Syntax Valid な個体数
+   */
+  public int getSyntaxValidVariantCount() {
+    return syntaxValidVariantCount;
+  }
+
+  /**
+   * @return 今まで生成した個体のうち、ビルド成功個体数
+   */
+  public int getBuildSuccessVariantCount() {
+    return buildSuccessVariantCount;
   }
 
   /**
@@ -232,5 +259,20 @@ public class VariantStore {
 
   public Configuration getConfiguration() {
     return config;
+  }
+
+  /**
+   * variantCount, syntaxValidVariantCount, buildSuccessVariantCountを更新する
+   *
+   * @param variants 前回の更新以降新たに生成した個体のリスト
+   */
+  public void updateVariantCounts(final List<Variant> variants) {
+    variantCount += variants.size();
+    syntaxValidVariantCount += variants.stream()
+        .filter(Variant::isSyntaxValid)
+        .count();
+    buildSuccessVariantCount += variants.stream()
+        .filter(Variant::isBuildSucceeded)
+        .count();
   }
 }


### PR DESCRIPTION
resolve #735 
resolve #738 

* 世代ごとに出すfitnessの小数を小数点第3位に四捨五入するように
    * これを実現するために `DecimalFormat` クラスのインポート
* kGP終了時に出るメッセージの順番を変更
    * これを実現するために新たな列挙型 `ExitStatus` の作成