### PR TITLE
CHANGELOGの生成バグを修正

### DIFF
--- a/.github/generate-change-log.sh
+++ b/.github/generate-change-log.sh
@@ -30,4 +30,6 @@ github-changes \
   --only-pulls --use-commit-body \
   --for-tag nightly-build
 
-sed -i -e '1,3d' ./workspace/CHANGELOG.md
+sed -i -e '1,3d' ./CHANGELOG.md
+cp ./CHANGELOG.md ./workspace/CHANGELOG.md
+rm ./CHANGELOG.md


### PR DESCRIPTION
resolve #824 

原因：カレントディレクトリ直下にCHANGELOGが生成されることを考慮していなかった