### PR TITLE
GHAのリリースバグを修正

### DIFF
--- a/.github/check-version.sh
+++ b/.github/check-version.sh
@@ -22,7 +22,7 @@ fi
 
 # Check published releases
 
-HTTP_STATUS=$(curl -LI "${GITHUB_TAG_URL_BASE}/${WANTED_VERSION}" -o /dev/null -w '%{http_code}\n' -s)
+HTTP_STATUS=$(curl -LI "${GITHUB_TAG_URL_BASE}/v${WANTED_VERSION}" -o /dev/null -w '%{http_code}\n' -s)
 
 if [[ $HTTP_STATUS = '400' ]]; then
   echo "[ERROR] Version number $WANTED_VERSION cannot be used as a tag." >&2


### PR DESCRIPTION
resolve #815 

正確にはnightly-build のリリースではなく正式バージョン（`vX.Y.Z`) のリリースバグ

### 原因
バージョン確認のスクリプトにバグがあった
→ 指定されたバージョンが既に存在している ことを把握できず，上書きしようとしてfailしていた