### PR TITLE
JDTASTCrossoverLocation の追加

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
@@ -1,0 +1,18 @@
+package jp.kusumotolab.kgenprog.project.jdt;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import jp.kusumotolab.kgenprog.project.SourcePath;
+
+public class JDTASTCrossoverLocation extends JDTASTLocation {
+
+  public JDTASTCrossoverLocation(final SourcePath sourcePath,
+      final ASTNode node, final GeneratedJDTAST<?> generatedAST) {
+    super(sourcePath, node, generatedAST);
+  }
+
+  @Override
+  public ASTNode locate(final ASTNode otherASTRoot) {
+    return null;
+  }
+
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
@@ -1,7 +1,6 @@
 package jp.kusumotolab.kgenprog.project.jdt;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -70,8 +69,6 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
   }
 
   private boolean isSameASTNode(ASTNode a, ASTNode b) {
-//    return a.toString()
-//        .equals(b.toString());// TODO: 正しくない．
     return a.getClass() == b.getClass();
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
@@ -5,6 +5,10 @@ import jp.kusumotolab.kgenprog.project.SourcePath;
 
 public class JDTASTCrossoverLocation extends JDTASTLocation {
 
+  public JDTASTCrossoverLocation(final JDTASTLocation location) {
+    super(location.getSourcePath(), location.getNode(), location.getGeneratedAST());
+  }
+
   public JDTASTCrossoverLocation(final SourcePath sourcePath,
       final ASTNode node, final GeneratedJDTAST<?> generatedAST) {
     super(sourcePath, node, generatedAST);
@@ -12,7 +16,8 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
 
   @Override
   public ASTNode locate(final ASTNode otherASTRoot) {
-    return null;
+    // call super as mock
+    return super.locate(otherASTRoot);
   }
 
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
@@ -1,6 +1,13 @@
 package jp.kusumotolab.kgenprog.project.jdt;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
 import jp.kusumotolab.kgenprog.project.SourcePath;
 
 public class JDTASTCrossoverLocation extends JDTASTLocation {
@@ -16,8 +23,55 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
 
   @Override
   public ASTNode locate(final ASTNode otherASTRoot) {
-    // call super as mock
-    return super.locate(otherASTRoot);
+    final List<ASTNode> treePaths = new ArrayList<>();
+    ASTNode currentNode = node;
+    do {
+      treePaths.add(currentNode);
+      currentNode = currentNode.getParent();
+    } while (currentNode != null);
+
+    treePaths.remove(treePaths.size() - 1);
+    Collections.reverse(treePaths);
+
+    List<ASTNode> possibleNode = new ArrayList<>();
+    possibleNode.add(otherASTRoot);
+    for (final ASTNode path : treePaths) {//これと比べる．これが正解．
+      final List<ASTNode> nextPossibleNode = new ArrayList<>();
+      for (final ASTNode current : possibleNode) {
+        getChildren(current).stream()
+            .filter(e -> isSameASTNode(path, e))
+            .forEach(nextPossibleNode::add);
+      }
+      possibleNode = nextPossibleNode;
+    }
+
+    possibleNode = possibleNode.stream()
+        .filter(e -> treePaths.get(treePaths.size() - 1)
+            .toString()
+            .equals(e.toString()))
+        .collect(Collectors.toList());
+
+    return possibleNode.isEmpty() ? null : possibleNode.get(0);
   }
 
+  private List<ASTNode> getChildren(ASTNode node) {
+    List<ASTNode> children = new ArrayList<>();
+    for (final Object o : node.structuralPropertiesForType()) {
+      Object child = node.getStructuralProperty((StructuralPropertyDescriptor) o);
+      if (child instanceof ASTNode) {
+        children.add((ASTNode) child);
+      } else if (child instanceof List) {
+        @SuppressWarnings("unchecked") // List の要素は必ず ASTNode
+        final List<ASTNode> c = (List<ASTNode>) child;
+        children.addAll(c);
+      }
+    }
+    return children;
+  }
+
+  private boolean isSameASTNode(ASTNode a, ASTNode b) {
+//    return a.toString()
+//        .equals(b.toString());// TODO: 正しくない．
+    return a.getClass() == b.getClass();
+  }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
@@ -9,6 +9,9 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
 import jp.kusumotolab.kgenprog.project.SourcePath;
 
+/**
+ * JDT AST の単一ノードを示すオブジェクト 交叉で個体を生成するときの Operation のターゲットに利用する．
+ */
 public class JDTASTCrossoverLocation extends JDTASTLocation {
 
   public JDTASTCrossoverLocation(final JDTASTLocation location) {
@@ -20,6 +23,10 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
     super(sourcePath, node, generatedAST);
   }
 
+  /**
+   * @param otherASTRoot 探索対象の別 AST のルート
+   * @return 探索に成功したとき，その AST ノード．探索対象のAST ノードが存在しないとき null
+   */
   @Override
   public ASTNode locate(final ASTNode otherASTRoot) {
     final List<ASTNode> treePaths = new ArrayList<>();

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
@@ -25,7 +25,7 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
 
   /**
    * @param otherASTRoot 探索対象の別 AST のルート
-   * @return 探索に成功したとき，その AST ノード．探索対象のAST ノードが存在しないとき null
+   * @return 探索に成功したとき，その AST ノード．探索対象のAST ノードが存在しないとき null．
    */
   @Override
   public ASTNode locate(final ASTNode otherASTRoot) {
@@ -60,22 +60,22 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
     return possibleNode.isEmpty() ? null : possibleNode.get(0);
   }
 
-  private List<ASTNode> getChildren(ASTNode node) {
-    List<ASTNode> children = new ArrayList<>();
+  private List<ASTNode> getChildren(final ASTNode node) {
+    final List<ASTNode> children = new ArrayList<>();
     for (final Object o : node.structuralPropertiesForType()) {
-      Object child = node.getStructuralProperty((StructuralPropertyDescriptor) o);
-      if (child instanceof ASTNode) {
-        children.add((ASTNode) child);
-      } else if (child instanceof List) {
-        @SuppressWarnings("unchecked") // List の要素は必ず ASTNode
-        final List<ASTNode> c = (List<ASTNode>) child;
+      final Object childOrChildren = node.getStructuralProperty((StructuralPropertyDescriptor) o);
+      if (childOrChildren instanceof ASTNode) {
+        children.add((ASTNode) childOrChildren);
+      } else if (childOrChildren instanceof List) {
+        @SuppressWarnings("unchecked") // このとき，List の要素は必ず ASTNode
+        final List<ASTNode> c = (List<ASTNode>) childOrChildren;
         children.addAll(c);
       }
     }
     return children;
   }
 
-  private boolean isSameASTNodeType(ASTNode a, ASTNode b) {
+  private boolean isSameASTNodeType(final ASTNode a, final ASTNode b) {
     return a.getClass() == b.getClass();
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
@@ -38,7 +38,7 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
       final List<ASTNode> nextPossibleNode = new ArrayList<>();
       for (final ASTNode current : possibleNode) {
         getChildren(current).stream()
-            .filter(e -> isSameASTNode(path, e))
+            .filter(e -> isSameASTNodeType(path, e))
             .forEach(nextPossibleNode::add);
       }
       possibleNode = nextPossibleNode;
@@ -68,7 +68,7 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
     return children;
   }
 
-  private boolean isSameASTNode(ASTNode a, ASTNode b) {
+  private boolean isSameASTNodeType(ASTNode a, ASTNode b) {
     return a.getClass() == b.getClass();
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
-import jp.kusumotolab.kgenprog.project.SourcePath;
 
 /**
  * JDT AST の単一ノードを示すオブジェクト 交叉で個体を生成するときの Operation のターゲットに利用する．
@@ -18,11 +17,6 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
     super(location.getSourcePath(), location.getNode(), location.getGeneratedAST());
   }
 
-  public JDTASTCrossoverLocation(final SourcePath sourcePath,
-      final ASTNode node, final GeneratedJDTAST<?> generatedAST) {
-    super(sourcePath, node, generatedAST);
-  }
-
   /**
    * @param otherASTRoot 探索対象の別 AST のルート
    * @return 探索に成功したとき，その AST ノード．探索対象のAST ノードが存在しないとき null．
@@ -31,33 +25,33 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
   public ASTNode locate(final ASTNode otherASTRoot) {
     final List<ASTNode> treePaths = new ArrayList<>();
     ASTNode currentNode = node;
-    do {
+    while (currentNode != null) {
       treePaths.add(currentNode);
       currentNode = currentNode.getParent();
-    } while (currentNode != null);
-
-    treePaths.remove(treePaths.size() - 1);
-    Collections.reverse(treePaths);
-
-    List<ASTNode> possibleNode = new ArrayList<>();
-    possibleNode.add(otherASTRoot);
-    for (final ASTNode path : treePaths) {//これと比べる．これが正解．
-      final List<ASTNode> nextPossibleNode = new ArrayList<>();
-      for (final ASTNode current : possibleNode) {
-        getChildren(current).stream()
-            .filter(e -> isSameASTNodeType(path, e))
-            .forEach(nextPossibleNode::add);
-      }
-      possibleNode = nextPossibleNode;
     }
 
-    possibleNode = possibleNode.stream()
-        .filter(e -> treePaths.get(treePaths.size() - 1)
-            .toString()
-            .equals(e.toString()))
+    treePaths.remove(treePaths.size() - 1); // remove compilationunit
+    Collections.reverse(treePaths);
+
+    List<ASTNode> possibleNodes = new ArrayList<>();
+    possibleNodes.add(otherASTRoot);
+    for (final ASTNode path : treePaths) {//これと比べる．これが正解．
+      final List<ASTNode> nextPossibleNodes = new ArrayList<>();
+      for (final ASTNode current : possibleNodes) {
+        getChildren(current).stream()
+            .filter(e -> isSameASTNodeType(path, e))
+            .forEach(nextPossibleNodes::add);
+      }
+      possibleNodes = nextPossibleNodes;
+    }
+
+    possibleNodes = possibleNodes.stream()
+        .filter(e -> isSameSourceCode(node, e))
         .collect(Collectors.toList());
 
-    return possibleNode.isEmpty() ? null : possibleNode.get(0);
+    //解が複数存在するときは，とりあえず最初のものを返している．
+    //TODO: 解が複数存在するときの適切な振る舞いを考える．
+    return possibleNodes.isEmpty() ? null : possibleNodes.get(0);
   }
 
   private List<ASTNode> getChildren(final ASTNode node) {
@@ -77,5 +71,10 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
 
   private boolean isSameASTNodeType(final ASTNode a, final ASTNode b) {
     return a.getClass() == b.getClass();
+  }
+
+  private boolean isSameSourceCode(final ASTNode a, final ASTNode b) {
+    return a.toString()
+        .compareTo(b.toString()) == 0;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
@@ -7,7 +7,6 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
 import jp.kusumotolab.kgenprog.project.ASTLocation;
-import jp.kusumotolab.kgenprog.project.GeneratedAST;
 import jp.kusumotolab.kgenprog.project.LineNumberRange;
 import jp.kusumotolab.kgenprog.project.SourcePath;
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
@@ -20,7 +20,6 @@ import jp.kusumotolab.kgenprog.project.SourcePath;
 public class JDTASTLocation implements ASTLocation {
 
   public final ASTNode node;
-
   private final SourcePath sourcePath;
   private final GeneratedJDTAST<?> generatedAST;
 
@@ -31,6 +30,13 @@ public class JDTASTLocation implements ASTLocation {
     this.generatedAST = generatedAST;
   }
 
+  /**
+   * 別ASTでの同形部分を取り出す．
+   * 具体的には，このLocationオブジェクトを起点とした親への木構造を取り出し，別ASTから同形部分を探索する．
+   *
+   * @param otherASTRoot 探索対象の別ASTのルート
+   * @return
+   */
   public ASTNode locate(final ASTNode otherASTRoot) {
     final List<TreePathElement> treePaths = new ArrayList<>();
     ASTNode currentNode = node;

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTLocation.java
@@ -115,7 +115,7 @@ public class JDTASTLocation implements ASTLocation {
   }
 
   @Override
-  public GeneratedAST<?> getGeneratedAST() {
+  public GeneratedJDTAST<?> getGeneratedAST() {
     return generatedAST;
   }
 

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/ASTNodeAssert.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/ASTNodeAssert.java
@@ -55,6 +55,16 @@ public class ASTNodeAssert extends AbstractAssert<ASTNodeAssert, ASTNode> {
   }
 
   /**
+   * astのルートノードが同じオブジェクトかを確かめる．
+   *
+   * @param sourceCode
+   * @return
+   */
+  public ASTNodeAssert isSameRootClassAs(final ASTNode ast) {
+    return assertThat(ast.getRoot()).hasSameClassAs(actual.getRoot());
+  }
+
+  /**
    * eclipse.jdt.coreを使ったフォーマッタ．
    *
    * @param source

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
@@ -1,0 +1,11 @@
+package jp.kusumotolab.kgenprog.project.jdt;
+
+import org.junit.Test;
+
+public class JDTASTCrossoverLocationTest {
+
+  @Test
+  public void testLocation() {
+
+  }
+}

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
@@ -1,11 +1,226 @@
 package jp.kusumotolab.kgenprog.project.jdt;
 
+import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
+import java.nio.file.Paths;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.junit.Test;
+import jp.kusumotolab.kgenprog.project.ASTLocations;
+import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 
 public class JDTASTCrossoverLocationTest {
 
   @Test
-  public void testLocation() {
+  public void testLocateForTheSameAst() {
+    final String source = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final GeneratedJDTAST<ProductSourcePath> ast = createAst(source);
 
+    // extract target location
+    final JDTASTLocation location = getLocation(ast, 1);
+    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try locate() for the same ast root
+    final ASTNode node = location.locate(ast.getRoot());
+
+    // of course, target node and located node are the same
+    assertThat(node).isSameSourceCodeAs("i=1;");
+    assertThat(node.getRoot()).isSameRootClassAs(ast.getRoot());
   }
+
+  @Test
+  public void testLocateForSameContentAst() {
+    final String source = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    // generate two asts (contents are the same but they are different object)
+    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source);
+    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast1, 1);
+    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try loc1.locate()
+    final ASTNode node = location.locate(ast2.getRoot());
+
+    // located node is the same as target node
+    assertThat(node).isSameSourceCodeAs("i=1;");
+    assertThat(node).isSameRootClassAs(ast2.getRoot());
+  }
+
+  @Test
+  public void testLocateForDifferentAst01() {
+    final String source1 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final String source2 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 2;")
+        .append("    i = 1;") // target
+        .append("  }")
+        .append("}")
+        .toString();
+
+    // generate two asts
+    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
+    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source2);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast1, 1);
+    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try loc1.locate()
+    final ASTNode node = location.locate(ast2.getRoot());
+
+    // located node is the same as target node
+    assertThat(node).isSameSourceCodeAs("i=1;");
+    assertThat(node).isSameRootClassAs(ast2.getRoot());
+  }
+
+  @Test
+  public void testLocateForDifferentAst02() {
+    final String source1 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final String source2 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    if (true) {")
+        .append("      i = 2;")
+        .append("    }")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    // generate two asts
+    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
+    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source2);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast1, 1);
+    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try loc1.locate()
+    final ASTNode node = location.locate(ast2.getRoot());
+
+    // located node is the same as target node
+    assertThat(node).isSameSourceCodeAs("i=1;");
+    assertThat(node).isSameRootClassAs(ast2.getRoot());
+  }
+
+  @Test
+  public void testLocateForDifferentAst03() {
+    final String source1 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final String source2 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    if (true) {")
+        .append("      i = 1;") // target
+        .append("    }")
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    // generate two asts
+    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
+    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source2);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast1, 1);
+    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try loc1.locate()
+    final ASTNode node = location.locate(ast2.getRoot());
+
+    // failed to locate
+    assertThat(node).isNull();
+  }
+
+  @Test
+  public void testLocateForDifferentAst04() {
+    final String source1 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final String source2 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    // generate two asts
+    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
+    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source2);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast1, 1);
+    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try loc1.locate()
+    final ASTNode node = location.locate(ast2.getRoot());
+
+    // failed to locate
+    assertThat(node).isNull();
+  }
+
+  private GeneratedJDTAST<ProductSourcePath> createAst(final String source) {
+    final String fname = source.hashCode() + ".java"; // dummy file name
+    final ProductSourcePath path = new ProductSourcePath(Paths.get("."), Paths.get(fname));
+    final JDTASTConstruction constructor = new JDTASTConstruction();
+    return constructor.constructAST(path, source);
+  }
+
+  private JDTASTCrossoverLocation getLocation(GeneratedJDTAST<ProductSourcePath> ast, int idx) {
+    final ASTLocations locs = ast.createLocations();
+    final JDTASTLocation loc = (JDTASTLocation) locs.getAll()
+        .get(idx);
+    return new JDTASTCrossoverLocation(loc);
+  }
+
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
@@ -10,7 +10,7 @@ import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 public class JDTASTCrossoverLocationTest {
 
   @Test
-  public void testLocateForTheSameAst() {
+  public void testLocateForTheSameAst01() {
     final String source = new StringBuilder()
         .append("class A {")
         .append("  public void a(int i) {")
@@ -24,13 +24,66 @@ public class JDTASTCrossoverLocationTest {
 
     // extract target location
     final JDTASTLocation location = getLocation(ast, 1);
-    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+    final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
+    assertThat(cLocation.getNode()).isSameSourceCodeAs("i=1;");
 
     // try locate() for the same ast root
-    final ASTNode node = location.locate(ast.getRoot());
+    final ASTNode node = cLocation.locate(ast.getRoot());
 
     // of course, target node and located node are the same
     assertThat(node).isSameSourceCodeAs("i=1;");
+    assertThat(node.getRoot()).isSameRootClassAs(ast.getRoot());
+  }
+
+  @Test
+  public void testLocateForTheSameAst02() {
+    final String source = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 1;") // target
+        .append("    i = 1;")
+        .append("    i = 1;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final GeneratedJDTAST<ProductSourcePath> ast = createAst(source);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast, 0);
+    final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
+    assertThat(cLocation.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try locate() for the same ast root
+    final ASTNode node = cLocation.locate(ast.getRoot());
+
+    // of course, target node and located node are the same
+    assertThat(node).isEqualTo(location.getNode());
+    assertThat(node.getRoot()).isSameRootClassAs(ast.getRoot());
+  }
+
+  @Test
+  public void testLocateForTheSameAst03() {
+    final String source = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 1;")
+        .append("    i = 1;") // target
+        .append("    i = 1;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final GeneratedJDTAST<ProductSourcePath> ast = createAst(source);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast, 1);
+    final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
+    assertThat(cLocation.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try locate() for the same ast root
+    final ASTNode node = cLocation.locate(ast.getRoot());
+
+    // there are the same nodes as target node, so located node is the first one
+    assertThat(node).isNotEqualTo(location.getNode());
     assertThat(node.getRoot()).isSameRootClassAs(ast.getRoot());
   }
 
@@ -52,10 +105,11 @@ public class JDTASTCrossoverLocationTest {
 
     // extract target location
     final JDTASTLocation location = getLocation(ast1, 1);
-    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+    final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
+    assertThat(cLocation.getNode()).isSameSourceCodeAs("i=1;");
 
     // try loc1.locate()
-    final ASTNode node = location.locate(ast2.getRoot());
+    final ASTNode node = cLocation.locate(ast2.getRoot());
 
     // located node is the same as target node
     assertThat(node).isSameSourceCodeAs("i=1;");
@@ -89,10 +143,11 @@ public class JDTASTCrossoverLocationTest {
 
     // extract target location
     final JDTASTLocation location = getLocation(ast1, 1);
-    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+    final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
+    assertThat(cLocation.getNode()).isSameSourceCodeAs("i=1;");
 
     // try loc1.locate()
-    final ASTNode node = location.locate(ast2.getRoot());
+    final ASTNode node = cLocation.locate(ast2.getRoot());
 
     // located node is the same as target node
     assertThat(node).isSameSourceCodeAs("i=1;");
@@ -128,10 +183,11 @@ public class JDTASTCrossoverLocationTest {
 
     // extract target location
     final JDTASTLocation location = getLocation(ast1, 1);
-    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+    final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
+    assertThat(cLocation.getNode()).isSameSourceCodeAs("i=1;");
 
     // try loc1.locate()
-    final ASTNode node = location.locate(ast2.getRoot());
+    final ASTNode node = cLocation.locate(ast2.getRoot());
 
     // located node is the same as target node
     assertThat(node).isSameSourceCodeAs("i=1;");
@@ -167,10 +223,11 @@ public class JDTASTCrossoverLocationTest {
 
     // extract target location
     final JDTASTLocation location = getLocation(ast1, 1);
-    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+    final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
+    assertThat(cLocation.getNode()).isSameSourceCodeAs("i=1;");
 
     // try loc1.locate()
-    final ASTNode node = location.locate(ast2.getRoot());
+    final ASTNode node = cLocation.locate(ast2.getRoot());
 
     // failed to locate
     assertThat(node).isNull();
@@ -200,10 +257,11 @@ public class JDTASTCrossoverLocationTest {
 
     // extract target location
     final JDTASTLocation location = getLocation(ast1, 1);
-    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+    final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
+    assertThat(cLocation.getNode()).isSameSourceCodeAs("i=1;");
 
     // try loc1.locate()
-    final ASTNode node = location.locate(ast2.getRoot());
+    final ASTNode node = cLocation.locate(ast2.getRoot());
 
     // failed to locate
     assertThat(node).isNull();
@@ -216,11 +274,9 @@ public class JDTASTCrossoverLocationTest {
     return constructor.constructAST(path, source);
   }
 
-  private JDTASTCrossoverLocation getLocation(GeneratedJDTAST<ProductSourcePath> ast, int idx) {
+  private JDTASTLocation getLocation(GeneratedJDTAST<ProductSourcePath> ast, int idx) {
     final ASTLocations locs = ast.createLocations();
-    final JDTASTLocation loc = (JDTASTLocation) locs.getAll()
+    return (JDTASTLocation) locs.getAll()
         .get(idx);
-    return new JDTASTCrossoverLocation(loc);
   }
-
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTLocationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTLocationTest.java
@@ -1,17 +1,14 @@
 package jp.kusumotolab.kgenprog.project.jdt;
 
-import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.junit.Test;
 import jp.kusumotolab.kgenprog.project.ASTLocation;
-import jp.kusumotolab.kgenprog.project.ASTLocations;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.LineNumberRange;
 import jp.kusumotolab.kgenprog.project.ProductSourcePath;
@@ -21,182 +18,6 @@ import jp.kusumotolab.kgenprog.testutil.ExampleAlias.Src;
 import jp.kusumotolab.kgenprog.testutil.TestUtil;
 
 public class JDTLocationTest {
-
-  @Test
-  public void testLocateForTheSameAst() {
-    final String source = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
-    final GeneratedJDTAST<ProductSourcePath> ast = createAst(source);
-
-    // extract target location
-    final JDTASTLocation locate = getLocation(ast, 1);
-    assertThat(locate.getNode()).isSameSourceCodeAs("i=1;");
-
-    // try locate() for the same ast root
-    final ASTNode node = locate.locate(ast.getRoot());
-
-    // of course, target node and located node are the same
-    assertThat(node).isSameSourceCodeAs("i=1;");
-    assertThat(node.getRoot()).hasSameClassAs(ast.getRoot());
-  }
-
-  @Test
-  public void testLocateForSameContentAst() {
-    final String source = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
-
-    // generate two asts (contents are the same but they are different object)
-    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source);
-    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source);
-
-    // extract target location
-    final JDTASTLocation location = getLocation(ast1, 1);
-    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
-
-    // try loc1.locate()
-    final ASTNode node = location.locate(ast2.getRoot());
-
-    // located node is the same as target node
-    assertThat(node).isSameSourceCodeAs("i=1;");
-    assertThat(node).isSameRootClassAs(ast2.getRoot());
-  }
-
-  @Test
-  public void testLocateForDifferentAst01() {
-    final String source1 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
-    final String source2 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 2;")
-        .append("    i = 1;") // target
-        .append("  }")
-        .append("}")
-        .toString();
-
-    // generate two asts
-    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
-    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source2);
-
-    // extract target location
-    final JDTASTLocation location = getLocation(ast1, 1);
-    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
-
-    // try loc1.locate()
-    final ASTNode node = location.locate(ast2.getRoot());
-
-    // located node is the same as target node
-    assertThat(node).isSameSourceCodeAs("i=1;");
-    assertThat(node).isSameRootClassAs(ast2.getRoot());
-  }
-
-  @Test
-  public void testLocateForDifferentAst02() {
-    final String source1 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
-    final String source2 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    if (true) {")
-        .append("      i = 1;") // target
-        .append("    }")
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
-
-    // generate two asts
-    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
-    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source2);
-
-    // extract target location
-    final JDTASTLocation location = getLocation(ast1, 1);
-    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
-
-    // try loc1.locate()
-    final ASTNode node = location.locate(ast2.getRoot());
-
-    // located node is the same as target node
-    assertThat(node).isSameSourceCodeAs("i=1;");
-    assertThat(node).isSameRootClassAs(ast2.getRoot());
-  }
-
-  @Test
-  public void testLocateForDifferentAst03() {
-    final String source1 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
-    final String source2 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("  }")
-        .append("}")
-        .toString();
-
-    // generate two asts
-    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
-    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source2);
-
-    // extract target location
-    final JDTASTLocation location = getLocation(ast1, 1);
-    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
-
-    // try loc1.locate()
-    final ASTNode node = location.locate(ast2.getRoot());
-
-    // located node is the same as target node
-    assertThat(node).isSameSourceCodeAs("i=1;");
-    assertThat(node).isSameRootClassAs(ast2.getRoot());
-  }
-
-  private GeneratedJDTAST<ProductSourcePath> createAst(final String source) {
-    final String fname = source.hashCode() + ".java"; // dummy file name
-    final ProductSourcePath path = new ProductSourcePath(Paths.get("."), Paths.get(fname));
-    final JDTASTConstruction constructor = new JDTASTConstruction();
-    return constructor.constructAST(path, source);
-  }
-
-  private JDTASTLocation getLocation(GeneratedJDTAST<ProductSourcePath> ast, int idx) {
-    final ASTLocations locs = ast.createLocations();
-    return (JDTASTLocation) locs.getAll()
-        .get(idx);
-  }
 
   @Test
   public void testInferLineNumbers() {

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTLocationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTLocationTest.java
@@ -1,14 +1,17 @@
 package jp.kusumotolab.kgenprog.project.jdt;
 
+import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.junit.Test;
 import jp.kusumotolab.kgenprog.project.ASTLocation;
+import jp.kusumotolab.kgenprog.project.ASTLocations;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.LineNumberRange;
 import jp.kusumotolab.kgenprog.project.ProductSourcePath;
@@ -18,6 +21,182 @@ import jp.kusumotolab.kgenprog.testutil.ExampleAlias.Src;
 import jp.kusumotolab.kgenprog.testutil.TestUtil;
 
 public class JDTLocationTest {
+
+  @Test
+  public void testLocateForTheSameAst() {
+    final String source = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final GeneratedJDTAST<ProductSourcePath> ast = createAst(source);
+
+    // extract target location
+    final JDTASTLocation locate = getLocation(ast, 1);
+    assertThat(locate.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try locate() for the same ast root
+    final ASTNode node = locate.locate(ast.getRoot());
+
+    // of course, target node and located node are the same
+    assertThat(node).isSameSourceCodeAs("i=1;");
+    assertThat(node.getRoot()).hasSameClassAs(ast.getRoot());
+  }
+
+  @Test
+  public void testLocateForSameContentAst() {
+    final String source = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    // generate two asts (contents are the same but they are different object)
+    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source);
+    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast1, 1);
+    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try loc1.locate()
+    final ASTNode node = location.locate(ast2.getRoot());
+
+    // located node is the same as target node
+    assertThat(node).isSameSourceCodeAs("i=1;");
+    assertThat(node).isSameRootClassAs(ast2.getRoot());
+  }
+
+  @Test
+  public void testLocateForDifferentAst01() {
+    final String source1 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final String source2 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 2;")
+        .append("    i = 1;") // target
+        .append("  }")
+        .append("}")
+        .toString();
+
+    // generate two asts
+    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
+    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source2);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast1, 1);
+    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try loc1.locate()
+    final ASTNode node = location.locate(ast2.getRoot());
+
+    // located node is the same as target node
+    assertThat(node).isSameSourceCodeAs("i=1;");
+    assertThat(node).isSameRootClassAs(ast2.getRoot());
+  }
+
+  @Test
+  public void testLocateForDifferentAst02() {
+    final String source1 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final String source2 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    if (true) {")
+        .append("      i = 1;") // target
+        .append("    }")
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    // generate two asts
+    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
+    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source2);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast1, 1);
+    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try loc1.locate()
+    final ASTNode node = location.locate(ast2.getRoot());
+
+    // located node is the same as target node
+    assertThat(node).isSameSourceCodeAs("i=1;");
+    assertThat(node).isSameRootClassAs(ast2.getRoot());
+  }
+
+  @Test
+  public void testLocateForDifferentAst03() {
+    final String source1 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    i = 0;")
+        .append("    i = 1;") // target
+        .append("    i = 2;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final String source2 = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("  }")
+        .append("}")
+        .toString();
+
+    // generate two asts
+    final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
+    final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source2);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast1, 1);
+    assertThat(location.getNode()).isSameSourceCodeAs("i=1;");
+
+    // try loc1.locate()
+    final ASTNode node = location.locate(ast2.getRoot());
+
+    // located node is the same as target node
+    assertThat(node).isSameSourceCodeAs("i=1;");
+    assertThat(node).isSameRootClassAs(ast2.getRoot());
+  }
+
+  private GeneratedJDTAST<ProductSourcePath> createAst(final String source) {
+    final String fname = source.hashCode() + ".java"; // dummy file name
+    final ProductSourcePath path = new ProductSourcePath(Paths.get("."), Paths.get(fname));
+    final JDTASTConstruction constructor = new JDTASTConstruction();
+    return constructor.constructAST(path, source);
+  }
+
+  private JDTASTLocation getLocation(GeneratedJDTAST<ProductSourcePath> ast, int idx) {
+    final ASTLocations locs = ast.createLocations();
+    return (JDTASTLocation) locs.getAll()
+        .get(idx);
+  }
 
   @Test
   public void testInferLineNumbers() {


### PR DESCRIPTION
related to #755 #764

JDTASTLocation#locate はASTの構造情報のみで探索を行っていた．
これが #755 の原因である．

そこで，AST をノードの種類で探索する JDTASTCrossoverLocation を追加する．
この PR ではファイルの追加のみを行う．


