### PR TITLE
jdk17 に対応

### DIFF
--- a/.github/workflows/test-branches.yml
+++ b/.github/workflows/test-branches.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['11', '12', '13']
+        java: ['11', '17']
         platform: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Git checkout
@@ -32,8 +32,9 @@ jobs:
           build-cache-
           build-
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Resolve dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:1.2.3'
     implementation 'com.github.albfernandez:juniversalchardet:2.3.2'
     implementation 'com.github.wumpz:diffutils:2.2'
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.10'
     implementation 'com.google.guava:guava:26.0-jre'
     implementation 'commons-codec:commons-codec:1.11'
     implementation 'io.gsonfire:gson-fire:1.8.5'
@@ -67,11 +67,11 @@ dependencies {
     implementation 'org.jacoco:org.jacoco.core:0.8.1'
     implementation 'org.slf4j:slf4j-api:1.7.25'
 
-    testImplementation 'org.assertj:assertj-core:3.18.1'
-    testImplementation 'org.mockito:mockito-core:2.+'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.mockito:mockito-core:4.10.0'
     testImplementation 'com.google.jimfs:jimfs:1.1'
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
-    testImplementation 'net.javacrumbs.json-unit:json-unit-assertj:2.25.0'
+    testImplementation 'net.javacrumbs.json-unit:json-unit-assertj:2.36.0'
 
     // Declare by "runtimeOnly" cuz hamcrest is necessary to execute junit-test dynamically,
     // but it doesn't seem to be loaded on compile task.

--- a/src/main/java/jp/kusumotolab/kgenprog/output/DurationSerializer.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/DurationSerializer.java
@@ -1,0 +1,16 @@
+package jp.kusumotolab.kgenprog.output;
+
+import java.lang.reflect.Type;
+import java.time.Duration;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class DurationSerializer implements JsonSerializer<Duration> {
+  @Override
+  public JsonElement serialize(
+      final Duration duration, final Type typeOfSrc, final JsonSerializationContext context) {
+    return new JsonPrimitive(duration.toString());
+  }
+}

--- a/src/main/java/jp/kusumotolab/kgenprog/output/JSONExporter.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/output/JSONExporter.java
@@ -4,6 +4,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,6 +82,7 @@ class JSONExporter implements Exporter {
             new CrossoverHistoricalElementSerializer())
         .registerTypeHierarchyAdapter(MutationHistoricalElement.class,
             new MutationHistoricalElementSerializer())
+        .registerTypeHierarchyAdapter(Duration.class, new DurationSerializer())
         .create();
   }
 }

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CascadeCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/CascadeCrossoverTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -413,7 +414,7 @@ public class CascadeCrossoverTest {
   public void testStopFirst01() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -437,7 +438,7 @@ public class CascadeCrossoverTest {
   public void testStopFirst02() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/RandomCrossoverTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 import java.util.List;
 import java.util.Random;
 import org.junit.Test;
@@ -23,7 +24,7 @@ public class RandomCrossoverTest {
   public void testNumberOfGeneratedVariants() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -49,7 +50,7 @@ public class RandomCrossoverTest {
   public void testStopFirst01() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -73,7 +74,7 @@ public class RandomCrossoverTest {
   public void testStopFirst02() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -102,7 +103,7 @@ public class RandomCrossoverTest {
   public void testGeneratedVariants01() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0)
         .thenReturn(0)
@@ -132,7 +133,7 @@ public class RandomCrossoverTest {
   public void testGeneratedVariants02() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(1)
         .thenReturn(1)
@@ -162,7 +163,7 @@ public class RandomCrossoverTest {
   public void testGeneratedVariants03() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -190,7 +191,7 @@ public class RandomCrossoverTest {
   public void testGeneratedVariants04() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(2);
 
@@ -218,7 +219,7 @@ public class RandomCrossoverTest {
   public void testGeneratedVariants05() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -246,7 +247,7 @@ public class RandomCrossoverTest {
   public void testGeneratedVariants06() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(2);
 
@@ -274,7 +275,7 @@ public class RandomCrossoverTest {
   public void testGeneratedVariants07() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -302,7 +303,7 @@ public class RandomCrossoverTest {
   public void testGeneratedVariants08() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(1);
 
@@ -330,7 +331,7 @@ public class RandomCrossoverTest {
   public void testGeneratedVariants09() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(1);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/SinglePointCrossoverTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 import java.util.List;
 import java.util.Random;
 import org.junit.Test;
@@ -23,7 +24,7 @@ public class SinglePointCrossoverTest {
   public void testNumberOfGeneratedVariants() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -49,7 +50,7 @@ public class SinglePointCrossoverTest {
   public void testStopFirst01() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -73,7 +74,7 @@ public class SinglePointCrossoverTest {
   public void testStopFirst02() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -102,7 +103,7 @@ public class SinglePointCrossoverTest {
   public void testGeneratedVariants01() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0) // variantAを選ぶための0
         .thenReturn(0) // variantBを選ぶための0
@@ -132,7 +133,7 @@ public class SinglePointCrossoverTest {
   public void testGeneratedVariants02() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(false);
     when(random.nextInt(anyInt())).thenReturn(2) // variantCを選ぶための2
         .thenReturn(2) // variantDを選ぶための2
@@ -162,7 +163,7 @@ public class SinglePointCrossoverTest {
   public void testGeneratedVariants03() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -191,7 +192,7 @@ public class SinglePointCrossoverTest {
   public void testGeneratedVariants04() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(false);
     when(random.nextInt(anyInt())).thenReturn(2);
 
@@ -220,7 +221,7 @@ public class SinglePointCrossoverTest {
   public void testGeneratedVariants05() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -249,7 +250,7 @@ public class SinglePointCrossoverTest {
   public void testGeneratedVariants06() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(false);
     when(random.nextInt(anyInt())).thenReturn(2);
 
@@ -278,7 +279,7 @@ public class SinglePointCrossoverTest {
   public void testGeneratedVariants07() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -306,7 +307,7 @@ public class SinglePointCrossoverTest {
   public void testGeneratedVariants08() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(1);
 
@@ -334,7 +335,7 @@ public class SinglePointCrossoverTest {
   public void testGeneratedVariants09() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(1);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/crossover/UniformCrossoverTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 import java.util.List;
 import java.util.Random;
 import org.junit.Test;
@@ -23,7 +24,7 @@ public class UniformCrossoverTest {
   public void testNumberOfGeneratedVariants() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -49,7 +50,7 @@ public class UniformCrossoverTest {
   public void testStopFirst01() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -73,7 +74,7 @@ public class UniformCrossoverTest {
   public void testStopFirst02() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -102,7 +103,7 @@ public class UniformCrossoverTest {
   public void testGeneratedVariants01() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0) // variantAを選ぶための0
         .thenReturn(0); // variantBを選ぶための1
@@ -131,7 +132,7 @@ public class UniformCrossoverTest {
   public void testGeneratedVariants02() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(false);
     when(random.nextInt(anyInt())).thenReturn(1) // variantBを選ぶための1
         .thenReturn(1); // variantCを選ぶための1
@@ -160,7 +161,7 @@ public class UniformCrossoverTest {
   public void testGeneratedVariants03() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -189,7 +190,7 @@ public class UniformCrossoverTest {
   public void testGeneratedVariants04() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(false);
     when(random.nextInt(anyInt())).thenReturn(2);
 
@@ -218,7 +219,7 @@ public class UniformCrossoverTest {
   public void testGeneratedVariants05() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -247,7 +248,7 @@ public class UniformCrossoverTest {
   public void testGeneratedVariants06() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(false);
     when(random.nextInt(anyInt())).thenReturn(2);
 
@@ -276,7 +277,7 @@ public class UniformCrossoverTest {
   public void testGeneratedVariants07() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(0);
 
@@ -304,7 +305,7 @@ public class UniformCrossoverTest {
   public void testGeneratedVariants08() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(false);
     when(random.nextInt(anyInt())).thenReturn(1);
 
@@ -332,7 +333,7 @@ public class UniformCrossoverTest {
   public void testGeneratedVariants09() {
 
     // 生成するバリアントを制御するための疑似乱数
-    final Random random = Mockito.mock(Random.class);
+    final Random random = Mockito.mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextBoolean()).thenReturn(true);
     when(random.nextInt(anyInt())).thenReturn(1);
 

--- a/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/HeuristicMutationTest.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/ga/mutation/HeuristicMutationTest.java
@@ -3,6 +3,7 @@ package jp.kusumotolab.kgenprog.ga.mutation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -28,7 +29,7 @@ public class HeuristicMutationTest {
     final GeneratedSourceCode sourceCode = new JDTASTConstruction().constructAST(factory.create());
 
     final List<GeneratedAST<ProductSourcePath>> generatedASTs = sourceCode.getProductAsts();
-    final Random random = mock(Random.class);
+    final Random random = mock(Random.class, withSettings().withoutAnnotations());
     when(random.nextDouble()).thenReturn(0.0);
 
     final HeuristicStatementSelection selection = new HeuristicStatementSelection(random);

--- a/src/test/java/jp/kusumotolab/kgenprog/testutil/TestUtil.java
+++ b/src/test/java/jp/kusumotolab/kgenprog/testutil/TestUtil.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Random;
 import java.util.stream.Stream;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -27,6 +28,7 @@ import jp.kusumotolab.kgenprog.ga.variant.VariantStore;
 import jp.kusumotolab.kgenprog.output.ASTNodeSerializer;
 import jp.kusumotolab.kgenprog.output.BaseSerializer;
 import jp.kusumotolab.kgenprog.output.CrossoverHistoricalElementSerializer;
+import jp.kusumotolab.kgenprog.output.DurationSerializer;
 import jp.kusumotolab.kgenprog.output.FileDiff;
 import jp.kusumotolab.kgenprog.output.FileDiffSerializer;
 import jp.kusumotolab.kgenprog.output.FitnessSerializer;
@@ -110,6 +112,7 @@ public class TestUtil {
             new CrossoverHistoricalElementSerializer())
         .registerTypeHierarchyAdapter(MutationHistoricalElement.class,
             new MutationHistoricalElementSerializer())
+        .registerTypeHierarchyAdapter(Duration.class, new DurationSerializer())
         .create();
   }
 


### PR DESCRIPTION
resolve #844 
resolve #860 

## 概要
* jdk17でテスト通過するように変更
* ci上でjdk17を用いてテストを行うよう変更

## 行ったこと
jdk17ではセキュリティの観点からリフレクションが制限されたらしい．
内部でリフレクションを使わないようコードを変更した．

### 依存の更新
jdk17に対応していなかった依存を更新

### util.Randomをモックする設定を変更
https://stackoverflow.com/questions/70993863/mockito-can-not-mock-random-in-java-17
randomをモック時に，`withSettings().withoutAnnotations()`を追加した．

### time.Duration向けのgsonカスタムシリアライザを追加
https://stackoverflow.com/questions/70412805/what-does-this-error-mean-java-lang-reflect-inaccessibleobjectexception-unable
