### PR TITLE
SimpleMutationにおいて置換対象のプログラム要素に応じた再利用ノードの選択

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
@@ -2,6 +2,8 @@ package jp.kusumotolab.kgenprog.ga.mutation;
 
 import java.util.Random;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.Statement;
 import jp.kusumotolab.kgenprog.ga.mutation.Scope.Type;
 import jp.kusumotolab.kgenprog.ga.mutation.selection.CandidateSelection;
 import jp.kusumotolab.kgenprog.project.ASTLocation;
@@ -19,6 +21,8 @@ import jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation;
  * @see Mutation
  */
 public class SimpleMutation extends Mutation {
+
+  private static final int ATTEMPT_FOR_REPLACE = 100;
 
   protected final Type type;
 
@@ -53,11 +57,23 @@ public class SimpleMutation extends Mutation {
     }
   }
 
+
   protected ASTNode chooseNodeForReuse(final ASTLocation location) {
     final FullyQualifiedName fqn = location.getGeneratedAST()
         .getPrimaryClassName();
     final Scope scope = new Scope(type, fqn);
     final Query query = new Query(scope);
-    return candidateSelection.exec(query);
+
+    ASTNode nodeForReuse = null;
+    int attempt = 0;
+    final boolean isStatement = location instanceof Statement;
+    final boolean isExpression = location instanceof Expression;
+    while(attempt++ < ATTEMPT_FOR_REPLACE){
+      nodeForReuse = candidateSelection.exec(query);
+      if(isStatement && nodeForReuse instanceof Statement || isExpression && nodeForReuse instanceof Expression){
+         break;
+      }
+    }
+    return nodeForReuse;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
@@ -75,17 +75,16 @@ public class SimpleMutation extends Mutation {
     final Scope scope = new Scope(type, fqn);
     final Query query = new Query(scope);
 
-    ASTNode nodeForReuse = null;
     int attempt = 0;
     final boolean isStatement = location.isStatement();
     final boolean isExpression = location.isExpression();
     while (attempt++ < ATTEMPT_FOR_REPLACE) {
-      nodeForReuse = candidateSelection.exec(query);
+      final ASTNode nodeForReuse = candidateSelection.exec(query);
       if (isStatement && nodeForReuse instanceof Statement
           || isExpression && nodeForReuse instanceof Expression) {
-        break;
+        return nodeForReuse;
       }
     }
-    return nodeForReuse;
+    return null;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
@@ -57,7 +57,6 @@ public class SimpleMutation extends Mutation {
     }
   }
 
-
   protected ASTNode chooseNodeForReuse(final ASTLocation location) {
     final FullyQualifiedName fqn = location.getGeneratedAST()
         .getPrimaryClassName();
@@ -66,12 +65,13 @@ public class SimpleMutation extends Mutation {
 
     ASTNode nodeForReuse = null;
     int attempt = 0;
-    final boolean isStatement = location instanceof Statement;
-    final boolean isExpression = location instanceof Expression;
-    while(attempt++ < ATTEMPT_FOR_REPLACE){
+    final boolean isStatement = location.isStatement();
+    final boolean isExpression = location.isExpression();
+    while (attempt++ < ATTEMPT_FOR_REPLACE) {
       nodeForReuse = candidateSelection.exec(query);
-      if(isStatement && nodeForReuse instanceof Statement || isExpression && nodeForReuse instanceof Expression){
-         break;
+      if (isStatement && nodeForReuse instanceof Statement
+          || isExpression && nodeForReuse instanceof Expression) {
+        break;
       }
     }
     return nodeForReuse;

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
@@ -57,6 +57,18 @@ public class SimpleMutation extends Mutation {
     }
   }
 
+  /**
+   * 再利用するASTノードを選択するメソッド．
+   * 再利用先が文の場合は文を，再利用先が式である場合は式を再利用対象として返す．
+   *
+   * Choosing an AST node for reuse.
+   * Chosen node type depends on a given location, which means
+   * if a statement is given, a statement is chosen and
+   * if an expression is given, an expression is chosen.
+   *
+   * @param location 再利用するノードで置換されるノード
+   * @return 再利用するノード
+   */
   protected ASTNode chooseNodeForReuse(final ASTLocation location) {
     final FullyQualifiedName fqn = location.getGeneratedAST()
         .getPrimaryClassName();

--- a/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/SimpleMutation.java
@@ -22,7 +22,7 @@ import jp.kusumotolab.kgenprog.project.jdt.ReplaceOperation;
  */
 public class SimpleMutation extends Mutation {
 
-  private static final int ATTEMPT_FOR_REPLACE = 100;
+  private static final int ATTEMPT_FOR_RESELECTION = 100;
 
   protected final Type type;
 
@@ -78,7 +78,7 @@ public class SimpleMutation extends Mutation {
     int attempt = 0;
     final boolean isStatement = location.isStatement();
     final boolean isExpression = location.isExpression();
-    while (attempt++ < ATTEMPT_FOR_REPLACE) {
+    while (attempt++ < ATTEMPT_FOR_RESELECTION) {
       final ASTNode nodeForReuse = candidateSelection.exec(query);
       if (isStatement && nodeForReuse instanceof Statement
           || isExpression && nodeForReuse instanceof Expression) {

--- a/src/main/java/jp/kusumotolab/kgenprog/output/FileDiffSerializer.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/FileDiffSerializer.java
@@ -48,7 +48,8 @@ public class FileDiffSerializer implements JsonSerializer<FileDiff> {
 
     final JsonObject serializedFileDiff = new JsonObject();
     serializedFileDiff.addProperty("fileName", fileDiff.getFileName());
-    serializedFileDiff.addProperty("diff", fileDiff.getDiff().toString());
+    serializedFileDiff.addProperty("diff", fileDiff.getDiff()
+        .toString());
 
     return serializedFileDiff;
   }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/ASTLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/ASTLocation.java
@@ -14,4 +14,8 @@ public interface ASTLocation {
   LineNumberRange inferLineNumbers();
 
   GeneratedAST<?> getGeneratedAST();
+
+  boolean isStatement();
+
+  boolean isExpression();
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import java.util.List;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
 import jp.kusumotolab.kgenprog.project.ASTLocation;
 import jp.kusumotolab.kgenprog.project.GeneratedAST;
@@ -135,5 +137,20 @@ public class JDTASTLocation implements ASTLocation {
 
     final JDTASTLocation target = (JDTASTLocation) o;
     return node.equals(target.node);
+  }
+
+  @Override
+  public String toString() {
+    return node.toString();
+  }
+
+  @Override
+  public boolean isStatement() {
+    return node instanceof Statement;
+  }
+
+  @Override
+  public boolean isExpression() {
+    return node instanceof Expression;
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/output/PatchGeneratorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/PatchGeneratorTest.java
@@ -1,7 +1,6 @@
 package jp.kusumotolab.kgenprog.output;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
SimpleMutationの置換操作において，置換対象のプログラム要素に応じた再利用ノードの選択処理を実装した．
具体的には，置換対象がプログラム文の場合はプログラム文のみを再利用ノードとして選択，
置換対象が式の場合は式のみを再利用ノードとして選択するようにした．

本来は，Rouletteにおいて再利用対象としないノードの重みを0にする実装が良さそう．
しかし，対象プログラム全体を対象としたRouletteはkGenProgの実行開始時に一度だけ作成され，
重みを与える関するはRouletteのコンストラクタとして与える仕様となっているため，その実装には大規模な改修が必要．
https://github.com/kusumotolab/kGenProg/blob/59944899b179f724d9e8ade768a762f30e7888b6/src/main/java/jp/kusumotolab/kgenprog/ga/mutation/selection/RouletteSelection.java#L59-L63
https://github.com/kusumotolab/kGenProg/blob/59944899b179f724d9e8ade768a762f30e7888b6/src/main/java/jp/kusumotolab/kgenprog/ga/Roulette.java#L30-L33

そのため，SimpleMutation#chooseForReuse において，再利用されたノードが適切ではない場合にもう一度再利用ノードを選択し直す，という方針で実装した．
