### PR TITLE
初期個体が失敗するテストメソッドの出力に改行を追加

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/KGenProgMain.java
@@ -227,7 +227,8 @@ public class KGenProgMain {
               succeededResults.size() + failedResults.size()))
           .append(System.lineSeparator());
       testResults.getFailedTestResults()
-          .forEach(r -> sb.append(String.format("%s: %s", r.executedTestFQN, r.getFailedReason())));
+          .forEach(r -> sb.append(String.format("%s: %s", r.executedTestFQN, r.getFailedReason()))
+              .append(System.lineSeparator()));
       log.info(sb.toString());
     }
 


### PR DESCRIPTION
resolve #838

before
```
2021-01-20 12:59:55 [Time-limited test] [INFO]  KGenProgMain - initial failed tests (3/4)
example.CloseToZeroTest.test04: expected:<-9> but was:<-8>example.CloseToZeroTest.test01: expected:<9> but was:<10>example.CloseToZeroTest.test02: expected:<99> but was:<100>
```

after
```
2021-02-17 17:41:09 [Time-limited test] [INFO]  KGenProgMain - initial failed tests (3/4)
example.CloseToZeroTest.test04: expected:<-9> but was:<-8>
example.CloseToZeroTest.test01: expected:<9> but was:<10>
example.CloseToZeroTest.test02: expected:<99> but was:<100>

2021-02-17 17:41:09 [Time-limited test] [INFO]  KGenProgMain - GA started
```

issueで言及しているのは複数行の出力の時ですが，全ての場合で改行を追加したため，最後に空行が発生します