### PR TITLE
CrossoverLocation のバグを修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
 
@@ -23,47 +22,56 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
    */
   @Override
   public ASTNode locate(final ASTNode otherASTRoot) {
-    final List<ASTNode> treePaths = new ArrayList<>();
-    ASTNode currentNode = node;
-    while (currentNode != null) {
-      treePaths.add(currentNode);
-      currentNode = currentNode.getParent();
-    }
 
-    treePaths.remove(treePaths.size() - 1); // remove compilationunit
-    Collections.reverse(treePaths);
+    final List<TreePathElement> treePaths = makePath(node);
+    treePaths.remove(0); // remove compilationUnit
 
-    List<ASTNode> possibleNodes = new ArrayList<>();
-    possibleNodes.add(otherASTRoot);
-    for (final ASTNode path : treePaths) {//これと比べる．これが正解．
-      final List<ASTNode> nextPossibleNodes = new ArrayList<>();
-      for (final ASTNode current : possibleNodes) {
-        getChildren(current).stream()
-            .filter(e -> isSameASTNodeType(path, e))
+    List<TreePathElement> possibleNodes = new ArrayList<>();
+    possibleNodes.add(new TreePathElement(otherASTRoot));
+    for (final TreePathElement path : treePaths) {//これと比べる．これが正解．
+      final List<TreePathElement> nextPossibleNodes = new ArrayList<>();
+      for (final TreePathElement current : possibleNodes) {
+        getChildren(current.getNode()).stream()
+            .filter(e -> isSameASTNodeType(path.getNode(), e.getNode()) && path.isSameDescriptor(e))
             .forEach(nextPossibleNodes::add);
       }
       possibleNodes = nextPossibleNodes;
     }
 
     possibleNodes = possibleNodes.stream()
-        .filter(e -> isSameSourceCode(node, e))
+        .filter(e -> isSameSourceCode(node, e.getNode()))
         .collect(Collectors.toList());
 
     //解が複数存在するときは，とりあえず最初のものを返している．
     //TODO: 解が複数存在するときの適切な振る舞いを考える．
-    return possibleNodes.isEmpty() ? null : possibleNodes.get(0);
+    return possibleNodes.isEmpty() ? null : possibleNodes.get(0)
+        .getNode();
   }
 
-  private List<ASTNode> getChildren(final ASTNode node) {
-    final List<ASTNode> children = new ArrayList<>();
+  private List<TreePathElement> makePath(final ASTNode n) {
+    final List<TreePathElement> treePaths = new ArrayList<>();
+    ASTNode currentNode = n;
+    while (currentNode != null) {
+      treePaths.add(new TreePathElement(currentNode));
+      currentNode = currentNode.getParent();
+    }
+
+    Collections.reverse(treePaths);
+    return treePaths;
+  }
+
+  private List<TreePathElement> getChildren(final ASTNode node) {
+    final List<TreePathElement> children = new ArrayList<>();
     for (final Object o : node.structuralPropertiesForType()) {
       final Object childOrChildren = node.getStructuralProperty((StructuralPropertyDescriptor) o);
       if (childOrChildren instanceof ASTNode) {
-        children.add((ASTNode) childOrChildren);
+        children.add(new TreePathElement((ASTNode) childOrChildren));
       } else if (childOrChildren instanceof List) {
         @SuppressWarnings("unchecked") // このとき，List の要素は必ず ASTNode
         final List<ASTNode> c = (List<ASTNode>) childOrChildren;
-        children.addAll(c);
+        c.stream()
+            .map(TreePathElement::new)
+            .forEach(children::add);
       }
     }
     return children;

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocation.java
@@ -77,4 +77,27 @@ public class JDTASTCrossoverLocation extends JDTASTLocation {
     return a.toString()
         .compareTo(b.toString()) == 0;
   }
+
+  private static class TreePathElement {
+
+    private final ASTNode node;
+    private final StructuralPropertyDescriptor descriptor;
+
+    public TreePathElement(final ASTNode node) {
+      this(node, node.getLocationInParent());
+    }
+
+    public TreePathElement(final ASTNode node, final StructuralPropertyDescriptor descriptor) {
+      this.node = node;
+      this.descriptor = descriptor;
+    }
+
+    public boolean isSameDescriptor(final TreePathElement t) {
+      return this.descriptor == t.descriptor;
+    }
+
+    public ASTNode getNode() {
+      return node;
+    }
+  }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
@@ -2,6 +2,8 @@ package jp.kusumotolab.kgenprog.project.jdt;
 
 import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.junit.Test;
 import jp.kusumotolab.kgenprog.project.ASTLocations;
@@ -52,8 +54,8 @@ public class JDTASTCrossoverLocationTest {
     // try locate() for the same ast root
     final ASTNode node = cLocation.locate(ast.getRoot());
 
-    // of course, target node and located node are the same
-    assertThat(node).isEqualTo(location.getNode());
+    // of course, target node and located node are the same instance
+    assertThat(node).isSameAs(location.getNode());
     assertThat(node.getRoot()).isSameRootClassAs(ast.getRoot());
   }
 
@@ -76,8 +78,9 @@ public class JDTASTCrossoverLocationTest {
     // try locate() for the same ast root
     final ASTNode node = cLocation.locate(ast.getRoot());
 
-    // there are the same nodes as target node, so located node is the first one
-    assertThat(node).isNotEqualTo(location.getNode());
+    // there are the same nodes as target node, so located node is not target node but first one
+    assertThat(node).isNotSameAs(location.getNode());
+    assertThat(node).isSameAs(getLocation(ast, 0).getNode());
     assertThat(node.getRoot()).isSameRootClassAs(ast.getRoot());
   }
 
@@ -86,40 +89,38 @@ public class JDTASTCrossoverLocationTest {
     final String source = "class A {"
         + "  public void a(int i) {"
         + "    if (true) {"
-        + "      i = 2;"
-        + "      i = 3;"
+        + "      i = 1;" // target
         + "      if (true) {"
-        + "        i = 2;"
-        + "        i = 3;"
+        + "        i = 1;" // target
         + "      } else {"
-        + "        i = 2;"
-        + "        i = 3;"
+        + "        i = 1;" // target
         + "      }"
         + "    } else {"
-        + "      i = 2;"
-        + "      i = 3;"
+        + "      i = 1;" // target
         + "      if (true) {"
-        + "        i = 2;" //target
-        + "        i = 3;"
+        + "        i = 1;" // target
         + "      } else {"
-        + "        i = 2;"
-        + "        i = 3;"
+        + "        i = 1;" // target
         + "      }"
         + "    }"
         + "}";
     final GeneratedJDTAST<ProductSourcePath> ast = createAst(source);
 
-    // extract target location
-    final JDTASTLocation location = getLocation(ast, 14);
-    final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
-    assertThat(cLocation.getNode()).isSameSourceCodeAs("i=2;");
+    final List<Integer> ids = Arrays.asList(1, 2, 3, 6, 7, 8); // These nodes have i=1
 
-    // try locate() for the same ast root
-    final ASTNode node = cLocation.locate(ast.getRoot());
+    for (int i : ids) {
+      // extract target location
+      final JDTASTLocation location = getLocation(ast, i);
+      final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
+      assertThat(cLocation.getNode()).isSameSourceCodeAs("i=1;");
 
-    // located node is the same as target node
-    assertThat(node).isEqualTo(location.getNode());
-    assertThat(node.getRoot()).isSameRootClassAs(ast.getRoot());
+      // try locate() for the same ast root
+      final ASTNode node = cLocation.locate(ast.getRoot());
+
+      // located node is the same instance as target node
+      assertThat(node).isSameAs(location.getNode());
+      assertThat(node.getRoot()).isSameRootClassAs(ast.getRoot());
+    }
   }
 
   @Test
@@ -132,7 +133,7 @@ public class JDTASTCrossoverLocationTest {
         + "  }"
         + "}";
 
-    // generate two asts (contents are the same but they are different object)
+    // generate two asts (contents are the same but they are different instances)
     final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source);
     final GeneratedJDTAST<ProductSourcePath> ast2 = createAst(source);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
@@ -11,15 +11,13 @@ public class JDTASTCrossoverLocationTest {
 
   @Test
   public void testLocateForTheSameAst01() {
-    final String source = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
+    final String source = "class A {"
+        + "  public void a(int i) {"
+        + "    i = 0;"
+        + "    i = 1;" // target
+        + "    i = 2;"
+        + "  }"
+        + "}";
     final GeneratedJDTAST<ProductSourcePath> ast = createAst(source);
 
     // extract target location
@@ -37,15 +35,13 @@ public class JDTASTCrossoverLocationTest {
 
   @Test
   public void testLocateForTheSameAst02() {
-    final String source = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 1;") // target
-        .append("    i = 1;")
-        .append("    i = 1;")
-        .append("  }")
-        .append("}")
-        .toString();
+    final String source = "class A {"
+        + "  public void a(int i) {"
+        + "    i = 1;" // target
+        + "    i = 1;"
+        + "    i = 1;"
+        + "  }"
+        + "}";
     final GeneratedJDTAST<ProductSourcePath> ast = createAst(source);
 
     // extract target location
@@ -63,15 +59,13 @@ public class JDTASTCrossoverLocationTest {
 
   @Test
   public void testLocateForTheSameAst03() {
-    final String source = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 1;")
-        .append("    i = 1;") // target
-        .append("    i = 1;")
-        .append("  }")
-        .append("}")
-        .toString();
+    final String source = "class A {"
+        + "  public void a(int i) {"
+        + "    i = 1;"
+        + "    i = 1;" // target
+        + "    i = 1;"
+        + "  }"
+        + "}";
     final GeneratedJDTAST<ProductSourcePath> ast = createAst(source);
 
     // extract target location
@@ -89,22 +83,34 @@ public class JDTASTCrossoverLocationTest {
 
   @Test
   public void testLocateForTheSameAst04() {
-    final String source = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    if (true) {")
-        .append("      i = 2;")
-        .append("      i = 3;")
-        .append("    } else {")
-        .append("      i = 2;") // target
-        .append("      i = 3;")
-        .append("  }")
-        .append("}")
-        .toString();
+    final String source = "class A {"
+        + "  public void a(int i) {"
+        + "    if (true) {"
+        + "      i = 2;"
+        + "      i = 3;"
+        + "      if (true) {"
+        + "        i = 2;"
+        + "        i = 3;"
+        + "      } else {"
+        + "        i = 2;"
+        + "        i = 3;"
+        + "      }"
+        + "    } else {"
+        + "      i = 2;"
+        + "      i = 3;"
+        + "      if (true) {"
+        + "        i = 2;" //target
+        + "        i = 3;"
+        + "      } else {"
+        + "        i = 2;"
+        + "        i = 3;"
+        + "      }"
+        + "    }"
+        + "}";
     final GeneratedJDTAST<ProductSourcePath> ast = createAst(source);
 
     // extract target location
-    final JDTASTLocation location = getLocation(ast, 4);
+    final JDTASTLocation location = getLocation(ast, 14);
     final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
     assertThat(cLocation.getNode()).isSameSourceCodeAs("i=2;");
 
@@ -118,15 +124,13 @@ public class JDTASTCrossoverLocationTest {
 
   @Test
   public void testLocateForSameContentAst() {
-    final String source = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
+    final String source = "class A {"
+        + "  public void a(int i) {"
+        + "    i = 0;"
+        + "    i = 1;" // target
+        + "    i = 2;"
+        + "  }"
+        + "}";
 
     // generate two asts (contents are the same but they are different object)
     final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source);
@@ -147,24 +151,20 @@ public class JDTASTCrossoverLocationTest {
 
   @Test
   public void testLocateForDifferentAst01() {
-    final String source1 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
-    final String source2 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 2;")
-        .append("    i = 1;") // target
-        .append("  }")
-        .append("}")
-        .toString();
+    final String source1 = "class A {"
+        + "  public void a(int i) {"
+        + "    i = 0;"
+        + "    i = 1;" // target
+        + "    i = 2;"
+        + "  }"
+        + "}";
+    final String source2 = "class A {"
+        + "  public void a(int i) {"
+        + "    i = 0;"
+        + "    i = 2;"
+        + "    i = 1;" // target
+        + "  }"
+        + "}";
 
     // generate two asts
     final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
@@ -185,26 +185,22 @@ public class JDTASTCrossoverLocationTest {
 
   @Test
   public void testLocateForDifferentAst02() {
-    final String source1 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
-    final String source2 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    if (true) {")
-        .append("      i = 2;")
-        .append("    }")
-        .append("  }")
-        .append("}")
-        .toString();
+    final String source1 = "class A {"
+        + "  public void a(int i) {"
+        + "    i = 0;"
+        + "    i = 1;" // target
+        + "    i = 2;"
+        + "  }"
+        + "}";
+    final String source2 = "class A {"
+        + "  public void a(int i) {"
+        + "    i = 0;"
+        + "    i = 1;" // target
+        + "    if (true) {"
+        + "      i = 2;"
+        + "    }"
+        + "  }"
+        + "}";
 
     // generate two asts
     final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
@@ -225,26 +221,22 @@ public class JDTASTCrossoverLocationTest {
 
   @Test
   public void testLocateForDifferentAst03() {
-    final String source1 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
-    final String source2 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    if (true) {")
-        .append("      i = 1;") // target
-        .append("    }")
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
+    final String source1 = "class A {"
+        + "  public void a(int i) {"
+        + "    i = 0;"
+        + "    i = 1;" // target
+        + "    i = 2;"
+        + "  }"
+        + "}";
+    final String source2 = "class A {"
+        + "  public void a(int i) {"
+        + "    i = 0;"
+        + "    if (true) {"
+        + "      i = 1;" // target
+        + "    }"
+        + "    i = 2;"
+        + "  }"
+        + "}";
 
     // generate two asts
     final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);
@@ -264,21 +256,17 @@ public class JDTASTCrossoverLocationTest {
 
   @Test
   public void testLocateForDifferentAst04() {
-    final String source1 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("    i = 0;")
-        .append("    i = 1;") // target
-        .append("    i = 2;")
-        .append("  }")
-        .append("}")
-        .toString();
-    final String source2 = new StringBuilder()
-        .append("class A {")
-        .append("  public void a(int i) {")
-        .append("  }")
-        .append("}")
-        .toString();
+    final String source1 = "class A {"
+        + "  public void a(int i) {"
+        + "    i = 0;"
+        + "    i = 1;" // target
+        + "    i = 2;"
+        + "  }"
+        + "}";
+    final String source2 = "class A {"
+        + "  public void a(int i) {"
+        + "  }"
+        + "}";
 
     // generate two asts
     final GeneratedJDTAST<ProductSourcePath> ast1 = createAst(source1);

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java
@@ -88,6 +88,35 @@ public class JDTASTCrossoverLocationTest {
   }
 
   @Test
+  public void testLocateForTheSameAst04() {
+    final String source = new StringBuilder()
+        .append("class A {")
+        .append("  public void a(int i) {")
+        .append("    if (true) {")
+        .append("      i = 2;")
+        .append("      i = 3;")
+        .append("    } else {")
+        .append("      i = 2;") // target
+        .append("      i = 3;")
+        .append("  }")
+        .append("}")
+        .toString();
+    final GeneratedJDTAST<ProductSourcePath> ast = createAst(source);
+
+    // extract target location
+    final JDTASTLocation location = getLocation(ast, 4);
+    final JDTASTCrossoverLocation cLocation = new JDTASTCrossoverLocation(location);
+    assertThat(cLocation.getNode()).isSameSourceCodeAs("i=2;");
+
+    // try locate() for the same ast root
+    final ASTNode node = cLocation.locate(ast.getRoot());
+
+    // located node is the same as target node
+    assertThat(node).isEqualTo(location.getNode());
+    assertThat(node.getRoot()).isSameRootClassAs(ast.getRoot());
+  }
+
+  @Test
   public void testLocateForSameContentAst() {
     final String source = new StringBuilder()
         .append("class A {")


### PR DESCRIPTION
resolve #788 

## 概要
候補ノード選定に木のたぐり方を追加し，深さと記述が同じだが，経路中の `descriptor` が異なるノードを区別できるようにした．
例えば，`testLocateForTheSameAst04` のようなテストをパスできるようになった．
https://github.com/kusumotolab/kGenProg/blob/4cf90d178ee4d350e321e985228872b170e81d9c/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTCrossoverLocationTest.java#L85-L109

## 実装方針
`TreePath` を`ASTNode` と `descriptor` の2組とし，探索時，`ASTNode` の種類一致と`descriptor`の完全一致を確認する．

## `descriptor` について
[`ASTNode#getLocationInParent`](https://www.ibm.com/support/knowledgecenter/ja/SS8PJ7_9.5.0/org.eclipse.jdt.doc.isv/reference/api/org/eclipse/jdt/core/dom/ASTNode.html#getLocationInParent--) で取得できて，そのノードが親のどこにあるかを示す．

例えば，[`IfStatement`](https://www.ibm.com/support/knowledgecenter/ja/SS8PJ7_9.5.0/org.eclipse.jdt.doc.isv/reference/api/org/eclipse/jdt/core/dom/IfStatement.html) だと，3種類．

- EXPRESSION_PROPERTY
- THEN_STATEMENT_PROPERTY
- ELSE_STATEMENT_PROPERTY