### PR TITLE
jitpackでのビルドに失敗する問題を解決

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id 'jacoco'
 
     // Maven plugin to use JitPack
-    id 'maven-publish'
+    id 'maven'
 
     // Gradle lint
     id "nebula.lint" version "16.9.0"

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
resolved #849

ビルド失敗の理由と対応
* JDK 8使ってた → `jitpack.yml` でJDK11を指定
* 成果物を見失ってた → 利用プラグインを成功していた`v1.7.0`のものに戻した

ビルド成功のログ
https://jitpack.io/com/github/kusumotolab/kGenProg/create-jitpack-setting-file-95708812bb-1/build.log


