### PR TITLE
テスト実行時間のログ出力機能を追加

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -270,7 +270,8 @@ public class KGenProgMain {
     }
 
     private String createTestTimeSummary(final List<Variant> variants) {
-      return String.format("Test time: sum %s ms, max %s ms, min %s ms",
+      return String.format(
+          "Test execution time: sum %s ms, max %s ms, min %s ms",
           getSumTestTime(variants),
           getMaxTestTime(variants),
           getMinTestTime(variants));
@@ -279,23 +280,28 @@ public class KGenProgMain {
     private String getSumTestTime(final List<Variant> variants) {
       return format.format(
           variants.stream()
-              .mapToDouble(e -> e.getTestResults().getTestTime())
+              .mapToDouble(e -> e.getTestResults()
+                  .getTestTime())
+              .filter(e -> Double.compare(e, Double.NaN) != 0)
               .sum());
     }
+
     private String getMaxTestTime(final List<Variant> variants) {
-      return format.format(
-          variants.stream()
-          .mapToDouble(e -> e.getTestResults().getTestTime())
-          .filter(e -> e != 0)
-          .max().orElse(0));
+      final var max = variants.stream()
+          .mapToDouble(e -> e.getTestResults()
+              .getTestTime())
+          .filter(e -> Double.compare(e, Double.NaN) != 0)
+          .max();
+      return format.format(max.isEmpty() ? "--" : max.orElse(Double.NaN));
     }
 
     private String getMinTestTime(final List<Variant> variants) {
-      return format.format(
-          variants.stream()
-              .mapToDouble(e -> e.getTestResults().getTestTime())
-              .filter(e -> e != 0)
-              .min().orElse(0));
+      final var min = variants.stream()
+          .mapToDouble(e -> e.getTestResults()
+              .getTestTime())
+          .filter(e -> Double.compare(e, Double.NaN) != 0)
+          .min();
+      return format.format(min.isEmpty() ? "--" : min.orElse(Double.NaN));
     }
 
     private int count(final List<Variant> variants, final Predicate<Variant> p) {

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalDouble;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -287,7 +288,7 @@ public class KGenProgMain {
     }
 
     private String getMaxTestTime(final List<Variant> variants) {
-      final var max = variants.stream()
+      final OptionalDouble max = variants.stream()
           .mapToDouble(e -> e.getTestResults()
               .getTestTime())
           .filter(e -> Double.compare(e, Double.NaN) != 0)
@@ -296,7 +297,7 @@ public class KGenProgMain {
     }
 
     private String getMinTestTime(final List<Variant> variants) {
-      final var min = variants.stream()
+      final OptionalDouble min = variants.stream()
           .mapToDouble(e -> e.getTestResults()
               .getTestTime())
           .filter(e -> Double.compare(e, Double.NaN) != 0)

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -292,7 +292,7 @@ public class KGenProgMain {
               .getTestTime())
           .filter(e -> Double.compare(e, Double.NaN) != 0)
           .max();
-      return format.format(max.isEmpty() ? "--" : max.orElse(Double.NaN));
+      return max.isEmpty() ? "--" : format.format(max.orElse(Double.NaN));
     }
 
     private String getMinTestTime(final List<Variant> variants) {
@@ -301,7 +301,7 @@ public class KGenProgMain {
               .getTestTime())
           .filter(e -> Double.compare(e, Double.NaN) != 0)
           .min();
-      return format.format(min.isEmpty() ? "--" : min.orElse(Double.NaN));
+      return min.isEmpty() ? "--" : format.format(min.orElse(Double.NaN));
     }
 
     private int count(final List<Variant> variants, final Predicate<Variant> p) {

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -283,7 +283,7 @@ public class KGenProgMain {
           variants.stream()
               .mapToDouble(e -> e.getTestResults()
                   .getTestTime())
-              .filter(e -> Double.compare(e, Double.NaN) != 0)
+              .filter(e -> !Double.isNaN(e))
               .sum());
     }
 
@@ -291,7 +291,7 @@ public class KGenProgMain {
       final OptionalDouble max = variants.stream()
           .mapToDouble(e -> e.getTestResults()
               .getTestTime())
-          .filter(e -> Double.compare(e, Double.NaN) != 0)
+          .filter(e -> !Double.isNaN(e))
           .max();
       return max.isEmpty() ? "--" : format.format(max.orElse(Double.NaN));
     }
@@ -300,7 +300,7 @@ public class KGenProgMain {
       final OptionalDouble min = variants.stream()
           .mapToDouble(e -> e.getTestResults()
               .getTestTime())
-          .filter(e -> Double.compare(e, Double.NaN) != 0)
+          .filter(e -> !Double.isNaN(e))
           .min();
       return min.isEmpty() ? "--" : format.format(min.orElse(Double.NaN));
     }

--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -245,6 +245,8 @@ public class KGenProgMain {
           .append(System.lineSeparator())
           .append(createFitnessSummary(variants))
           .append(System.lineSeparator())
+          .append(createTestTimeSummary(variants))
+          .append(System.lineSeparator())
           .append("----------------------------------------------------------------")
           .append(System.lineSeparator());
       log.info(sb.toString());
@@ -265,6 +267,35 @@ public class KGenProgMain {
           count(variants, v -> v.triedBuild() && !v.isBuildSucceeded()),
           count(variants, v -> !v.isSyntaxValid() && !v.isReproduced()),
           count(variants, Variant::isReproduced));
+    }
+
+    private String createTestTimeSummary(final List<Variant> variants) {
+      return String.format("Test time: sum %s ms, max %s ms, min %s ms",
+          getSumTestTime(variants),
+          getMaxTestTime(variants),
+          getMinTestTime(variants));
+    }
+
+    private String getSumTestTime(final List<Variant> variants) {
+      return format.format(
+          variants.stream()
+              .mapToDouble(e -> e.getTestResults().getTestTime())
+              .sum());
+    }
+    private String getMaxTestTime(final List<Variant> variants) {
+      return format.format(
+          variants.stream()
+          .mapToDouble(e -> e.getTestResults().getTestTime())
+          .filter(e -> e != 0)
+          .max().orElse(0));
+    }
+
+    private String getMinTestTime(final List<Variant> variants) {
+      return format.format(
+          variants.stream()
+              .mapToDouble(e -> e.getTestResults().getTestTime())
+              .filter(e -> e != 0)
+              .min().orElse(0));
     }
 
     private int count(final List<Variant> variants, final Predicate<Variant> p) {

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/EmptyTestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/EmptyTestResults.java
@@ -15,7 +15,7 @@ public class EmptyTestResults extends TestResults {
   private final String cause;
 
   public EmptyTestResults(final BuildResults buildResults) {
-    super(buildResults);
+    super(buildResults, null);
     this.cause = buildResults.diagnostics.getDiagnostics()
         .stream()
         .map(d -> d.getMessage(null))
@@ -82,5 +82,14 @@ public class EmptyTestResults extends TestResults {
    */
   public String getCause() {
     return cause;
+  }
+
+  /**
+   * {@inheritDoc}<br>
+   * Double.NaNを返す
+   */
+  @Override
+  public double getTestTime() {
+    return Double.NaN;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/EmptyTestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/EmptyTestResults.java
@@ -15,7 +15,7 @@ public class EmptyTestResults extends TestResults {
   private final String cause;
 
   public EmptyTestResults(final BuildResults buildResults) {
-    super(buildResults, null);
+    super(buildResults);
     this.cause = buildResults.diagnostics.getDiagnostics()
         .stream()
         .map(d -> d.getMessage(null))

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
@@ -14,6 +14,7 @@ import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 import jp.kusumotolab.kgenprog.project.build.BuildResults;
 import jp.kusumotolab.kgenprog.project.build.JavaBinaryObject;
 import jp.kusumotolab.kgenprog.project.test.Coverage.Status;
+import org.apache.commons.lang3.time.StopWatch;
 
 /**
  * 全テストの結果を表すオブジェクト．<br>
@@ -27,9 +28,9 @@ public class TestResults {
 
   private BuildResults buildResults;
 
-  private double testTime = 0;
-
   private final Map<FullyQualifiedName, TestResult> value;
+
+  private StopWatch stopWatch;
 
   /**
    * constructor
@@ -41,9 +42,10 @@ public class TestResults {
   /**
    * constructor
    */
-  public TestResults(final BuildResults buildResults) {
+  public TestResults(final BuildResults buildResults, final StopWatch stopWatch) {
     this();
     this.buildResults = buildResults;
+    this.stopWatch = stopWatch;
   }
 
   /**
@@ -290,11 +292,11 @@ public class TestResults {
         .collect(Collectors.toSet());
   }
 
-  public void setTestTime(double testTime) {
-    this.testTime = testTime;
-  }
-
+  /**
+   * テスト実行時間
+   * @return
+   */
   public double getTestTime() {
-    return testTime;
+    return this.stopWatch.getTime();
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
@@ -29,14 +29,14 @@ public class TestResults {
 
   private final Map<FullyQualifiedName, TestResult> value;
 
-  private final double testTime;
+  private final double testExecTime;
 
   /**
    * constructor
    */
   public TestResults() {
     this.value = new HashMap<>();
-    this.testTime = Double.NaN;
+    this.testExecTime = Double.NaN;
   }
 
   /**
@@ -45,25 +45,18 @@ public class TestResults {
   public TestResults(final BuildResults buildResults) {
     this.value = new HashMap<>();
     this.buildResults = buildResults;
-    this.testTime = Double.NaN;
+    this.testExecTime = Double.NaN;
   }
 
   /**
    * constructor
    */
-  public TestResults(final BuildResults buildResults, final double testTime) {
+  public TestResults(final BuildResults buildResults, final double testExecTime,
+      final List<TestResult> testResultList) {
     this.value = new HashMap<>();
+    testResultList.forEach(testResult -> this.value.put(testResult.executedTestFQN, testResult));
     this.buildResults = buildResults;
-    this.testTime = testTime;
-  }
-
-  /**
-   * 新規TestResultの追加
-   *
-   * @param testResult
-   */
-  public void add(final TestResult testResult) {
-    this.value.put(testResult.executedTestFQN, testResult);
+    this.testExecTime = testExecTime;
   }
 
   /**
@@ -303,9 +296,10 @@ public class TestResults {
 
   /**
    * テスト実行時間
+   *
    * @return
    */
   public double getTestTime() {
-    return this.testTime;
+    return this.testExecTime;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
@@ -30,7 +30,7 @@ public class TestResults {
 
   private final Map<FullyQualifiedName, TestResult> value;
 
-  private StopWatch stopWatch;
+  private double testTime;
 
   /**
    * constructor
@@ -42,10 +42,17 @@ public class TestResults {
   /**
    * constructor
    */
-  public TestResults(final BuildResults buildResults, final StopWatch stopWatch) {
+  public TestResults(final BuildResults buildResults) {
     this();
     this.buildResults = buildResults;
-    this.stopWatch = stopWatch;
+  }
+
+  /**
+   * constructor
+   */
+  public TestResults(final BuildResults buildResults, final double testTime) {
+    this(buildResults);
+    this.testTime = testTime;
   }
 
   /**
@@ -297,6 +304,6 @@ public class TestResults {
    * @return
    */
   public double getTestTime() {
-    return this.stopWatch.getTime();
+    return this.testTime;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
@@ -27,6 +27,8 @@ public class TestResults {
 
   private BuildResults buildResults;
 
+  private double testTime = 0;
+
   private final Map<FullyQualifiedName, TestResult> value;
 
   /**
@@ -286,5 +288,13 @@ public class TestResults {
         .stream()
         .map(JavaBinaryObject::getFqn)
         .collect(Collectors.toSet());
+  }
+
+  public void setTestTime(double testTime) {
+    this.testTime = testTime;
+  }
+
+  public double getTestTime() {
+    return testTime;
   }
 }

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
@@ -14,7 +14,6 @@ import jp.kusumotolab.kgenprog.project.ProductSourcePath;
 import jp.kusumotolab.kgenprog.project.build.BuildResults;
 import jp.kusumotolab.kgenprog.project.build.JavaBinaryObject;
 import jp.kusumotolab.kgenprog.project.test.Coverage.Status;
-import org.apache.commons.lang3.time.StopWatch;
 
 /**
  * 全テストの結果を表すオブジェクト．<br>

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestResults.java
@@ -29,28 +29,31 @@ public class TestResults {
 
   private final Map<FullyQualifiedName, TestResult> value;
 
-  private double testTime;
+  private final double testTime;
 
   /**
    * constructor
    */
   public TestResults() {
     this.value = new HashMap<>();
+    this.testTime = Double.NaN;
   }
 
   /**
    * constructor
    */
   public TestResults(final BuildResults buildResults) {
-    this();
+    this.value = new HashMap<>();
     this.buildResults = buildResults;
+    this.testTime = Double.NaN;
   }
 
   /**
    * constructor
    */
   public TestResults(final BuildResults buildResults, final double testTime) {
-    this(buildResults);
+    this.value = new HashMap<>();
+    this.buildResults = buildResults;
     this.testTime = testTime;
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
@@ -106,6 +106,7 @@ class TestThread extends Thread {
       return;
     }
 
+    final long beginTestTime = System.nanoTime();
     testResults = new TestResults(buildResults);
 
     final List<FullyQualifiedName> productFQNs = getProductFQNs();
@@ -142,6 +143,10 @@ class TestThread extends Thread {
       // Should handle safely
       // ひとまず本クラスをThreadで包むためにRuntimeExceptionでエラーを吐く．
       throw new RuntimeException(e);
+    }
+    finally {
+      final long endTestTime = System.nanoTime();
+      testResults.setTestTime((endTestTime - beginTestTime) * 0.000001);
     }
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.time.StopWatch;
 import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.CoverageBuilder;
 import org.jacoco.core.data.ExecutionData;
@@ -106,8 +108,9 @@ class TestThread extends Thread {
       return;
     }
 
-    final long beginTestTime = System.nanoTime();
-    testResults = new TestResults(buildResults);
+    final StopWatch stopWatch = new StopWatch();
+    stopWatch.start();
+    testResults = new TestResults(buildResults, stopWatch);
 
     final List<FullyQualifiedName> productFQNs = getProductFQNs();
     final List<FullyQualifiedName> executionTestFQNs = getExecutionTestFQNs();
@@ -145,8 +148,7 @@ class TestThread extends Thread {
       throw new RuntimeException(e);
     }
     finally {
-      final long endTestTime = System.nanoTime();
-      testResults.setTestTime((endTestTime - beginTestTime) * 0.000001);
+      stopWatch.stop();
     }
   }
 

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
@@ -155,7 +155,6 @@ class TestThread extends Thread {
    *
    * @param memoryClassLoader
    * @param fqns
-   * @param isInstrument
    * @throws IOException
    */
   private void addAllDefinitions(final MemoryClassLoader memoryClassLoader,

--- a/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/test/TestThread.java
@@ -127,7 +127,7 @@ class TestThread extends Thread {
       // JUnitカスタムによる強制タイムアウトの指定
       junitCore.setTimeout(timeout, timeUnit);
 
-      final CoverageMeasurementListener listener = new CoverageMeasurementListener();
+      final RunListener listener = new CoverageMeasurementListener();
       junitCore.addListener(listener);
 
       // JUnit実行対象の題材テストはMemClassLoaderでロードされているので，
@@ -137,7 +137,7 @@ class TestThread extends Thread {
       junitCore.run(testClasses.toArray(new Class<?>[testClasses.size()]));
 
       stopWatch.stop();
-      testResults = listener.getTestResults(buildResults, stopWatch.getTime());
+      testResults = ((CoverageMeasurementListener) listener).getTestResults(buildResults, stopWatch.getTime());
     } catch (final ClassNotFoundException e) {
       // クラスロードに失敗．FQNの指定ミスの可能性が大
       testResults = new EmptyTestResults("failed to load classes.");


### PR DESCRIPTION
resolve #739 
kGPの各世代におけるテスト実行に要する時間を計測し、その結果を出力する機能を追加しました。