### PR TITLE
maven-publishの設定を追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,32 @@ jar {
     }
 }
 
+//config of maven-publish plugin for jitpack
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'kGenProg'
+            from components.java
+            pom {
+                name = 'kGenProg'
+                description = 'A High-performance, High-extensibility and High-portability APR System'
+                inceptionYear = '2018'
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://github.com/kusumotolab/kGenProg/blob/master/LICENSE'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/kusumotolab/kGenProg.git'
+                    developerConnection = 'scm:git:ssh://git@github.com/kusumotolab/kGenProg.git'
+                    url = 'https://github.com/kusumotolab/kGenProg'
+                }
+            }
+        }
+    }
+}
+
 // Define App's version
 version = currentVersion
 

--- a/docs/LIBRARIES.md
+++ b/docs/LIBRARIES.md
@@ -1,15 +1,15 @@
 kGenProg uses the following libraries WITHOUT any modifications.
 
-Apache Commons Lang: APACHE Lisence 2.0, 
+Apache Commons Lang: Apache License 2.0, 
 https://commons.apache.org/proper/commons-lang/
 
-Apache Commons Codec: APACHE licens, 2.0, 
+Apache Commons Codec: Apache License 2.0, 
 https://commons.apache.org/proper/commons-codec/
 
 Apache Maven: Apache License 2.0,
 https://maven.apache.org/
 
-args4j: MIT license, 
+args4j: MIT License, 
 https://args4j.kohsuke.org/
 
 ASM: 3-Clause BSD License, 
@@ -45,7 +45,7 @@ https://code.google.com/archive/p/java-diff-utils/
 LOGBack: dual-licensed under Eclipse Public License 1.0 and the LGPL 2.1, 
 https://logback.qos.ch/
 
-mockito: MIT license
+mockito: MIT License
 https://site.mockito.org/
 
 NightConfig: LGPL,
@@ -54,7 +54,7 @@ https://github.com/TheElectronWill/night-config
 ReactiveX RxJava: Apache License 2.0,
 https://github.com/ReactiveX/RxJava
 
-SLF4J: MIT license, 
+SLF4J: MIT License, 
 https://www.slf4j.org/
 
 


### PR DESCRIPTION
resolve #858

## 行ったこと
https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:complete_example
を参考に，maven-publishの設定をbuild.gradleに追記．

ビルドを可能とするには以下で十分だが，本PRではライブラリのメタ情報も追記．
```gradle
publishing {
    publications {
        mavenJava(MavenPublication) {
            from components.java
    }
}
```

## 確認したこと
JitPackでのビルド成功
https://jitpack.io/#kusumotolab/kGenProg
https://jitpack.io/com/github/kusumotolab/kGenProg/add-maven-publish-config-f16fcb03dd-1/build.log
![image](https://user-images.githubusercontent.com/29752757/158346731-865c9398-8e3b-4529-8ced-d72b33f1a087.png)


## reviewerに確認いただきたいこと
1. pomの内容に過不足/間違いがないか
1. Groovyのお作法