### PR TITLE
Windows10 環境で PatchSerializerTest が失敗するバグを修正

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/output/FileDiff.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/FileDiff.java
@@ -53,14 +53,11 @@ public class FileDiff {
    * デフォルトエンコーディングに変換したdiffを返す
    */
   public String toStringWithDefaultEncoding() {
-    final Charset defaultEncoding = Charset.defaultCharset();
-    if (defaultEncoding.equals(StandardCharsets.UTF_8)) {
-      return toString();
-    } else {
-      return diff.stream()
-          .map(e -> e.getBytes(defaultEncoding))
-          .map(e -> new String(e, defaultEncoding))
-          .collect(Collectors.joining(System.lineSeparator()));
-    }
+    final Charset defaultCharset = Charset.defaultCharset();
+
+    return diff.stream()
+        .map(e -> e.getBytes(defaultCharset))
+        .map(e -> new String(e, defaultCharset))
+        .collect(Collectors.joining(System.lineSeparator()));
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/output/FileDiff.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/FileDiff.java
@@ -1,7 +1,6 @@
 package jp.kusumotolab.kgenprog.output;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/jp/kusumotolab/kgenprog/output/PatchGenerator.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/PatchGenerator.java
@@ -1,8 +1,6 @@
 package jp.kusumotolab.kgenprog.output;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -22,7 +20,6 @@ import org.slf4j.LoggerFactory;
 import com.github.difflib.DiffUtils;
 import com.github.difflib.UnifiedDiffUtils;
 import com.github.difflib.algorithm.DiffException;
-import jp.kusumotolab.kgenprog.CharsetDetector;
 import jp.kusumotolab.kgenprog.ga.variant.Variant;
 import jp.kusumotolab.kgenprog.project.GeneratedAST;
 
@@ -62,17 +59,7 @@ public class PatchGenerator {
         .getResolvedPath();
 
     try {
-      final CharsetDetector detector = new CharsetDetector();
-      final Charset charset = detector.detect(originalPath);
-      if (charset.equals(StandardCharsets.UTF_8)) {
-        return Files.readAllLines(originalPath, StandardCharsets.UTF_8);
-      } else {
-        return Files.readAllLines(originalPath, charset)
-            .stream()
-            .map(e -> e.getBytes(StandardCharsets.UTF_8))
-            .map(e -> new String(e, StandardCharsets.UTF_8))
-            .collect(Collectors.toList());
-      }
+      return Files.readAllLines(originalPath, ast.getCharset());
     } catch (final IOException e) {
       log.error(e.getMessage(), e);
       return Collections.emptyList();

--- a/src/main/java/jp/kusumotolab/kgenprog/project/GeneratedAST.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/GeneratedAST.java
@@ -1,5 +1,7 @@
 package jp.kusumotolab.kgenprog.project;
 
+import java.nio.charset.Charset;
+
 // TODO: クラス名を再検討
 public interface GeneratedAST<T extends SourcePath> {
 
@@ -12,6 +14,8 @@ public interface GeneratedAST<T extends SourcePath> {
   ASTLocations createLocations();
 
   String getMessageDigest();
+
+  Charset getCharset();
 
   int getNumberOfLines();
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/GeneratedJDTAST.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/GeneratedJDTAST.java
@@ -1,5 +1,6 @@
 package jp.kusumotolab.kgenprog.project.jdt;
 
+import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
@@ -23,15 +24,17 @@ public class GeneratedJDTAST<T extends SourcePath> implements GeneratedAST<T> {
   private final T sourcePath;
   private final FullyQualifiedName primaryClassName;
   private final String sourceCode;
+  private final Charset charset;
   private final String messageDigest;
   private final int numberOfLines;
 
   public GeneratedJDTAST(final JDTASTConstruction construction, final T sourcePath,
-      final CompilationUnit root, final String source) {
+      final CompilationUnit root, final String source, final Charset charset) {
     this.construction = construction;
     this.root = root;
     this.sourcePath = sourcePath;
     this.sourceCode = source;
+    this.charset = charset;
 
     this.primaryClassName = searchPrimaryClassName(root);
     this.messageDigest = createMessageDigest();
@@ -61,6 +64,11 @@ public class GeneratedJDTAST<T extends SourcePath> implements GeneratedAST<T> {
   @Override
   public String getMessageDigest() {
     return messageDigest;
+  }
+
+  @Override
+  public Charset getCharset() {
+    return charset;
   }
 
   @Override

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperation.java
@@ -75,7 +75,7 @@ public class InsertTimeoutRuleFieldOperation implements Operation {
     }
 
     return jdtast.getConstruction()
-        .constructAST(ast.getSourcePath(), document.get());
+        .constructAST(ast.getSourcePath(), document.get(), jdtast.getCharset());
   }
 
   /**

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTConstruction.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTConstruction.java
@@ -41,12 +41,23 @@ public class JDTASTConstruction {
             .toString())
         .toArray(String[]::new);
 
+    final CharsetDetector detector = new CharsetDetector();
+    final String[] encodings = Stream.concat(productSourcePaths.stream(), testSourcePaths.stream())
+        .map(SourcePath::getResolvedPath)
+        .map(detector::detect)
+        .map(Charset::name)
+        .toArray(String[]::new);
+
     final ASTParser parser = createNewParser();
 
     final Map<Path, ProductSourcePath> pathToProductSourcePath = productSourcePaths.stream()
         .collect(Collectors.toMap(SourcePath::getResolvedPath, path -> path));
     final Map<Path, TestSourcePath> pathToTestSourcePath = testSourcePaths.stream()
         .collect(Collectors.toMap(SourcePath::getResolvedPath, path -> path));
+    final Map<Path, Charset> pathToCharset = Stream.concat(productSourcePaths.stream(),
+        testSourcePaths.stream())
+        .map(SourcePath::getResolvedPath)
+        .collect(Collectors.toMap(path -> path, detector::detect));
 
     final List<GeneratedAST<ProductSourcePath>> productAsts = new ArrayList<>();
     final List<GeneratedAST<TestSourcePath>> testAsts = new ArrayList<>();
@@ -58,21 +69,23 @@ public class JDTASTConstruction {
       public void acceptAST(final String sourcePath, final CompilationUnit ast) {
         final ProductSourcePath productPath = pathToProductSourcePath.get(Paths.get(sourcePath));
         if (productPath != null) {
+          final Charset charset = pathToCharset.get(Paths.get(sourcePath));
           productAsts.add(new GeneratedJDTAST<>(JDTASTConstruction.this, productPath, ast,
-              loadAsString(sourcePath)));
+              loadAsString(sourcePath, charset), charset));
         }
 
         final TestSourcePath testPath = pathToTestSourcePath.get(Paths.get(sourcePath));
         if (testPath != null) {
+          final Charset charset = pathToCharset.get(Paths.get(sourcePath));
           testAsts.add(new GeneratedJDTAST<>(JDTASTConstruction.this, testPath, ast,
-              loadAsString(sourcePath)));
+              loadAsString(sourcePath, charset), charset));
         }
 
         problems.addAll(Arrays.asList(ast.getProblems()));
       }
     };
 
-    parser.createASTs(paths, null, new String[] {}, requestor, null);
+    parser.createASTs(paths, encodings, new String[] {}, requestor, null);
 
     if (isConstructionSuccess(problems)) {
       return new GeneratedSourceCode(productAsts, testAsts);
@@ -83,18 +96,18 @@ public class JDTASTConstruction {
   }
 
   public <T extends SourcePath> GeneratedJDTAST<T> constructAST(final T sourcePath,
-      final String data) {
+      final String data, final Charset charset) {
     final ASTParser parser = createNewParser();
     parser.setSource(data.toCharArray());
 
-    return new GeneratedJDTAST<>(this, sourcePath, (CompilationUnit) parser.createAST(null), data);
+    return new GeneratedJDTAST<>(this, sourcePath, (CompilationUnit) parser.createAST(null), data,
+        charset);
   }
 
   public static ASTParser createNewParser() {
     final ASTParser parser = ASTParser.newParser(AST.JLS10);
 
-    @SuppressWarnings("unchecked")
-    final Map<String, String> options = DefaultCodeFormatterConstants.getEclipseDefaultSettings();
+    @SuppressWarnings("unchecked") final Map<String, String> options = DefaultCodeFormatterConstants.getEclipseDefaultSettings();
     options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
     options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
     options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
@@ -108,12 +121,9 @@ public class JDTASTConstruction {
     return parser;
   }
 
-  private String loadAsString(final String path) {
+  private String loadAsString(final String path, final Charset charset) {
     try {
-      final CharsetDetector detector = new CharsetDetector();
-      final Charset charset = detector.detect(Paths.get(path));
-      final String code = Files.readString(Paths.get(path), charset);
-      return new String(code.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+      return Files.readString(Paths.get(path), charset);
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTConstruction.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTConstruction.java
@@ -2,7 +2,6 @@ package jp.kusumotolab.kgenprog.project.jdt;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/JDTOperation.java
@@ -58,7 +58,7 @@ public abstract class JDTOperation implements Operation {
     }
 
     return jdtast.getConstruction()
-        .constructAST(ast.getSourcePath(), document.get());
+        .constructAST(ast.getSourcePath(), document.get(), ast.getCharset());
   }
 
   protected abstract <T extends SourcePath> void applyToASTRewrite(final GeneratedJDTAST<T> ast,

--- a/src/test/java/jp/kusumotolab/kgenprog/output/PatchGeneratorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/PatchGeneratorTest.java
@@ -297,7 +297,7 @@ public class PatchGeneratorTest {
     final String originalSource = targetAst.getSourceCode();
     final String modifiedSource = originalSource.replace(replaceFrom, replaceTo);
     final GeneratedAST ast = constructor.constructAST(targetAst.getSourcePath(), modifiedSource,
-        StandardCharsets.UTF_8);
+        targetAst.getCharset());
 
     // spy to return the modified ast
     final GeneratedSourceCode spy = spy(baseSourceCode);

--- a/src/test/java/jp/kusumotolab/kgenprog/output/PatchGeneratorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/PatchGeneratorTest.java
@@ -296,7 +296,8 @@ public class PatchGeneratorTest {
     final JDTASTConstruction constructor = new JDTASTConstruction();
     final String originalSource = targetAst.getSourceCode();
     final String modifiedSource = originalSource.replace(replaceFrom, replaceTo);
-    final GeneratedAST ast = constructor.constructAST(targetAst.getSourcePath(), modifiedSource);
+    final GeneratedAST ast = constructor.constructAST(targetAst.getSourcePath(), modifiedSource,
+        StandardCharsets.UTF_8);
 
     // spy to return the modified ast
     final GeneratedSourceCode spy = spy(baseSourceCode);

--- a/src/test/java/jp/kusumotolab/kgenprog/project/GeneratedSourceCodeTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/GeneratedSourceCodeTest.java
@@ -1,6 +1,8 @@
 package jp.kusumotolab.kgenprog.project;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,6 +38,11 @@ public class GeneratedSourceCodeTest {
     @Override
     public String getMessageDigest() {
       return messageDigest;
+    }
+
+    @Override
+    public Charset getCharset() {
+      return StandardCharsets.UTF_8;
     }
 
     @Override

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/ASTStreamTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/ASTStreamTest.java
@@ -1,6 +1,7 @@
 package jp.kusumotolab.kgenprog.project.jdt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,7 +25,8 @@ public class ASTStreamTest {
 
     final ProductSourcePath sourcePath = new ProductSourcePath(Paths.get("."), Paths.get("A.java"));
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source);
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source,
+        StandardCharsets.UTF_8);
 
     final List<ASTNode> actual = ASTStream.stream(ast.getRoot())
         .collect(Collectors.toList());

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/DeleteOperationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/DeleteOperationTest.java
@@ -2,6 +2,7 @@ package jp.kusumotolab.kgenprog.project.jdt;
 
 import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Collections;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -28,7 +29,7 @@ public class DeleteOperationTest {
   public void testDeleteStatement() {
     final ProductSourcePath path = new ProductSourcePath(Paths.get("."), Paths.get("A.java"));
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source);
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source, StandardCharsets.UTF_8);
     @SuppressWarnings("unchecked")
     final GeneratedJDTAST<TestSourcePath> mockAst = Mockito.mock(
         GeneratedJDTAST.class);

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/GeneratedJDTASTTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/GeneratedJDTASTTest.java
@@ -3,6 +3,7 @@ package jp.kusumotolab.kgenprog.project.jdt;
 import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -54,7 +55,7 @@ public class GeneratedJDTASTTest {
     final ProductSourcePath productSourcePath =
         new ProductSourcePath(Paths.get("."), Paths.get(FILE_NAME));
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    this.ast = constructor.constructAST(productSourcePath, SOURCE);
+    this.ast = constructor.constructAST(productSourcePath, SOURCE, StandardCharsets.UTF_8);
   }
 
   @Test
@@ -113,7 +114,8 @@ public class GeneratedJDTASTTest {
         new ProductSourcePath(Paths.get("."), Paths.get("a/b/c/T2.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source);
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source,
+        StandardCharsets.UTF_8);
 
     assertThat(ast.getPrimaryClassName()).isEqualTo("a.b.c.T2");
   }
@@ -124,7 +126,8 @@ public class GeneratedJDTASTTest {
     final ProductSourcePath path = new ProductSourcePath(Paths.get("."), Paths.get("T2.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source);
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source,
+        StandardCharsets.UTF_8);
 
     assertThat(ast.getPrimaryClassName()).isEqualTo("T2");
   }
@@ -136,7 +139,8 @@ public class GeneratedJDTASTTest {
         new ProductSourcePath(Paths.get("."), Paths.get("a/b/c/T2.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source);
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source,
+        StandardCharsets.UTF_8);
 
     assertThat(ast.getPrimaryClassName()).isEqualTo("a.b.c.T1");
   }
@@ -148,7 +152,8 @@ public class GeneratedJDTASTTest {
         new ProductSourcePath(Paths.get("."), Paths.get("a/b/c/package-info.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source);
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source,
+        StandardCharsets.UTF_8);
 
     assertThat(ast.getPrimaryClassName()).isEqualTo("a.b.c.package-info");
   }
@@ -160,10 +165,10 @@ public class GeneratedJDTASTTest {
         new ProductSourcePath(Paths.get("."), Paths.get("StaticImport.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source);
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source,
+        StandardCharsets.UTF_8);
 
-    @SuppressWarnings("unchecked")
-    final List<ImportDeclaration> imports = ast.getRoot()
+    @SuppressWarnings("unchecked") final List<ImportDeclaration> imports = ast.getRoot()
         .imports();
 
     assertThat(imports).hasSize(1)
@@ -326,8 +331,7 @@ public class GeneratedJDTASTTest {
     methodInvocationB.setName(ast.newSimpleName("b"));
     final Block block = ast.newBlock();
 
-    @SuppressWarnings("unchecked")
-    final List<Statement> blockStatementList = block.statements();
+    @SuppressWarnings("unchecked") final List<Statement> blockStatementList = block.statements();
 
     blockStatementList.add(ast.newExpressionStatement(methodInvocationA));
     blockStatementList.add(ast.newExpressionStatement(methodInvocationB));
@@ -367,8 +371,10 @@ public class GeneratedJDTASTTest {
     final String source2 = "class A { public void a() { b(1); } public void b(int v){}}\n\n";
     final ProductSourcePath path = new ProductSourcePath(Paths.get("."), Paths.get("A.java"));
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast1 = constructor.constructAST(path, source1);
-    final GeneratedJDTAST<ProductSourcePath> ast2 = constructor.constructAST(path, source2);
+    final GeneratedJDTAST<ProductSourcePath> ast1 = constructor.constructAST(path, source1,
+        StandardCharsets.UTF_8);
+    final GeneratedJDTAST<ProductSourcePath> ast2 = constructor.constructAST(path, source2,
+        StandardCharsets.UTF_8);
 
     assertThat(ast1.getMessageDigest()).isEqualTo(ast2.getMessageDigest());
   }
@@ -379,8 +385,10 @@ public class GeneratedJDTASTTest {
     final String source2 = "class A { public void a() { b(2); } public void b(int v){}}";
     final ProductSourcePath path = new ProductSourcePath(Paths.get("."), Paths.get("A.java"));
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast1 = constructor.constructAST(path, source1);
-    final GeneratedJDTAST<ProductSourcePath> ast2 = constructor.constructAST(path, source2);
+    final GeneratedJDTAST<ProductSourcePath> ast1 = constructor.constructAST(path, source1,
+        StandardCharsets.UTF_8);
+    final GeneratedJDTAST<ProductSourcePath> ast2 = constructor.constructAST(path, source2,
+        StandardCharsets.UTF_8);
 
     assertThat(ast1.getMessageDigest()).isNotEqualTo(ast2.getMessageDigest());
   }

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertAfterOperationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertAfterOperationTest.java
@@ -2,6 +2,7 @@ package jp.kusumotolab.kgenprog.project.jdt;
 
 import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Collections;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -29,9 +30,9 @@ public class InsertAfterOperationTest {
     final ProductSourcePath sourcePath = new ProductSourcePath(Paths.get("."), Paths.get("A.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source);
-    @SuppressWarnings("unchecked")
-    final GeneratedJDTAST<TestSourcePath> mockAst = Mockito.mock(
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source,
+        StandardCharsets.UTF_8);
+    @SuppressWarnings("unchecked") final GeneratedJDTAST<TestSourcePath> mockAst = Mockito.mock(
         GeneratedJDTAST.class);
     final GeneratedSourceCode generatedSourceCode =
         new GeneratedSourceCode(Collections.singletonList(ast), Collections.singletonList(mockAst));
@@ -85,7 +86,8 @@ public class InsertAfterOperationTest {
     final ProductSourcePath sourcePath = new ProductSourcePath(Paths.get("."), Paths.get("B.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source);
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source,
+        StandardCharsets.UTF_8);
 
     final TypeDeclaration type = (TypeDeclaration) ast.getRoot()
         .types()

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertBeforeOperationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertBeforeOperationTest.java
@@ -2,6 +2,7 @@ package jp.kusumotolab.kgenprog.project.jdt;
 
 import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Collections;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -29,9 +30,9 @@ public class InsertBeforeOperationTest {
     final ProductSourcePath sourcePath = new ProductSourcePath(Paths.get("."), Paths.get("A.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source);
-    @SuppressWarnings("unchecked")
-    final GeneratedJDTAST<TestSourcePath> mockAst = Mockito.mock(
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source,
+        StandardCharsets.UTF_8);
+    @SuppressWarnings("unchecked") final GeneratedJDTAST<TestSourcePath> mockAst = Mockito.mock(
         GeneratedJDTAST.class);
     final GeneratedSourceCode generatedSourceCode =
         new GeneratedSourceCode(Collections.singletonList(ast), Collections.singletonList(mockAst));
@@ -85,7 +86,8 @@ public class InsertBeforeOperationTest {
     final ProductSourcePath sourcePath = new ProductSourcePath(Paths.get("."), Paths.get("B.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source);
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(sourcePath, source,
+        StandardCharsets.UTF_8);
 
     final TypeDeclaration type = (TypeDeclaration) ast.getRoot()
         .types()

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/InsertTimeoutRuleFieldOperationTest.java
@@ -1,6 +1,7 @@
 package jp.kusumotolab.kgenprog.project.jdt;
 
 import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Collections;
 import org.junit.Ignore;
@@ -26,7 +27,8 @@ public class InsertTimeoutRuleFieldOperationTest {
 
     final TestSourcePath sourcePath = new TestSourcePath(Paths.get("."), Paths.get("A.java"));
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<TestSourcePath> ast = constructor.constructAST(sourcePath, source);
+    final GeneratedJDTAST<TestSourcePath> ast = constructor.constructAST(sourcePath, source,
+        StandardCharsets.UTF_8);
     final GeneratedSourceCode sourceCode =
         new GeneratedSourceCode(Collections.emptyList(), Collections.singletonList(ast));
     final InsertTimeoutRuleFieldOperation operation = new InsertTimeoutRuleFieldOperation(10);
@@ -61,7 +63,8 @@ public class InsertTimeoutRuleFieldOperationTest {
 
     final TestSourcePath sourcePath = new TestSourcePath(Paths.get("."), Paths.get("A.java"));
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<TestSourcePath> ast = constructor.constructAST(sourcePath, source);
+    final GeneratedJDTAST<TestSourcePath> ast = constructor.constructAST(sourcePath, source,
+        StandardCharsets.UTF_8);
     final GeneratedSourceCode sourceCode =
         new GeneratedSourceCode(Collections.emptyList(), Collections.singletonList(ast));
     final InsertTimeoutRuleFieldOperation operation = new InsertTimeoutRuleFieldOperation(10);

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTConstructionTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTASTConstructionTest.java
@@ -5,6 +5,8 @@ import static jp.kusumotolab.kgenprog.testutil.ExampleAlias.Src.BAR_TEST;
 import static jp.kusumotolab.kgenprog.testutil.ExampleAlias.Src.FOO;
 import static jp.kusumotolab.kgenprog.testutil.ExampleAlias.Src.FOO_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -64,6 +66,40 @@ public class JDTASTConstructionTest {
         .extracting(GeneratedAST::getSourcePath)
         .extracting(p -> p.path)
         .containsExactlyInAnyOrder(FOO);
+
+    // テストのASTはゼロのはず
+    final List<GeneratedAST<TestSourcePath>> testAsts = generatedSourceCode.getTestAsts();
+    assertThat(testAsts).hasSize(0);
+  }
+
+  @Test
+  public void testConstructASTWithUTF8() {
+    final Path basePath = Paths.get("example/BuildSuccess24");
+    final TargetProject targetProject = TargetProjectFactory.create(basePath);
+    final JDTASTConstruction construction = new JDTASTConstruction();
+    final GeneratedSourceCode generatedSourceCode = construction.constructAST(targetProject);
+    final List<GeneratedAST<ProductSourcePath>> productAsts = generatedSourceCode.getProductAsts();
+
+    assertThat(productAsts).hasSize(1)
+        .extracting(GeneratedAST::getCharset)
+        .containsExactlyInAnyOrder(StandardCharsets.UTF_8);
+
+    // テストのASTはゼロのはず
+    final List<GeneratedAST<TestSourcePath>> testAsts = generatedSourceCode.getTestAsts();
+    assertThat(testAsts).hasSize(0);
+  }
+
+  @Test
+  public void testConstructASTWithShiftJIS() {
+    final Path basePath = Paths.get("example/BuildSuccess25");
+    final TargetProject targetProject = TargetProjectFactory.create(basePath);
+    final JDTASTConstruction construction = new JDTASTConstruction();
+    final GeneratedSourceCode generatedSourceCode = construction.constructAST(targetProject);
+    final List<GeneratedAST<ProductSourcePath>> productAsts = generatedSourceCode.getProductAsts();
+
+    assertThat(productAsts).hasSize(1)
+        .extracting(GeneratedAST::getCharset)
+        .containsExactlyInAnyOrder(Charset.forName("shift-jis"));
 
     // テストのASTはゼロのはず
     final List<GeneratedAST<TestSourcePath>> testAsts = generatedSourceCode.getTestAsts();

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTLocationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/JDTLocationTest.java
@@ -1,6 +1,7 @@
 package jp.kusumotolab.kgenprog.project.jdt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -349,7 +350,7 @@ public class JDTLocationTest {
     final String fname = source.hashCode() + ".java"; // dummy file name
     final ProductSourcePath path = new ProductSourcePath(Paths.get("."), Paths.get(fname));
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    return constructor.constructAST(path, source);
+    return constructor.constructAST(path, source, StandardCharsets.UTF_8);
   }
 
   private JDTASTLocation getLocation(GeneratedJDTAST<ProductSourcePath> ast, int idx) {

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/ReplaceOperationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/ReplaceOperationTest.java
@@ -2,6 +2,7 @@ package jp.kusumotolab.kgenprog.project.jdt;
 
 import static jp.kusumotolab.kgenprog.project.jdt.ASTNodeAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Collections;
 import org.eclipse.jdt.core.dom.AST;
@@ -33,9 +34,9 @@ public class ReplaceOperationTest {
     final ProductSourcePath path = new ProductSourcePath(Paths.get("."), Paths.get("A.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source);
-    @SuppressWarnings("unchecked")
-    final GeneratedJDTAST<TestSourcePath> mockAst = Mockito.mock(
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source,
+        StandardCharsets.UTF_8);
+    @SuppressWarnings("unchecked") final GeneratedJDTAST<TestSourcePath> mockAst = Mockito.mock(
         GeneratedJDTAST.class);
     final GeneratedSourceCode generatedSourceCode =
         new GeneratedSourceCode(Collections.singletonList(ast), Collections.singletonList(mockAst));
@@ -79,9 +80,9 @@ public class ReplaceOperationTest {
     final ProductSourcePath path = new ProductSourcePath(Paths.get("."), Paths.get("A.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source);
-    @SuppressWarnings("unchecked")
-    final GeneratedJDTAST<TestSourcePath> mockAst = Mockito.mock(
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source,
+        StandardCharsets.UTF_8);
+    @SuppressWarnings("unchecked") final GeneratedJDTAST<TestSourcePath> mockAst = Mockito.mock(
         GeneratedJDTAST.class);
     final GeneratedSourceCode generatedSourceCode =
         new GeneratedSourceCode(Collections.singletonList(ast), Collections.singletonList(mockAst));
@@ -139,7 +140,8 @@ public class ReplaceOperationTest {
     final ProductSourcePath path = new ProductSourcePath(Paths.get("."), Paths.get("B.java"));
 
     final JDTASTConstruction constructor = new JDTASTConstruction();
-    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source);
+    final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(path, source,
+        StandardCharsets.UTF_8);
 
     final TypeDeclaration type = (TypeDeclaration) ast.getRoot()
         .types()

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/StatementAndConditionVisitorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/StatementAndConditionVisitorTest.java
@@ -1,6 +1,7 @@
 package jp.kusumotolab.kgenprog.project.jdt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.List;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -34,7 +35,7 @@ public class StatementAndConditionVisitorTest {
         new ProductSourcePath(Paths.get("."), Paths.get(FILE_NAME_FOR));
     final JDTASTConstruction constructor = new JDTASTConstruction();
     final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(
-        productSourcePath, SOURCE_FOR);
+        productSourcePath, SOURCE_FOR, StandardCharsets.UTF_8);
 
     // assuming that any instance of Block is not included in statements
     // Blockが含まれていないはず

--- a/src/test/java/jp/kusumotolab/kgenprog/project/jdt/StatementListVisitorTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/project/jdt/StatementListVisitorTest.java
@@ -1,6 +1,7 @@
 package jp.kusumotolab.kgenprog.project.jdt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.List;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -44,7 +45,7 @@ public class StatementListVisitorTest {
         new ProductSourcePath(Paths.get("."), Paths.get(FILE_NAME_A));
     final JDTASTConstruction constructor = new JDTASTConstruction();
     final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(
-        productSourcePath, SOURCE_A);
+        productSourcePath, SOURCE_A, StandardCharsets.UTF_8);
 
     // assuming that any instance of Block is not included in statements
     // Blockが含まれていないはず
@@ -63,7 +64,7 @@ public class StatementListVisitorTest {
         new ProductSourcePath(Paths.get("."), Paths.get(FILE_NAME_B));
     final JDTASTConstruction constructor = new JDTASTConstruction();
     final GeneratedJDTAST<ProductSourcePath> ast = constructor.constructAST(
-        productSourcePath, SOURCE_B);
+        productSourcePath, SOURCE_B, StandardCharsets.UTF_8);
 
     // assuming that any instance of Block is included in statements
     // Blockが含まれているはず


### PR DESCRIPTION
resolve #797 

## 原因
実行環境の文字コードがUTF-8以外かつマルチバイト文字が修正対象に含まれるときに，ASTの操作に失敗するため．

## 変更点
- ASTを作るときに読み込むソースコードのエンコーディングを渡すようにした．
- ソースコードをUTF-8に変換せずにそのまま保持するようにした.

## TODO
- [x] windows環境での動作確認
- [x] テストを書く
