### PR TITLE
build-failed個体の原因を出力する

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/build/ProjectBuilder.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/build/ProjectBuilder.java
@@ -13,6 +13,8 @@ import javax.tools.JavaCompiler.CompilationTask;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import jp.kusumotolab.kgenprog.project.GeneratedAST;
 import jp.kusumotolab.kgenprog.project.GeneratedSourceCode;
 import jp.kusumotolab.kgenprog.project.factory.TargetProject;
@@ -30,6 +32,8 @@ import jp.kusumotolab.kgenprog.project.factory.TargetProject;
  * @author shinsuke
  */
 public class ProjectBuilder {
+
+  public static final Logger log = LoggerFactory.getLogger(ProjectBuilder.class);
 
   // TODO デフォルトのコンパイラバージョンは要検討．ひとまず1.8固定．
   // TODO #289: 加え，toml からコンパイラバージョンを指定できるようにするべき．
@@ -79,6 +83,23 @@ public class ProjectBuilder {
       final boolean success = build(allAsts, javaSourceObjects, diagnostics, progress);
 
       if (!success) {
+        if (!diagnostics.getDiagnostics()
+            .isEmpty()) {
+          final StringBuilder sb = new StringBuilder();
+          sb.append("build failed.")
+              .append(System.lineSeparator())
+              .append(diagnostics.getDiagnostics()
+                  .get(0));
+          if (diagnostics.getDiagnostics()
+              .size() > 1) {
+            sb.append(System.lineSeparator())
+                .append("and ")
+                .append(diagnostics.getDiagnostics()
+                    .size() - 1)
+                .append(" more.");
+          }
+          log.debug(sb.toString());
+        }
         return new EmptyBuildResults(diagnostics, progress.toString());
       }
     }


### PR DESCRIPTION
resolve #737
Log level=DEBUGの時にbuild failed個体の失敗原因を次のように出力します
```
2020-12-05 15:14:08 [Time-limited test] [DEBUG] ProjectBuilder - build failed.
example.QuickSort:20: エラー: 変数 leftはすでにメソッド quicksort(int[],int,int)で定義されています
    int left = 0;
        ^
and 7 more.
```

#737 では `JDTOperation` がエラーを吐いた直後に来るように見本を書いていますが，実装ではbuild failedの理由が `JDTOperation` の直後に来るとは限りません．


なお，入力ファイルが最初からコンパイルできないときに情報が重複しています．
情報量が違うのでとりあえず重複した状態のままです．
```
(config info)
================================================================
2020-12-05 15:13:58 [Time-limited test] [DEBUG] ProjectBuilder - build failed.
example.CloseToZero:7: エラー: シンボルを見つけられません
      k++; // build failure
      ^
  シンボル:   変数 k
  場所: クラス example.CloseToZero
2020-12-05 15:13:58 [Time-limited test] [ERROR] KGenProgMain - Failed to build the specified project.
2020-12-05 15:13:58 [Time-limited test] [ERROR] KGenProgMain - 

2020-12-05 15:13:58 [Time-limited test] [ERROR] KGenProgMain - シンボルを見つけられません
  シンボル:   変数 k
  場所: クラス example.CloseToZero
```