### PR TITLE
ファイル出力オプションの名前/挙動を自然な形に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ java -jar path/to/kGenProg.jar
 | `-t`, `--test` | Specifies paths to test source code, or to directories containing them. Paths are separated with spaces. | Nothing |
 | `-x`, `--exec-test` | Specifies fully qualified names of test classes executed during evaluation of variants (i.e. fix-candidates). It is recommended to specify test classes detecting a bug. Class names are separated with spaces. | All test classes |
 | `-c`, `--cp` | Specifies class paths needed to build the target project. Paths are separated with spaces. | Nothing |
-| `-o`, `--out-dir` | Writes patches kGenProg generated under the specified directory. Patches are outputted to a directory having a name of the execution time and date under the specified directory. | A directory named `kgenprog-out` is created in the current directory. |
+| `-o`, `--out-dir` | Specifies an output directory. Generated files include patches and history json. They can be enabled by `--patch-output` or `--history-record` |  A directory named `kgenprog-out` is created in the current directory. |
 | `-v`, `--verbose` | Be more verbose, printing DEBUG level logs. | `false` |
 | `-q`, `--quiet` | Be more quiet, suppressing non-ERROR logs. | `false` |
 | `--config` |  Specifies the path to config file. | Reads config file named `kgenprog.toml` in the current directory. |
@@ -110,7 +110,8 @@ $ java -jar path/to/kGenProg.jar
 | `--crossover-type` | Specifies crossover type. (`Random`, `Single`, `Uniform`). | `Random` |
 | `--crossover-first-variant` | Specifies first variant selection strategy for crossover. (`Elite`, `Random`). | `Random` |
 | `--crossover-second-variant` | Specifies second variant selection strategy for crossover.  (`Elite`, `GeneSimilarity`, `Random`, `TestSimilarity`). | `Random` |
-| `--history-record` | Stores generation process of each variant and all generated variants. | `false` |
+| `--patch-output` | Writes patch files to the output directory specified in `-o` option. | `false` |
+| `--history-record` | Records and writes generation process of all generated variants as JSON format. | `false` |
 
 
 ## Use in your research

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ java -jar path/to/kGenProg.jar
 | `-t`, `--test` | Specifies paths to test source code, or to directories containing them. Paths are separated with spaces. | Nothing |
 | `-x`, `--exec-test` | Specifies fully qualified names of test classes executed during evaluation of variants (i.e. fix-candidates). It is recommended to specify test classes detecting a bug. Class names are separated with spaces. | All test classes |
 | `-c`, `--cp` | Specifies class paths needed to build the target project. Paths are separated with spaces. | Nothing |
-| `-o`, `--out-dir` | Specifies an output directory. Generated files include patches and history json. They can be enabled by `--patch-output` or `--history-record` |  A directory named `kgenprog-out` is created in the current directory. |
+| `-o`, `--out-dir` | Specifies an output directory. Generated files include patches and history json. They can be enabled by `--patch-output` or `--history-record` | `./kgenprog-out` |
 | `-v`, `--verbose` | Be more verbose, printing DEBUG level logs. | `false` |
 | `-q`, `--quiet` | Be more quiet, suppressing non-ERROR logs. | `false` |
 | `--config` |  Specifies the path to config file. | Reads config file named `kgenprog.toml` in the current directory. |
@@ -112,7 +112,7 @@ $ java -jar path/to/kGenProg.jar
 | `--crossover-first-variant` | Specifies first variant selection strategy for crossover. (`Elite`, `Random`). | `Random` |
 | `--crossover-second-variant` | Specifies second variant selection strategy for crossover.  (`Elite`, `GeneSimilarity`, `Random`, `TestSimilarity`). | `Random` |
 | `--patch-output` | Writes patch files to the output directory specified in `-o` option. | `false` |
-| `--history-record` | Records and writes generation process of all generated variants as JSON format. | `false` |
+| `--history-record` | Records and writes generation process of all generated variants as JSON format. Note that, this feature significantly reduces overall performance. | `false` |
 
 
 ## Use in your research

--- a/doc/ja/README.md
+++ b/doc/ja/README.md
@@ -93,7 +93,7 @@ $ java -jar path/to/kGenProg.jar
 | `-t`, `--test` | テストコード（単体テスト用のソースコード）へのパス，もしくはテストコードを含むディレクトリへのパス．スペース区切りで複数指定可能． | なし |
 | `-x`, `--exec-test` | 遺伝的アルゴリズム中に実行されるテストクラスの完全限定名．バグを発現させるテストクラスを指定してください．スペース区切りで複数指定可能． | すべてのテストクラス |
 | `-c`, `--cp` | 修正対象プロジェクトのビルドに必要なクラスパス．スペース区切りで複数指定可能． | なし |
-| `-o`, `--out-dir` | kGenProg が結果の出力を行うディレクトリへのパス．指定ディレクトリ直下に実行時のタイムスタンプを名前とするディレクトリが生成され，そのディレクトリに結果が出力されます． | カレントディレクトリ直下に `kgenprog-out` というディレクトリが作成される |
+| `-o`, `--out-dir` | kGenProg が結果を出力するディレクトリへのパス．出力ファイルはパッチファイルとGAの生成過程．それぞれ `--patch-output` と `--history-record` でon/offを切り替え可能． | `./kgenprog-out` |
 | `-v`, `--verbose` | 詳細なログを出力する | `false` |
 | `-q`, `--quiet` | エラー出力のみを行う | `false` |
 | `--config` | 設定ファイルへのパス | カレントディレクトリの `kgenprog.toml` を読み込む |
@@ -111,7 +111,8 @@ $ java -jar path/to/kGenProg.jar
 | `--crossover-type` | 交叉種別（`Random`，`Single`，`Uniform`） | `Random` |
 | `--crossover-first-variant` | 交叉対象の第一バリアントの選択方法（`Elite`，`Random`） | `Random` |
 | `--crossover-second-variant` | 交叉対象の第二バリアントの選択方法（`Elite`，`GeneSimilarity`，`Random`，`TestComplementary`) | `Random` |
-| `--history-record` | 個体の生成過程および生成された全個体を記録する | `false` |
+| `--patch-output` | 解のパッチファイル生成の有無 | `false` |
+| `--history-record` | 個体の生成過程および生成された全個体を記録するJSONファイルの記録の有無．この機能は実行速度の低下に繋がる点に注意 | `false` |
 
 ## 受賞
 - [Best Poster Award - APSEC 2018](http://www.apsec2018.org/)  

--- a/doc/kgenprog-config-template.toml
+++ b/doc/kgenprog-config-template.toml
@@ -47,7 +47,7 @@ test = ["path/to/test/source/code"]
 # Terminates searching solutions when the specified time has passed.
 #time-limit = <sec>
 
-# Specifies time limit to build and test for each variant in second 
+# Specifies time limit to build and test for each variant in second
 #test-time-limit = <sec>
 
 # Terminates searching solutions when the specified number of solutions are found.

--- a/doc/kgenprog-config-template.toml
+++ b/doc/kgenprog-config-template.toml
@@ -47,7 +47,7 @@ test = ["path/to/test/source/code"]
 # Terminates searching solutions when the specified time has passed.
 #time-limit = <sec>
 
-# Specifies time limit to build and test for each variant in second
+# Specifies time limit to build and test for each variant in second 
 #test-time-limit = <sec>
 
 # Terminates searching solutions when the specified number of solutions are found.
@@ -56,3 +56,8 @@ test = ["path/to/test/source/code"]
 # Specifies random seed used by random number generator.
 #random-seed = <num>
 
+# Writes patch files to the output directory specified in `-o` option.
+#patch-output = true/false
+
+# Records and writes generation process of all generated variants as JSON format.
+#history-record = true/false

--- a/example/BuildSuccess08/withPatchOutputFalse.toml
+++ b/example/BuildSuccess08/withPatchOutputFalse.toml
@@ -1,4 +1,4 @@
 root-dir = "./"
 src = ["src/"]
 test = ["test/"]
-no-output = false
+patch-output = false

--- a/example/BuildSuccess08/withPatchOutputTrue.toml
+++ b/example/BuildSuccess08/withPatchOutputTrue.toml
@@ -1,4 +1,4 @@
 root-dir = "./"
 src = ["src/"]
 test = ["test/"]
-no-output = true
+patch-output = true

--- a/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/Configuration.java
@@ -55,7 +55,6 @@ public class Configuration {
   public static final Path DEFAULT_OUT_DIR = Paths.get("kgenprog-out");
   public static final long DEFAULT_RANDOM_SEED = 0;
   public static final Scope.Type DEFAULT_SCOPE = Scope.Type.PACKAGE;
-  public static final boolean DEFAULT_NEED_NOT_OUTPUT = false;
   public static final FaultLocalization.Technique DEFAULT_FAULT_LOCALIZATION =
       FaultLocalization.Technique.Ochiai;
   public static final Crossover.Type DEFAULT_CROSSOVER_TYPE = Crossover.Type.Random;
@@ -63,7 +62,8 @@ public class Configuration {
       FirstVariantSelectionStrategy.Strategy.Random;
   public static final SecondVariantSelectionStrategy.Strategy DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY =
       SecondVariantSelectionStrategy.Strategy.Random;
-  public static final boolean DEFAULT_HISTORY_RECORD = false;
+  public static final boolean DEFAULT_IS_PATCH_OUTPUT = false;
+  public static final boolean DEFAULT_IS_HISTORY_RECORD = false;
 
   private final TargetProject targetProject;
   private final List<String> executionTests;
@@ -78,12 +78,12 @@ public class Configuration {
   private final Level logLevel;
   private final long randomSeed;
   private final Scope.Type scope;
-  private final boolean needNotOutput;
   private final FaultLocalization.Technique faultLocalization;
   private final Crossover.Type crossoverType;
   private final FirstVariantSelectionStrategy.Strategy firstVariantSelectionStrategy;
   private final SecondVariantSelectionStrategy.Strategy secondVariantSelectionStrategy;
-  private final boolean historyRecord;
+  private final boolean isPatchOutput;
+  private final boolean isHistoryRecord;
   private final Builder builder;
 
   private Configuration(final Builder builder) {
@@ -100,12 +100,12 @@ public class Configuration {
     this.logLevel = builder.logLevel;
     this.randomSeed = builder.randomSeed;
     this.scope = builder.scope;
-    this.needNotOutput = builder.needNotOutput;
     this.faultLocalization = builder.faultLocalization;
     this.crossoverType = builder.crossoverType;
     this.firstVariantSelectionStrategy = builder.firstVariantSelectionStrategy;
     this.secondVariantSelectionStrategy = builder.secondVariantSelectionStrategy;
-    this.historyRecord = builder.historyRecord;
+    this.isPatchOutput = builder.isPatchOutput;
+    this.isHistoryRecord = builder.isHistoryRecord;
     this.builder = builder;
   }
 
@@ -169,9 +169,6 @@ public class Configuration {
     return scope;
   }
 
-  public boolean needNotOutput() {
-    return needNotOutput;
-  }
 
   public FaultLocalization.Technique getFaultLocalization() {
     return faultLocalization;
@@ -189,8 +186,12 @@ public class Configuration {
     return secondVariantSelectionStrategy;
   }
 
+  public boolean isPatchOutput() {
+    return isPatchOutput;
+  }
+
   public boolean isHistoryRecord() {
-    return historyRecord;
+    return isHistoryRecord;
   }
 
   @Override
@@ -279,11 +280,6 @@ public class Configuration {
     @Conversion(ScopeTypeToString.class)
     private Scope.Type scope = DEFAULT_SCOPE;
 
-    @Option(name = "--no-output", usage = "Do not output anything.", hidden = true)
-    @com.electronwill.nightconfig.core.conversion.Path("no-output")
-    @PreserveNotNull
-    private boolean needNotOutput = DEFAULT_NEED_NOT_OUTPUT;
-
     @com.electronwill.nightconfig.core.conversion.Path("fault-localization")
     @PreserveNotNull
     @Conversion(FaultLocalizationTechniqueToString.class)
@@ -306,9 +302,13 @@ public class Configuration {
     private SecondVariantSelectionStrategy.Strategy secondVariantSelectionStrategy =
         DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY;
 
+    @com.electronwill.nightconfig.core.conversion.Path("patch-output")
+    @PreserveNotNull
+    private boolean isPatchOutput = DEFAULT_IS_PATCH_OUTPUT;
+
     @com.electronwill.nightconfig.core.conversion.Path("history-record")
     @PreserveNotNull
-    private boolean historyRecord = DEFAULT_HISTORY_RECORD;
+    private boolean isHistoryRecord = DEFAULT_IS_HISTORY_RECORD;
 
     private final transient Set<String> optionsSetByCmdLineArgs = new HashSet<>();
     private final transient Set<String> optionsSetByConfigFile = new HashSet<>();
@@ -470,10 +470,6 @@ public class Configuration {
       return this;
     }
 
-    public Builder setNeedNotOutput(final boolean needNotOutput) {
-      this.needNotOutput = needNotOutput;
-      return this;
-    }
 
     public Builder setFaultLocalization(final FaultLocalization.Technique faultLocalization) {
       this.faultLocalization = faultLocalization;
@@ -497,8 +493,13 @@ public class Configuration {
       return this;
     }
 
-    public Builder setHistoryRecord(final boolean historyRecord) {
-      this.historyRecord = historyRecord;
+    public Builder setPatchOutput(final boolean isPatchOutput) {
+      this.isPatchOutput = isPatchOutput;
+      return this;
+    }
+
+    public Builder setHistoryRecord(final boolean isHistoryRecord) {
+      this.isHistoryRecord = isHistoryRecord;
       return this;
     }
 
@@ -516,7 +517,7 @@ public class Configuration {
 
     private static void validateExistence(final Path path) {
       if (Files.notExists(path)) {
-        log.error(path.toString() + " does not exist.");
+        log.error("{} does not exist.", path);
         throw new IllegalArgumentException(path.toString() + " does not exist.");
       }
     }
@@ -718,7 +719,7 @@ public class Configuration {
     }
 
     @Option(name = "-o", aliases = "--out-dir", metaVar = "<path>",
-        usage = "Writes patches kGenProg generated to the specified directory.")
+        usage = "Specifies an output directory storing patch and/or history json.")
     private void setOutDirFromCmdLineParser(final String outDir) {
       this.outDir = Paths.get(outDir);
       this.optionsSetByCmdLineArgs.add("outDir");
@@ -830,9 +831,15 @@ public class Configuration {
       this.optionsSetByCmdLineArgs.add("secondVariantSelectionStrategy");
     }
 
-    @Option(name = "--history-record", usage = "Record historical element.")
-    private void setHistoryRecordFromCmdLineParser(final boolean historyRecord) {
-      this.historyRecord = historyRecord;
+    @Option(name = "--patch-output", usage = "Write patch files to output dir.")
+    private void setPatchOutputFromCmdLineParser(final boolean isPatchOutput) {
+      this.isPatchOutput = isPatchOutput;
+      this.optionsSetByCmdLineArgs.add("patchOutput");
+    }
+
+    @Option(name = "--history-record", usage = "Record and write generation history to output dir.")
+    private void setHistoryRecordFromCmdLineParser(final boolean isHistoryRecord) {
+      this.isHistoryRecord = isHistoryRecord;
       this.optionsSetByCmdLineArgs.add("historyRecord");
     }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/output/Exporters.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/Exporters.java
@@ -30,7 +30,7 @@ public class Exporters {
     final Set<Exporter> exporters = new HashSet<>();
     exporters.add(new PatchLogExporter()); // always write patch to log
 
-    if (!config.needNotOutput()) {
+    if (config.isPatchOutput()) {
       exporters.add(new PatchFileExporter(outdir));
     }
     if (config.isHistoryRecord()) {

--- a/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
@@ -55,14 +55,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -93,14 +93,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -132,14 +132,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -170,14 +170,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -208,14 +208,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -247,14 +247,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -284,14 +284,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -322,14 +322,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -360,14 +360,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -398,14 +398,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(logLevel);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -435,14 +435,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Level.DEBUG);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -473,14 +473,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, classPaths, JUnitVersion.JUNIT4);
@@ -511,14 +511,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(randomSeed);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -549,14 +549,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(scope);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -564,10 +564,10 @@ public class ConfigurationBuilderTest {
   }
 
   @Test
-  public void testBuildWithNeedNotOutput() {
-    final boolean needNotOutput = true;
-    final Builder builder = new Builder(rootDir, productPaths, testPaths).setNeedNotOutput(
-        needNotOutput);
+  public void testBuildWithNoPatchOutput() {
+    final boolean noPatchOutput = true;
+    final Builder builder = new Builder(rootDir, productPaths, testPaths).setPatchOutput(
+        noPatchOutput);
     final Configuration config = builder.build();
 
     assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
@@ -588,14 +588,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(needNotOutput);
+    assertThat(config.isPatchOutput()).isEqualTo(noPatchOutput);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -627,14 +627,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(faultLocalization);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -666,14 +666,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(crossoverType);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -706,11 +706,11 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(firstVariantSelectionStrategy);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -743,14 +743,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         secondVariantSelectionStrategy);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -781,14 +781,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -821,14 +821,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -861,14 +861,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -901,14 +901,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -941,14 +941,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -981,14 +981,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -1021,14 +1021,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -1060,14 +1060,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -1099,14 +1099,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Level.DEBUG);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -1138,14 +1138,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Level.ERROR);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -1178,14 +1178,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -1218,14 +1218,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(randomSeed);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -1258,14 +1258,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(scope);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, ImmutableList.of(productPath),
@@ -1340,9 +1340,9 @@ public class ConfigurationBuilderTest {
   }
 
   @Test
-  public void testBuildFromCmdLineArgsWithNeedNotOutput() {
+  public void testBuildFromCmdLineArgsWithPatchOutput() {
     final String[] args = {"-r", rootDir.toString(), "-s", productPath.toString(), "-t",
-        testPath.toString(), "--no-output"};
+        testPath.toString(), "--patch-output"};
     final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
 
     assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
@@ -1363,14 +1363,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isTrue();
+    assertThat(config.isPatchOutput()).isTrue();
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -1445,14 +1445,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1486,14 +1486,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1527,14 +1527,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1568,14 +1568,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1610,14 +1610,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1652,14 +1652,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1693,14 +1693,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1734,14 +1734,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1775,14 +1775,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1817,14 +1817,14 @@ public class ConfigurationBuilderTest {
 
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1856,14 +1856,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final Path classPath = rootDir.resolve("lib");
     final TargetProject expectedProject =
@@ -1899,14 +1899,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getRandomSeed()).isEqualTo(randomSeed);
 
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1941,14 +1941,14 @@ public class ConfigurationBuilderTest {
     final Scope.Type scope = Scope.Type.FILE;
     assertThat(config.getScope()).isEqualTo(scope);
 
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -1980,14 +1980,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final String executionTest1 = "example.FooTest";
     final String executionTest2 = "example.BarTest";
@@ -2000,8 +2000,8 @@ public class ConfigurationBuilderTest {
   }
 
   @Test
-  public void testBuildFromConfigFileWithNeedNotOutput() {
-    final Path configPath = rootDir.resolve("withNeedNotOutputTrue.toml");
+  public void testBuildFromConfigFileWithPatchOutput() {
+    final Path configPath = rootDir.resolve("withPatchOutputTrue.toml");
     final String[] args = {"--config", configPath.toString()};
     final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
 
@@ -2029,10 +2029,10 @@ public class ConfigurationBuilderTest {
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
-    final boolean needNotOutput = true;
-    assertThat(config.needNotOutput()).isEqualTo(needNotOutput);
+    final boolean isPatchOutput = true;
+    assertThat(config.isPatchOutput()).isEqualTo(isPatchOutput);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2068,14 +2068,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2114,14 +2114,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2160,14 +2160,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2205,14 +2205,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2250,14 +2250,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2296,14 +2296,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2343,14 +2343,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2388,14 +2388,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2432,14 +2432,14 @@ public class ConfigurationBuilderTest {
 
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2473,14 +2473,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final Path classPathFromConfigFile = rootDir.resolve("lib");
     final TargetProject projectWithClassPathFromConfigFile =
@@ -2524,14 +2524,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getRandomSeed()).isEqualTo(randomSeedFromCmdLine);
 
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2569,14 +2569,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getScope()).isNotEqualTo(scopeFromConfigFile);
     assertThat(config.getScope()).isEqualTo(scopeFromCmdLine);
 
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2609,14 +2609,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final String executionTestFromConfigFile1 = "example.FooTest";
     final String executionTestFromConfigFile2 = "example.BarTest";
@@ -2631,9 +2631,9 @@ public class ConfigurationBuilderTest {
   }
 
   @Test
-  public void testBuildFromConfigFileWithNeedNotOutputOverwrittenFromCmdLineArgs() {
-    final Path configPath = rootDir.resolve("withNeedNotOutputFalse.toml");
-    final String[] args = {"--config", configPath.toString(), "--no-output"};
+  public void testBuildFromConfigFileWithPatchOutputOverwrittenFromCmdLineArgs() {
+    final Path configPath = rootDir.resolve("withPatchOutputFalse.toml");
+    final String[] args = {"--config", configPath.toString(), "--patch-output"};
     final Configuration config = Configuration.Builder.buildFromCmdLineArgs(args);
 
     assertThat(config.getOutDir()).isEqualTo(Configuration.DEFAULT_OUT_DIR);
@@ -2655,16 +2655,16 @@ public class ConfigurationBuilderTest {
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
 
-    final boolean needNotOutputFromConfigFile = false;
-    assertThat(config.needNotOutput()).isNotEqualTo(needNotOutputFromConfigFile);
-    assertThat(config.needNotOutput()).isTrue();
+    final boolean isPatchOutputFromConfigFile = false;
+    assertThat(config.isPatchOutput()).isNotEqualTo(isPatchOutputFromConfigFile);
+    assertThat(config.isPatchOutput()).isTrue();
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2698,7 +2698,7 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
 
     final FaultLocalization.Technique faultLocalizationFromConfigFile = FaultLocalization.Technique.Ample;
     assertThat(config.getFaultLocalization()).isNotEqualTo(faultLocalizationFromConfigFile);
@@ -2708,7 +2708,7 @@ public class ConfigurationBuilderTest {
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2742,7 +2742,7 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
 
     final Crossover.Type crossoverTypeFromConfigFile = Crossover.Type.SinglePoint;
@@ -2752,7 +2752,7 @@ public class ConfigurationBuilderTest {
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2787,7 +2787,7 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
 
@@ -2799,7 +2799,7 @@ public class ConfigurationBuilderTest {
         firstVariantSelectionStrategyFromCmdLine);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject =
         TargetProjectFactory.create(rootDir, productPaths, testPaths, Collections.emptyList(),
@@ -2834,12 +2834,12 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final SecondVariantSelectionStrategy.Strategy secondVariantSelectionStrategyFromConfigFile =
         SecondVariantSelectionStrategy.Strategy.Random;
@@ -2887,14 +2887,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir,
         ImmutableList.of(link), testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);
@@ -2930,7 +2930,7 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getCrossoverType()).isEqualTo(Configuration.DEFAULT_CROSSOVER_TYPE);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(

--- a/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ConfigurationBuilderTest.java
@@ -682,14 +682,14 @@ public class ConfigurationBuilderTest {
     assertThat(config.getLogLevel()).isEqualTo(Configuration.DEFAULT_LOG_LEVEL);
     assertThat(config.getRandomSeed()).isEqualTo(Configuration.DEFAULT_RANDOM_SEED);
     assertThat(config.getScope()).isEqualTo(Configuration.DEFAULT_SCOPE);
-    assertThat(config.needNotOutput()).isEqualTo(Configuration.DEFAULT_NEED_NOT_OUTPUT);
+    assertThat(config.isPatchOutput()).isEqualTo(Configuration.DEFAULT_IS_PATCH_OUTPUT);
     assertThat(config.getFaultLocalization()).isEqualTo(Configuration.DEFAULT_FAULT_LOCALIZATION);
     assertThat(config.getMutationType()).isEqualTo(mutationType);
     assertThat(config.getFirstVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_FIRST_VARIANT_SELECTION_STRATEGY);
     assertThat(config.getSecondVariantSelectionStrategy()).isEqualTo(
         Configuration.DEFAULT_SECOND_VARIANT_SELECTION_STRATEGY);
-    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_HISTORY_RECORD);
+    assertThat(config.isHistoryRecord()).isEqualTo(Configuration.DEFAULT_IS_HISTORY_RECORD);
 
     final TargetProject expectedProject = TargetProjectFactory.create(rootDir, productPaths,
         testPaths, Collections.emptyList(), JUnitVersion.JUNIT4);

--- a/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/KGenProgMainTest.java
@@ -6,18 +6,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import jp.kusumotolab.kgenprog.KGenProgMain.ExitStatus;
 
 public class KGenProgMainTest {
 
   private final static String PRODUCT_NAME = "src/example/CloseToZero.java";
   private final static String TEST_NAME = "src/example/CloseToZeroTest.java";
-
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
 
   /*
    * 引数で与えられた情報を利用して，CUILauncher経由でkGenProgMainを実行するメソッド
@@ -27,17 +22,14 @@ public class KGenProgMainTest {
 
     final List<Path> productPaths = Collections.singletonList(productPath);
     final List<Path> testPaths = Collections.singletonList(testPath);
-    final Path outDir = tempFolder.getRoot()
-        .toPath();
-
-    final Configuration config =
-        new Configuration.Builder(rootPath, productPaths, testPaths).setTimeLimitSeconds(600)
-            .setTestTimeLimitSeconds(1)
-            .setMaxGeneration(100)
-            .setRequiredSolutionsCount(1)
-            .setOutDir(outDir)
-            .setNeedNotOutput(true)
-            .build();
+    final Configuration config = new Configuration.Builder(rootPath, productPaths, testPaths)
+        .setTimeLimitSeconds(600)
+        .setTestTimeLimitSeconds(1)
+        .setMaxGeneration(100)
+        .setRequiredSolutionsCount(1)
+        .setPatchOutput(false) // to prevent file output
+        .setHistoryRecord(false) // to prevent file output
+        .build();
 
     final CUILauncher launcher = new CUILauncher();
     return launcher.launch(config);

--- a/src/test/java/jp/kusumotolab/kgenprog/output/ExportersTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/ExportersTest.java
@@ -15,7 +15,7 @@ import jp.kusumotolab.kgenprog.testutil.TestUtil;
 public class ExportersTest {
 
   @Test
-  public void testInstanciationWithPreviousResults() throws IOException {
+  public void testInstantiationWithPreviousResults() throws IOException {
     // setup previous results which contains some files and a sub-directory
     final Path outdir = TestUtil.createVirtualDir();
     Files.createDirectory(outdir);
@@ -81,7 +81,6 @@ public class ExportersTest {
     assertThat(outdir).exists();
     assertThat(outdir.resolve(JSONExporter.JSON_FILENAME)).exists();
   }
-
 
   private Configuration setupMinimalConfig(final Path outdir) {
     return setupMinimalConfig(outdir, false, false);

--- a/src/test/java/jp/kusumotolab/kgenprog/output/ExportersTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/output/ExportersTest.java
@@ -22,13 +22,12 @@ public class ExportersTest {
     Files.createFile(outdir.resolve("a.txt"));
     Files.createFile(outdir.resolve("z.txt"));
     Files.createDirectory(outdir.resolve("x"));
-    Files.createFile(outdir.resolve("x")
-        .resolve("xxx"));
+    Files.createFile(outdir.resolve("x/xxx"));
 
     final Configuration config = setupMinimalConfig(outdir);
-    final Exporters exporters = new Exporters(config);
+    new Exporters(config);
 
-    // outdir should be deleted by the instanciation
+    // outdir should be deleted by the instantiation
     assertThat(outdir).doesNotExist();
   }
 
@@ -41,58 +40,60 @@ public class ExportersTest {
 
     exporters.exportAll(store);
 
+    // no output dir exists by default
+    assertThat(outdir).doesNotExist();
+  }
+
+  @Test
+  public void testExportAllWithHistoryRecord() {
+    final Path outdir = TestUtil.createVirtualDir();
+    final Configuration config = setupMinimalConfig(outdir, false, true);
+    final Exporters exporters = new Exporters(config);
+    final VariantStore store = TestUtil.createVariantStoreWithDefaultStrategies(config);
+
+    exporters.exportAll(store);
+
     // assert only file exists (contents should be tested in each exporter test)
     assertThat(outdir).exists();
     assertThat(outdir.resolve(JSONExporter.JSON_FILENAME)).exists();
   }
 
   @Test
-  public void testExportAllWithNoHistoryRecord() {
-    final Path outdir = TestUtil.createVirtualDir();
-    final Configuration config = setupMinimalConfig(outdir, false, false);
-    final Exporters exporters = new Exporters(config);
-    final VariantStore store = TestUtil.createVariantStoreWithDefaultStrategies(config);
-
-    exporters.exportAll(store);
-
-    // assert only file exists (contents should be tested in each exporter test)
-    assertThat(outdir).exists();
-    assertThat(outdir.resolve(JSONExporter.JSON_FILENAME)).doesNotExist();
-  }
-
-  @Test
-  public void testExportAllWithNoOutput01() {
+  public void testExportAllWithPatchOutput() {
     final Path outdir = TestUtil.createVirtualDir();
     final Configuration config = setupMinimalConfig(outdir, true, false);
     final Exporters exporters = new Exporters(config);
     final VariantStore store = TestUtil.createVariantStoreWithDefaultStrategies(config);
 
     exporters.exportAll(store);
-    assertThat(outdir).doesNotExist(); // asssert no file output
+    assertThat(outdir).exists();
+    assertThat(outdir.resolve(JSONExporter.JSON_FILENAME)).doesNotExist();
   }
 
   @Test
-  public void testExportAllWithNoOutput02() {
+  public void testExportAllWithBothOutput() {
     final Path outdir = TestUtil.createVirtualDir();
     final Configuration config = setupMinimalConfig(outdir, true, true);
     final Exporters exporters = new Exporters(config);
     final VariantStore store = TestUtil.createVariantStoreWithDefaultStrategies(config);
 
     exporters.exportAll(store);
-    assertThat(outdir).exists(); // outdir should be created by historyrecord
+    assertThat(outdir).exists();
+    assertThat(outdir.resolve(JSONExporter.JSON_FILENAME)).exists();
   }
 
+
   private Configuration setupMinimalConfig(final Path outdir) {
-    return setupMinimalConfig(outdir, false, true);
+    return setupMinimalConfig(outdir, false, false);
   }
 
   private Configuration setupMinimalConfig(final Path outdir,
-      final boolean isNoOutput,
+      final boolean isPatchOutput,
       final boolean isHistoryRecord) {
     final Path rootPath = Paths.get("example/BuildSuccess01");
     final TargetProject targetProject = TargetProjectFactory.create(rootPath);
     return new Configuration.Builder(targetProject)
-        .setNeedNotOutput(isNoOutput)
+        .setPatchOutput(isPatchOutput)
         .setHistoryRecord(isHistoryRecord)
         .setOutDir(outdir)
         .build();


### PR DESCRIPTION
resolve #801
depends PR #804

### notes
PR #804 からの派生ブランチである点に注意．
PR #804 解決後にreviewしてください．
~~行儀の悪いPRだけど依存を持つので仕方なし．~~
![image](https://user-images.githubusercontent.com/5342911/100977699-b1361980-3584-11eb-9e71-ea4a6310a3c1.png)

~~レビュー時のファイル差分はこっち見て下さい．~~
~~https://github.com/kusumotolab/kGenProg/compare/better-exporter-params..separate-exporters?w=1~~

#804 がマージされたのでmasterからマージさせておいた．
行儀の悪さは解消．

### やったこと
- #801 の解決
- 伴い，ExporterTestのテスト手段を自然な形に
- READMEやcuiヘルプの修正

### tungled
kgpMainTestのファイル出力の指定周りを改善
ExporterTest の CRLF → LF